### PR TITLE
Tests: Reproducer for Swift 6.3 typed-throws async closure miscompile

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ClosureCodegen.swift
@@ -16,7 +16,7 @@ public struct ClosureCodegen {
         let closureParams = signature.parameters.map { "\(sendingPrefix)\($0.closureSwiftType)" }.joined(
             separator: ", "
         )
-        let swiftEffects = (signature.isAsync ? " async" : "") + (signature.isThrows ? " throws" : "")
+        let swiftEffects = (signature.isAsync ? " async" : "") + (signature.isThrows ? " throws(JSException)" : "")
         let swiftReturnType = signature.returnType.closureSwiftType
         return "(\(closureParams))\(swiftEffects) -> \(swiftReturnType)"
     }
@@ -73,7 +73,17 @@ public struct ClosureCodegen {
             helperEnumDeclPrinter.indent {
                 helperEnumDeclPrinter.write("let callback = JSObject.bridgeJSLiftParameter(callbackId)")
                 let parameters: String
-                if signature.parameters.isEmpty {
+                if signature.isThrows || signature.isAsync {
+                    let sendingPrefix = signature.sendingParameters ? "sending " : ""
+                    let typedParams =
+                        signature.parameters.enumerated().map { index, paramType in
+                            "param\(index): \(sendingPrefix)\(paramType.closureSwiftType)"
+                        }.joined(separator: ", ")
+                    let returnType = signature.returnType.closureSwiftType
+                    let effects =
+                        (signature.isAsync ? " async" : "") + (signature.isThrows ? " throws(JSException)" : "")
+                    parameters = " (\(typedParams))\(effects) -> \(returnType)"
+                } else if signature.parameters.isEmpty {
                     parameters = ""
                 } else if signature.parameters.count == 1 {
                     parameters = " param0"
@@ -146,9 +156,17 @@ public struct ClosureCodegen {
             liftedParams.append("\(paramType.swiftType).bridgeJSLiftParameter(\(argNames.joined(separator: ", ")))")
         }
 
-        let closureCallExpr = ExprSyntax("closure(\(raw: liftedParams.joined(separator: ", ")))")
+        let tryPrefix = signature.isThrows ? "try " : ""
+        let closureCallExpr = ExprSyntax("\(raw: tryPrefix)closure(\(raw: liftedParams.joined(separator: ", ")))")
+        let asyncTryPrefix = (signature.isThrows ? "try " : "") + "await "
+        let asyncClosureCallExpr = ExprSyntax(
+            "\(raw: asyncTryPrefix)closure(\(raw: liftedParams.joined(separator: ", ")))"
+        )
 
-        let abiReturnWasmType = try signature.returnType.loweringReturnInfo().returnType
+        let abiReturnWasmType =
+            signature.isAsync
+            ? try BridgeType.jsObject(nil).loweringReturnInfo().returnType
+            : try signature.returnType.loweringReturnInfo().returnType
 
         // Build signature using SwiftSignatureBuilder
         let funcSignature = SwiftSignatureBuilder.buildABIFunctionSignature(
@@ -156,12 +174,7 @@ public struct ClosureCodegen {
             returnType: abiReturnWasmType
         )
 
-        // Build function declaration using helper
-        let funcDecl = SwiftCodePattern.buildExposedFunctionDecl(
-            abiName: abiName,
-            signature: funcSignature
-        ) { printer in
-            printer.write("let closure = Unmanaged<\(boxType)>.fromOpaque(boxPtr).takeUnretainedValue().closure")
+        let emitCallAndLower: (CodeFragmentPrinter) -> Void = { printer in
             if signature.returnType == .void {
                 printer.write(closureCallExpr.description)
             } else {
@@ -186,6 +199,79 @@ public struct ClosureCodegen {
                 default:
                     printer.write("return result.bridgeJSLowerReturn()")
                 }
+            }
+        }
+
+        let emitAsyncCallAndLower: (CodeFragmentPrinter) -> Void = { printer in
+            printer.write("let closure = Unmanaged<\(boxType)>.fromOpaque(boxPtr).takeUnretainedValue().closure")
+            let resolveType = signature.returnType
+            let resolveName = "Promise_resolve_\(resolveType.mangleTypeName)"
+            let rejectName = "Promise_reject"
+            let closureHead: String
+            if signature.isThrows {
+                let returnSpelling = resolveType == .void ? "" : " -> \(resolveType.closureSwiftType)"
+                closureHead = " () async throws(JSException)\(returnSpelling) in"
+            } else {
+                closureHead = ""
+            }
+            printer.write("return _bjs_makePromise(resolve: \(resolveName), reject: \(rejectName)) {\(closureHead)")
+            printer.indent {
+                if resolveType == .void {
+                    printer.write(asyncClosureCallExpr.description)
+                } else {
+                    printer.write("return \(asyncClosureCallExpr)")
+                }
+            }
+            printer.write("}")
+        }
+
+        let catchPlaceholderStmt = abiReturnWasmType?.swiftReturnPlaceholderStmt
+
+        // Build function declaration using helper
+        let funcDecl = SwiftCodePattern.buildExposedFunctionDecl(
+            abiName: abiName,
+            signature: funcSignature
+        ) { printer in
+            if signature.isAsync {
+                emitAsyncCallAndLower(printer)
+            } else if signature.isThrows {
+                printer.write(
+                    "let closure = Unmanaged<\(boxType)>.fromOpaque(boxPtr).takeUnretainedValue().closure"
+                )
+                printer.write("do {")
+                printer.indent {
+                    emitCallAndLower(printer)
+                }
+                printer.write("} catch let error {")
+                printer.indent {
+                    printer.write("if let error = error.thrownValue.object {")
+                    printer.indent {
+                        printer.write("withExtendedLifetime(error) {")
+                        printer.indent {
+                            printer.write("_swift_js_throw(Int32(bitPattern: $0.id))")
+                        }
+                        printer.write("}")
+                    }
+                    printer.write("} else {")
+                    printer.indent {
+                        printer.write("let jsError = JSError(message: error.description)")
+                        printer.write("withExtendedLifetime(jsError.jsObject) {")
+                        printer.indent {
+                            printer.write("_swift_js_throw(Int32(bitPattern: $0.id))")
+                        }
+                        printer.write("}")
+                    }
+                    printer.write("}")
+                    if let catchPlaceholderStmt {
+                        printer.write(catchPlaceholderStmt)
+                    }
+                }
+                printer.write("}")
+            } else {
+                printer.write(
+                    "let closure = Unmanaged<\(boxType)>.fromOpaque(boxPtr).takeUnretainedValue().closure"
+                )
+                emitCallAndLower(printer)
             }
         }
 

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ImportTS.swift
@@ -272,9 +272,7 @@ public struct ImportTS {
                 }
             }
 
-            // Add exception check for ImportTS context (skipped for async, where
-            // errors are funneled through the JS-side reject path)
-            if !effects.isAsync && context == .importTS {
+            if !effects.isAsync && (context == .importTS || effects.isThrows) {
                 body.write("if let error = _swift_js_take_exception() { throw error }")
             }
         }
@@ -323,18 +321,19 @@ public struct ImportTS {
             let innerBody = body
             body = CodeFragmentPrinter()
 
+            let tryKeyword = effects.isThrows ? "try" : "try!"
             let rejectFactory = "makeRejectClosure: { JSTypedClosure<(sending JSValue) -> Void>($0) }"
             if returnType == .void {
                 let resolveFactory = "makeResolveClosure: { JSTypedClosure<() -> Void>($0) }"
                 body.write(
-                    "try await _bjs_awaitPromise(\(resolveFactory), \(rejectFactory)) { resolveRef, rejectRef in"
+                    "\(tryKeyword) await _bjs_awaitPromise(\(resolveFactory), \(rejectFactory)) { resolveRef, rejectRef in"
                 )
             } else {
                 let resolveSwiftType = returnType.closureSwiftType
                 let resolveFactory =
                     "makeResolveClosure: { JSTypedClosure<(sending \(resolveSwiftType)) -> Void>($0) }"
                 body.write(
-                    "let resolved = try await _bjs_awaitPromise(\(resolveFactory), \(rejectFactory)) { resolveRef, rejectRef in"
+                    "let resolved = \(tryKeyword) await _bjs_awaitPromise(\(resolveFactory), \(rejectFactory)) { resolveRef, rejectRef in"
                 )
             }
             body.indent {

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/Misc.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/Misc.swift
@@ -137,14 +137,21 @@ import SwiftSyntax
 import class Foundation.ProcessInfo
 
 public struct DiagnosticError: Error {
+    public enum Severity: String, Sendable {
+        case error
+        case warning
+    }
+
     public let node: Syntax
     public let message: String
     public let hint: String?
+    public let severity: Severity
 
-    public init(node: some SyntaxProtocol, message: String, hint: String? = nil) {
+    public init(node: some SyntaxProtocol, message: String, hint: String? = nil, severity: Severity = .error) {
         self.node = Syntax(node)
         self.message = message
         self.hint = hint
+        self.severity = severity
     }
 
     /// Formats the diagnostic error as a string.
@@ -166,12 +173,14 @@ public struct DiagnosticError: Error {
 
         let lineNumberWidth = max(3, String(lines.count).count)
 
+        let severityLabel = severity.rawValue
+        let severityColor = severity == .warning ? ANSI.boldYellow : ANSI.boldRed
         let header: String = {
             guard colorize else {
-                return "\(displayFileName):\(startLocation.line):\(startLocation.column): error: \(message)"
+                return "\(displayFileName):\(startLocation.line):\(startLocation.column): \(severityLabel): \(message)"
             }
             return
-                "\(displayFileName):\(startLocation.line):\(startLocation.column): \(ANSI.boldRed)error: \(ANSI.boldDefault)\(message)\(ANSI.reset)"
+                "\(displayFileName):\(startLocation.line):\(startLocation.column): \(severityColor)\(severityLabel): \(ANSI.boldDefault)\(message)\(ANSI.reset)"
         }()
 
         let highlightStartColumn = min(max(1, startLocation.column), mainLine.utf8.count + 1)
@@ -227,8 +236,8 @@ public struct DiagnosticError: Error {
         let pointerSpacing = max(0, highlightStartColumn - 1)
         let pointerMessage: String = {
             let pointer = String(repeating: " ", count: pointerSpacing) + "`- "
-            guard colorize else { return pointer + "error: \(message)" }
-            return pointer + "\(ANSI.boldRed)error: \(ANSI.boldDefault)\(message)\(ANSI.reset)"
+            guard colorize else { return pointer + "\(severityLabel): \(message)" }
+            return pointer + "\(severityColor)\(severityLabel): \(ANSI.boldDefault)\(message)\(ANSI.reset)"
         }()
         descriptionParts.append(
             Self.formatSourceLine(
@@ -304,6 +313,7 @@ public struct BridgeJSCoreDiagnosticError: Swift.Error, CustomStringConvertible 
 private enum ANSI {
     static let reset = "\u{001B}[0;0m"
     static let boldRed = "\u{001B}[1;31m"
+    static let boldYellow = "\u{001B}[1;33m"
     static let boldDefault = "\u{001B}[1;39m"
     static let cyan = "\u{001B}[0;36m"
     static let underline = "\u{001B}[4;39m"

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -24,6 +24,9 @@ public final class SwiftToSkeleton {
     private var sourceFiles: [(sourceFile: SourceFileSyntax, inputFilePath: String)] = []
     private var usedExternalModules = Set<String>()
 
+    /// Non-fatal diagnostics collected during `finalize()`. These do not fail the build.
+    public private(set) var warnings: [(file: String, diagnostic: DiagnosticError)] = []
+
     public init(
         progress: ProgressReporting,
         moduleName: String,
@@ -87,10 +90,15 @@ public final class SwiftToSkeleton {
             )
             importCollector.walk(sourceFile)
 
-            let importErrorsFatal = importCollector.errors.filter { !$0.message.contains("Unsupported type '") }
-            if !exportCollector.errors.isEmpty || !importErrorsFatal.isEmpty {
+            let exportErrors = exportCollector.errors.filter { $0.severity == .error }
+            let importErrorsFatal = importCollector.errors.filter {
+                $0.severity == .error && !$0.message.contains("Unsupported type '")
+            }
+            let fileWarnings = (exportCollector.errors + importCollector.errors).filter { $0.severity == .warning }
+            warnings.append(contentsOf: fileWarnings.map { (file: inputFilePath, diagnostic: $0) })
+            if !exportErrors.isEmpty || !importErrorsFatal.isEmpty {
                 perSourceErrors.append(
-                    (inputFilePath: inputFilePath, errors: exportCollector.errors + importErrorsFatal)
+                    (inputFilePath: inputFilePath, errors: exportErrors + importErrorsFatal)
                 )
             }
 
@@ -191,7 +199,40 @@ public final class SwiftToSkeleton {
             }
 
             let isAsync = functionType.effectSpecifiers?.asyncSpecifier != nil
-            let isThrows = functionType.effectSpecifiers?.throwsClause != nil
+
+            if isAsync, !returnType.isAsyncResolvable {
+                errors.append(
+                    DiagnosticError(
+                        node: functionType,
+                        message:
+                            "Returning '\(returnType.swiftType)' from an async closure is not yet supported",
+                        hint:
+                            "Return a type lowerable through the async resolve ABI "
+                            + "(String/Int/Bool/Double/Float/raw-value or case-only enum/@JS struct/JSObject/Optional/Array/Dictionary), "
+                            + "or make the closure non-async."
+                    )
+                )
+                return nil
+            }
+
+            var isThrows = false
+            if let throwsClause = functionType.effectSpecifiers?.throwsClause {
+                guard let thrownType = throwsClause.type,
+                    thrownType.trimmedDescription == "JSException"
+                else {
+                    errors.append(
+                        DiagnosticError(
+                            node: throwsClause,
+                            message:
+                                "Only JSException is supported for thrown type of Swift closures, "
+                                + "got \(throwsClause.type?.trimmedDescription ?? "unspecified")",
+                            hint: "Annotate the closure as `throws(JSException)`"
+                        )
+                    )
+                    return nil
+                }
+                isThrows = true
+            }
 
             return .closure(
                 ClosureSignature(
@@ -567,6 +608,37 @@ public final class SwiftToSkeleton {
 
 private enum ExportSwiftConstants {
     static let supportedRawTypes = SwiftEnumRawType.supportedTypeNames
+}
+
+/// Warns about Swift closures handed to JavaScript with an `async throws(JSException)` signature.
+/// Captureless closure values lose their thrown error at runtime due to a Swift compiler bug.
+private func asyncThrowsClosureWarning(node: some SyntaxProtocol) -> DiagnosticError {
+    DiagnosticError(
+        node: node,
+        message:
+            "async throwing closures passed to JavaScript may lose thrown errors due to a Swift compiler bug "
+            + "(swiftlang/swift#89320) unless the closure value captures state",
+        hint:
+            "Pass a closure that captures state, or see the BridgeJS closure documentation for details",
+        severity: .warning
+    )
+}
+
+extension BridgeType {
+    fileprivate var containsAsyncThrowsClosure: Bool {
+        switch self {
+        case .closure(let signature, _):
+            return signature.isAsync && signature.isThrows
+        case .nullable(let wrapped, _):
+            return wrapped.containsAsyncThrowsClosure
+        case .array(let element):
+            return element.containsAsyncThrowsClosure
+        case .dictionary(let value):
+            return value.containsAsyncThrowsClosure
+        default:
+            return false
+        }
+    }
 }
 
 extension AttributeSyntax {
@@ -1028,22 +1100,6 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             guard let type = resolvedType else {
                 continue  // Skip unsupported types
             }
-            if case .closure(let signature, _) = type {
-                if signature.isAsync {
-                    diagnose(
-                        node: param.type,
-                        message: "Async is not supported for Swift closures yet."
-                    )
-                    continue
-                }
-                if signature.isThrows {
-                    diagnose(
-                        node: param.type,
-                        message: "Throws is not supported for Swift closures yet."
-                    )
-                    continue
-                }
-            }
             if case .nullable(let wrappedType, _) = type, wrappedType.isOptional {
                 diagnoseNestedOptional(node: param.type, type: param.type.trimmedDescription)
                 continue
@@ -1177,6 +1233,9 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
 
             guard let type = resolvedType else { return nil }
             returnType = type
+            if returnType.containsAsyncThrowsClosure {
+                errors.append(asyncThrowsClosureWarning(node: returnClause.type))
+            }
         } else {
             returnType = .void
         }
@@ -2835,6 +2894,11 @@ private final class ImportSwiftMacrosAPICollector: SyntaxAnyVisitor {
             }
             guard let bridgeType = withLookupErrors({ parent.lookupType(for: type, errors: &$0) }) else {
                 return nil
+            }
+            if case .closure(let signature, useJSTypedClosure: true) = bridgeType,
+                signature.isAsync, signature.isThrows
+            {
+                errors.append(asyncThrowsClosureWarning(node: type))
             }
             let nameToken = param.secondName ?? param.firstName
             let name = SwiftToSkeleton.normalizeIdentifier(nameToken.text)

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -894,7 +894,7 @@ public struct BridgeJSLink {
     ) throws -> [String] {
         let printer = CodeFragmentPrinter()
         let builder = ExportedThunkBuilder(
-            effects: Effects(isAsync: false, isThrows: true),
+            effects: Effects(isAsync: signature.isAsync, isThrows: signature.isAsync ? signature.isThrows : true),
             hasDirectAccessToSwiftClass: false,
             intrinsicRegistry: intrinsicRegistry
         )
@@ -3743,7 +3743,9 @@ extension BridgeType {
             let paramTypes = signature.parameters.enumerated().map { index, param in
                 "arg\(index): \(param.tsType)"
             }.joined(separator: ", ")
-            return "(\(paramTypes)) => \(signature.returnType.tsType)"
+            let returnTS =
+                signature.isAsync ? "Promise<\(signature.returnType.tsType)>" : signature.returnType.tsType
+            return "(\(paramTypes)) => \(returnTS)"
         case .array(let elementType):
             let inner = elementType.tsType
             if inner.contains("|") || inner.contains("=>") {

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -157,7 +157,8 @@ public struct ClosureSignature: Codable, Equatable, Hashable, Sendable {
             ? "y"
             : parameters.map { $0.mangleTypeName }.joined()
         let sendingPart = sendingParameters ? "s" : ""
-        let signaturePart = "\(sendingPart)\(paramPart)_\(returnType.mangleTypeName)"
+        let effects = (isAsync ? "Ya" : "") + (isThrows ? "K" : "")
+        let signaturePart = "\(sendingPart)\(effects)\(paramPart)_\(returnType.mangleTypeName)"
         self.mangleName = "\(moduleName.count)\(moduleName)\(signaturePart)"
     }
 }
@@ -1049,7 +1050,30 @@ public struct ExportedSkeleton: Codable {
         for enumDef in enums {
             for method in enumDef.staticMethods { consider(method.returnType, method.effects) }
         }
+        for returnType in asyncClosureResolveReturnTypes {
+            consider(returnType, Effects(isAsync: true, isThrows: false))
+        }
         return result
+    }
+
+    private var asyncClosureResolveReturnTypes: [BridgeType] {
+        var collector = AsyncClosureReturnTypeCollector()
+        var walker = BridgeSkeletonWalker(visitor: collector)
+        walker.walk(self)
+        return walker.visitor.returnTypes
+    }
+}
+
+private struct AsyncClosureReturnTypeCollector: BridgeSkeletonVisitor {
+    private(set) var returnTypes: [BridgeType] = []
+
+    mutating func visitClosure(
+        _ signature: ClosureSignature,
+        useJSTypedClosure: Bool,
+        accessLevel: BridgeJSAccessLevel
+    ) {
+        guard signature.isAsync else { return }
+        returnTypes.append(signature.returnType)
     }
 }
 
@@ -1424,11 +1448,18 @@ public struct ClosureSignatureCollectorVisitor: BridgeSkeletonVisitor {
         accessLevel: BridgeJSAccessLevel
     ) {
         recordSignature(signature, accessLevel: accessLevel)
+
+        if signature.isAsync {
+            recordInjectedSignatures(
+                forReturnType: signature.returnType,
+                accessLevel: accessLevel
+            )
+        }
     }
 
     /// Insert `signature` at `accessLevel`, or upgrade the existing level to
     /// the more permissive of the two. Centralizing the merge here keeps
-    /// `visitClosure` and `recordInjectedSignature` in lockstep — if the
+    /// `visitClosure` and `recordInjectedSignatures` in lockstep - if the
     /// merge policy ever needs to change (e.g. adding a diagnostic for
     /// conflicting levels), there's only one place to update.
     private mutating func recordSignature(
@@ -1444,55 +1475,47 @@ public struct ClosureSignatureCollectorVisitor: BridgeSkeletonVisitor {
     public mutating func visitImportedFunction(_ function: ImportedFunctionSkeleton) {
         guard function.effects.isAsync else { return }
 
-        // When async imports exist, inject closure signatures for the typed resolve
-        // and reject callbacks used by _bjs_awaitPromise.
-        // - Reject always uses (sending JSValue) -> Void
-        // - Resolve uses a typed closure matching the return type (or () -> Void for void)
-        // All async callback closures use `sending` parameters so values can be
-        // transferred through the checked continuation without Sendable constraints.
+        recordInjectedSignatures(
+            forReturnType: function.returnType,
+            accessLevel: function.accessLevel
+        )
+    }
 
+    private mutating func recordInjectedSignatures(
+        forReturnType returnType: BridgeType,
+        accessLevel: BridgeJSAccessLevel
+    ) {
         // Reject callback
-        recordInjectedSignature(
+        recordSignature(
             ClosureSignature(
                 parameters: [.jsValue],
                 returnType: .void,
                 moduleName: moduleName,
                 sendingParameters: true
             ),
-            for: function
+            accessLevel: accessLevel
         )
         // Resolve callback (typed per return type)
-        if function.returnType == .void {
-            recordInjectedSignature(
+        if returnType == .void {
+            recordSignature(
                 ClosureSignature(
                     parameters: [],
                     returnType: .void,
                     moduleName: moduleName
                 ),
-                for: function
+                accessLevel: accessLevel
             )
         } else {
-            recordInjectedSignature(
+            recordSignature(
                 ClosureSignature(
-                    parameters: [function.returnType],
+                    parameters: [returnType],
                     returnType: .void,
                     moduleName: moduleName,
                     sendingParameters: true
                 ),
-                for: function
+                accessLevel: accessLevel
             )
         }
-    }
-
-    /// Inject a closure signature derived from an async import (e.g. Promise
-    /// resolve/reject callbacks). The injected signature inherits the access
-    /// level of the originating function so its synthesized init matches the
-    /// visibility of the async API surface.
-    private mutating func recordInjectedSignature(
-        _ signature: ClosureSignature,
-        for function: ImportedFunctionSkeleton
-    ) {
-        recordSignature(signature, accessLevel: function.accessLevel)
     }
 }
 
@@ -1678,7 +1701,8 @@ extension BridgeType {
                 signature.parameters.isEmpty
                 ? "y"
                 : signature.parameters.map { $0.mangleTypeName }.joined()
-            return "K\(params)_\(signature.returnType.mangleTypeName)\(useJSTypedClosure ? "J" : "")"
+            let effects = (signature.isAsync ? "Ya" : "") + (signature.isThrows ? "K" : "")
+            return "K\(effects)\(params)_\(signature.returnType.mangleTypeName)\(useJSTypedClosure ? "J" : "")"
         case .array(let elementType):
             // Array mangling: "Sa" prefix followed by element type
             return "Sa\(elementType.mangleTypeName)"

--- a/Plugins/BridgeJS/Sources/BridgeJSTool/BridgeJSTool.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSTool/BridgeJSTool.swift
@@ -201,6 +201,9 @@ import BridgeJSUtilities
             let skeleton = try withSpan("SwiftToSkeleton.finalize") {
                 return try swiftToSkeleton.finalize()
             }
+            for (file, diagnostic) in swiftToSkeleton.warnings {
+                printStderr(diagnostic.formattedDescription(fileName: file))
+            }
 
             var exporter: ExportSwift?
             if let skeleton = skeleton.exported {

--- a/Plugins/BridgeJS/Sources/BridgeJSToolInternal/BridgeJSToolInternal.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSToolInternal/BridgeJSToolInternal.swift
@@ -60,6 +60,11 @@ import ArgumentParser
                 swiftToSkeleton.addSourceFile(sourceFile, inputFilePath: inputFile)
             }
             let skeleton = try swiftToSkeleton.finalize()
+            for (file, diagnostic) in swiftToSkeleton.warnings {
+                FileHandle.standardError.write(
+                    Data((diagnostic.formattedDescription(fileName: file, colorize: false) + "\n").utf8)
+                )
+            }
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             let skeletonData = try encoder.encode(skeleton)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureAsyncDiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureAsyncDiagnosticsTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import BridgeJSCore
+@testable import BridgeJSSkeleton
+
+@Suite struct ClosureAsyncDiagnosticsTests {
+    @Test
+    func parsesAsyncClosureParameter() throws {
+        let app = try resolveApp(
+            source: """
+                @JS public func process(_ cb: (Int) async -> String) {}
+                """
+        )
+        let function = try #require(app.exported?.functions.first(where: { $0.name == "process" }))
+        let parameter = try #require(function.parameters.first)
+        guard case .closure(let signature, _) = parameter.type else {
+            Issue.record("Expected closure parameter type, got \(parameter.type)")
+            return
+        }
+        #expect(signature.isAsync)
+    }
+
+    @Test
+    func collectsResolveRejectSignaturesForAsyncClosure() throws {
+        let app = try resolveApp(
+            source: """
+                @JS public func process(_ cb: (Int) async -> String) {}
+                """
+        )
+        let signatures = collectSignatures(from: app)
+
+        let reject = ClosureSignature(
+            parameters: [.jsValue],
+            returnType: .void,
+            moduleName: "App",
+            sendingParameters: true
+        )
+        let resolve = ClosureSignature(
+            parameters: [.string],
+            returnType: .void,
+            moduleName: "App",
+            sendingParameters: true
+        )
+
+        #expect(signatures.contains(reject))
+        #expect(signatures.contains(resolve))
+    }
+
+    @Test
+    func collectsVoidResolveSignatureForVoidReturningAsyncClosure() throws {
+        let app = try resolveApp(
+            source: """
+                @JS public func process(_ cb: (Int) async -> Void) {}
+                """
+        )
+        let signatures = collectSignatures(from: app)
+
+        let reject = ClosureSignature(
+            parameters: [.jsValue],
+            returnType: .void,
+            moduleName: "App",
+            sendingParameters: true
+        )
+        let voidResolve = ClosureSignature(
+            parameters: [],
+            returnType: .void,
+            moduleName: "App"
+        )
+
+        #expect(signatures.contains(reject))
+        #expect(signatures.contains(voidResolve))
+    }
+
+    @Test
+    func supportsAsyncClosureReturningJSStruct() throws {
+        let app = try resolveApp(
+            source: """
+                @JS struct Point { var x: Int }
+                @JS public func makePoint() -> JSTypedClosure<(Int) async -> Point> {
+                    fatalError()
+                }
+                """
+        )
+        let resolveTypes = try #require(app.exported?.asyncPromiseResolveReturnTypes)
+        #expect(resolveTypes.contains { $0.mangleTypeName == "5PointV" })
+    }
+
+    @Test
+    func supportsAsyncThrowsClosureReturningJSStruct() throws {
+        let app = try resolveApp(
+            source: """
+                @JS struct Point { var x: Int }
+                @JS public func makePoint() -> JSTypedClosure<(Int) async throws(JSException) -> Point> {
+                    fatalError()
+                }
+                """
+        )
+        let resolveTypes = try #require(app.exported?.asyncPromiseResolveReturnTypes)
+        #expect(resolveTypes.contains { $0.mangleTypeName == "5PointV" })
+    }
+
+    @Test
+    func supportsAsyncClosureReturningAssociatedValueEnum() throws {
+        let app = try resolveApp(
+            source: """
+                @JS enum Shape { case circle(radius: Double); case square(side: Double) }
+                @JS public func process(_ cb: (Int) async -> Shape) {}
+                """
+        )
+        let resolveTypes = try #require(app.exported?.asyncPromiseResolveReturnTypes)
+        #expect(resolveTypes.contains { $0.mangleTypeName == "5ShapeO" })
+    }
+
+    @Test
+    func supportsAsyncThrowsClosureReturningAssociatedValueEnum() throws {
+        let app = try resolveApp(
+            source: """
+                @JS enum Shape { case circle(radius: Double); case square(side: Double) }
+                @JS public func makeShape() -> JSTypedClosure<(Int) async throws(JSException) -> Shape> {
+                    fatalError()
+                }
+                """
+        )
+        let resolveTypes = try #require(app.exported?.asyncPromiseResolveReturnTypes)
+        #expect(resolveTypes.contains { $0.mangleTypeName == "5ShapeO" })
+    }
+
+    // MARK: - Utilities
+
+    private func collectSignatures(from skeleton: BridgeJSSkeleton) -> Set<ClosureSignature> {
+        let collector = ClosureSignatureCollectorVisitor(moduleName: skeleton.moduleName)
+        var walker = BridgeSkeletonWalker(visitor: collector)
+        walker.walk(skeleton)
+        return walker.visitor.signatures
+    }
+
+    private func resolveApp(source appSource: String) throws -> BridgeJSSkeleton {
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "App",
+            exposeToGlobal: false,
+            externalModuleIndex: ExternalModuleIndex(dependencies: [])
+        )
+        let sourceFile = Parser.parse(source: appSource)
+        swiftAPI.addSourceFile(sourceFile, inputFilePath: "App.swift")
+        return try swiftAPI.finalize()
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureAsyncThrowsWarningTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureAsyncThrowsWarningTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import BridgeJSCore
+@testable import BridgeJSSkeleton
+
+@Suite struct ClosureAsyncThrowsWarningTests {
+    @Test
+    func warnsOnTypedAsyncThrowsClosureReturn() throws {
+        let result = try resolveApp(
+            source: """
+                @JS public func makeParser() -> JSTypedClosure<(String) async throws(JSException) -> String> {
+                    fatalError()
+                }
+                """
+        )
+        #expect(result.warnings.count == 1)
+        let warning = try #require(result.warnings.first)
+        #expect(warning.diagnostic.severity == .warning)
+        #expect(warning.diagnostic.message.contains("swiftlang/swift#89320"))
+    }
+
+    @Test
+    func warnsOnPlainAsyncThrowsClosureReturn() throws {
+        let result = try resolveApp(
+            source: """
+                @JS public func makeParser() -> (String) async throws(JSException) -> String {
+                    fatalError()
+                }
+                """
+        )
+        #expect(result.warnings.count == 1)
+        #expect(result.warnings.first?.diagnostic.severity == .warning)
+    }
+
+    @Test
+    func doesNotWarnOnAsyncThrowsClosureParameter() throws {
+        let result = try resolveApp(
+            source: """
+                @JS public func process(_ cb: (String) async throws(JSException) -> String) {}
+                """
+        )
+        #expect(result.warnings.isEmpty)
+    }
+
+    @Test
+    func doesNotWarnOnNonThrowingAsyncClosureReturn() throws {
+        let result = try resolveApp(
+            source: """
+                @JS public func makeParser() -> JSTypedClosure<(String) async -> String> {
+                    fatalError()
+                }
+                """
+        )
+        #expect(result.warnings.isEmpty)
+    }
+
+    @Test
+    func doesNotWarnOnSyncThrowsClosureReturn() throws {
+        let result = try resolveApp(
+            source: """
+                @JS public func makeParser() -> JSTypedClosure<(String) throws(JSException) -> String> {
+                    fatalError()
+                }
+                """
+        )
+        #expect(result.warnings.isEmpty)
+    }
+
+    @Test
+    func warnsOnTypedAsyncThrowsClosureImportParameter() throws {
+        let result = try resolveApp(
+            source: """
+                @JSFunction func register(
+                    _ cb: JSTypedClosure<(String) async throws(JSException) -> String>
+                ) throws(JSException)
+                """
+        )
+        #expect(result.warnings.count == 1)
+        #expect(result.warnings.first?.diagnostic.severity == .warning)
+    }
+
+    @Test
+    func warningDoesNotFailSkeletonResolution() throws {
+        let result = try resolveApp(
+            source: """
+                @JS public func makeParser() -> JSTypedClosure<(String) async throws(JSException) -> String> {
+                    fatalError()
+                }
+                """
+        )
+        let function = try #require(result.skeleton.exported?.functions.first(where: { $0.name == "makeParser" }))
+        guard case .closure(let signature, true) = function.returnType else {
+            Issue.record("Expected typed closure return type, got \(function.returnType)")
+            return
+        }
+        #expect(signature.isAsync)
+        #expect(signature.isThrows)
+    }
+
+    // MARK: - Utilities
+
+    private struct Resolution {
+        let skeleton: BridgeJSSkeleton
+        let warnings: [(file: String, diagnostic: DiagnosticError)]
+    }
+
+    private func resolveApp(source appSource: String) throws -> Resolution {
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "App",
+            exposeToGlobal: false,
+            externalModuleIndex: ExternalModuleIndex(dependencies: [])
+        )
+        let sourceFile = Parser.parse(source: appSource)
+        swiftAPI.addSourceFile(sourceFile, inputFilePath: "App.swift")
+        let skeleton = try swiftAPI.finalize()
+        return Resolution(skeleton: skeleton, warnings: swiftAPI.warnings)
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureManglingTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureManglingTests.swift
@@ -1,0 +1,30 @@
+import Testing
+
+@testable import BridgeJSSkeleton
+
+@Suite struct ClosureManglingTests {
+    private func sig(async a: Bool, throws t: Bool) -> ClosureSignature {
+        ClosureSignature(
+            parameters: [.integer(.int)],
+            returnType: .integer(.int),
+            moduleName: "M",
+            isAsync: a,
+            isThrows: t
+        )
+    }
+
+    @Test func effectsDisambiguateMangle() {
+        let plain = sig(async: false, throws: false).mangleName
+        let thr = sig(async: false, throws: true).mangleName
+        let asy = sig(async: true, throws: false).mangleName
+        let both = sig(async: true, throws: true).mangleName
+        #expect(Set([plain, thr, asy, both]).count == 4)
+        #expect(thr.contains("K"))
+        #expect(asy.contains("Ya"))
+        if let ya = both.range(of: "Ya"), let k = both.range(of: "K") {
+            #expect(ya.lowerBound < k.lowerBound)
+        } else {
+            Issue.record("expected both Ya and K in async-throws mangle")
+        }
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureThrowsDiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureThrowsDiagnosticsTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import BridgeJSCore
+@testable import BridgeJSSkeleton
+
+@Suite struct ClosureThrowsDiagnosticsTests {
+    @Test
+    func parsesThrowsJSExceptionClosureParameter() throws {
+        let app = try resolveApp(
+            source: """
+                @JS public func process(_ cb: (Int) throws(JSException) -> Int) {}
+                """
+        )
+        let function = try #require(app.exported?.functions.first(where: { $0.name == "process" }))
+        let parameter = try #require(function.parameters.first)
+        guard case .closure(let signature, _) = parameter.type else {
+            Issue.record("Expected closure parameter type, got \(parameter.type)")
+            return
+        }
+        #expect(signature.isThrows)
+        #expect(!signature.isAsync)
+    }
+
+    @Test
+    func rejectsPlainThrowsClosureParameter() throws {
+        do {
+            _ = try resolveApp(
+                source: """
+                    @JS public func process(_ cb: (Int) throws -> Int) {}
+                    """
+            )
+            Issue.record("Expected a plain-throws closure diagnostic, but resolution succeeded")
+        } catch let error as BridgeJSCoreDiagnosticError {
+            let combined = error.diagnostics.map(\.diagnostic.message).joined(separator: "\n")
+            #expect(combined.contains("JSException"))
+            #expect(!combined.contains("Throws is not supported for Swift closures yet."))
+        }
+    }
+
+    // MARK: - Utilities
+
+    private func resolveApp(source appSource: String) throws -> BridgeJSSkeleton {
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: "App",
+            exposeToGlobal: false,
+            externalModuleIndex: ExternalModuleIndex(dependencies: [])
+        )
+        let sourceFile = Parser.parse(source: appSource)
+        swiftAPI.addSourceFile(sourceFile, inputFilePath: "App.swift")
+        return try swiftAPI.finalize()
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftClosure.swift
@@ -38,6 +38,17 @@ import JavaScriptKit
 @JS func roundtripPerson(_ personClosure: (Person) -> Person) -> (Person) -> Person
 @JS func roundtripOptionalPerson(_ personClosure: (Person?) -> Person?) -> (Person?) -> Person?
 
+@JS func makeThrowingParser() -> JSTypedClosure<(String) throws(JSException) -> Int>
+@JS func validateWith(_ validate: (String) throws(JSException) -> Bool)
+
+@JS func makeFetcher() -> JSTypedClosure<(String) async throws(JSException) -> String>
+
+@JS func makeAsyncEcho() -> JSTypedClosure<(String) async -> String>
+
+@JS func makeAnimalLoader() -> JSTypedClosure<(String) async -> Animal>
+
+@JS func makeResultLoader() -> JSTypedClosure<(Bool) async throws(JSException) -> APIResult>
+
 @JS func roundtripDirection(_ callback: (Direction) -> Direction) -> (Direction) -> Direction
 @JS func roundtripTheme(_ callback: (Theme) -> Theme) -> (Theme) -> Theme
 @JS func roundtripHttpStatus(_ callback: (HttpStatus) -> HttpStatus) -> (HttpStatus) -> HttpStatus

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftClosureImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/Inputs/MacroSwift/SwiftClosureImports.swift
@@ -1,3 +1,7 @@
 @JSFunction func applyInt(_ value: Int, _ transform: (Int) -> Int) throws(JSException) -> Int
 
 @JSFunction func makeAdder(_ base: Int) throws(JSException) -> (Int) -> Int
+
+@JS func runValidator(_ cb: (String) throws(JSException) -> Bool)
+
+@JS func loadEach(_ fetch: (String) async throws(JSException) -> String)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.json
@@ -1331,6 +1331,233 @@
         }
       },
       {
+        "abiName" : "bjs_makeThrowingParser",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeThrowingParser",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : false,
+              "isThrows" : true,
+              "mangleName" : "10TestModuleKSS_Si",
+              "moduleName" : "TestModule",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_validateWith",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "validateWith",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "validate",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : false,
+                  "isThrows" : true,
+                  "mangleName" : "10TestModuleKSS_Sb",
+                  "moduleName" : "TestModule",
+                  "parameters" : [
+                    {
+                      "string" : {
+
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "bool" : {
+
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "void" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeFetcher",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeFetcher",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : true,
+              "mangleName" : "10TestModuleYaKSS_SS",
+              "moduleName" : "TestModule",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "string" : {
+
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncEcho",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncEcho",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : false,
+              "mangleName" : "10TestModuleYaSS_SS",
+              "moduleName" : "TestModule",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "string" : {
+
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAnimalLoader",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAnimalLoader",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : false,
+              "mangleName" : "10TestModuleYaSS_6AnimalV",
+              "moduleName" : "TestModule",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "swiftStruct" : {
+                  "_0" : "Animal"
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeResultLoader",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeResultLoader",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : true,
+              "mangleName" : "10TestModuleYaKSb_9APIResultO",
+              "moduleName" : "TestModule",
+              "parameters" : [
+                {
+                  "bool" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "associatedValueEnum" : {
+                  "_0" : "APIResult"
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
         "abiName" : "bjs_roundtripDirection",
         "effects" : {
           "isAsync" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
@@ -380,6 +380,172 @@ public func _invoke_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleKSS_Sb")
+fileprivate func invoke_js_callback_TestModule_10TestModuleKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleKSS_Sb(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModuleKSS_Sb_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleKSS_Sb")
+fileprivate func make_swift_closure_TestModule_10TestModuleKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleKSS_Sb_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleKSS_Sb {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) throws(JSException) -> Bool {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) throws(JSException) -> Bool in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let ret = invoke_js_callback_TestModule_10TestModuleKSS_Sb(callbackValue, param0Bytes, param0Length)
+                return ret
+            }
+            let ret = ret0
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return Bool.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) throws(JSException) -> Bool {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) throws(JSException) -> Bool) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleKSS_Sb,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleKSS_Sb")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleKSS_Sb")
+public func _invoke_swift_closure_TestModule_10TestModuleKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) throws(JSException) -> Bool>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    do {
+        let result = try closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+        return result.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: error.description)
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleKSS_Si")
+fileprivate func invoke_js_callback_TestModule_10TestModuleKSS_Si_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleKSS_Si_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleKSS_Si(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModuleKSS_Si_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleKSS_Si")
+fileprivate func make_swift_closure_TestModule_10TestModuleKSS_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleKSS_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleKSS_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleKSS_Si_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleKSS_Si {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) throws(JSException) -> Int {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) throws(JSException) -> Int in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let ret = invoke_js_callback_TestModule_10TestModuleKSS_Si(callbackValue, param0Bytes, param0Length)
+                return ret
+            }
+            let ret = ret0
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return Int.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) throws(JSException) -> Int {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) throws(JSException) -> Int) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleKSS_Si,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleKSS_Si")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleKSS_Si")
+public func _invoke_swift_closure_TestModule_10TestModuleKSS_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) throws(JSException) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    do {
+        let result = try closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+        return result.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: error.description)
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSS_SS")
 fileprivate func invoke_js_callback_TestModule_10TestModuleSS_SS_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
 #else
@@ -1392,6 +1558,534 @@ public func _invoke_swift_closure_TestModule_10TestModuleSqSi_SqSi(_ boxPtr: Uns
     #endif
 }
 
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleYaKSS_SS")
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSS_SS(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleYaKSS_SS_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleYaKSS_SS")
+fileprivate func make_swift_closure_TestModule_10TestModuleYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleYaKSS_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleYaKSS_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async throws(JSException) -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async throws(JSException) -> String in
+            #if arch(wasm32)
+            let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending String) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_TestModule_10TestModuleYaKSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async throws(JSException) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async throws(JSException) -> String) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleYaKSS_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleYaKSS_SS")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleYaKSS_SS")
+public func _invoke_swift_closure_TestModule_10TestModuleYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async throws(JSException) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
+        return try await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO")
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO_extern(resolveRef, rejectRef, callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO")
+fileprivate func make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleYaKSb_9APIResultO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Bool) async throws(JSException) -> APIResult {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: Bool) async throws(JSException) -> APIResult in
+            #if arch(wasm32)
+            let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending APIResult) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                let param0Value = param0.bridgeJSLowerParameter()
+                invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO(resolveRef, rejectRef, callbackValue, param0Value)
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> APIResult {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Bool) async throws(JSException) -> APIResult) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO")
+public func _invoke_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Bool) async throws(JSException) -> APIResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_9APIResultO, reject: Promise_reject) { () async throws(JSException) -> APIResult in
+        return try await closure(Bool.bridgeJSLiftParameter(param0))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV")
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV")
+fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleYaSS_6AnimalV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async -> Animal {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async -> Animal in
+            #if arch(wasm32)
+            let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending Animal) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async -> Animal {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async -> Animal) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleYaSS_6AnimalV")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleYaSS_6AnimalV")
+public func _invoke_swift_closure_TestModule_10TestModuleYaSS_6AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async -> Animal>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_6AnimalV, reject: Promise_reject) {
+        return await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleYaSS_SS")
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_SS(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleYaSS_SS_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleYaSS_SS")
+fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleYaSS_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleYaSS_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async -> String in
+            #if arch(wasm32)
+            let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending String) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_TestModule_10TestModuleYaSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async -> String) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleYaSS_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleYaSS_SS")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleYaSS_SS")
+public func _invoke_swift_closure_TestModule_10TestModuleYaSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
+        return await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModules6AnimalV_y")
+fileprivate func invoke_js_callback_TestModule_10TestModules6AnimalV_y_extern(_ callback: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModules6AnimalV_y_extern(_ callback: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModules6AnimalV_y(_ callback: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModules6AnimalV_y_extern(callback)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModules6AnimalV_y")
+fileprivate func make_swift_closure_TestModule_10TestModules6AnimalV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModules6AnimalV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModules6AnimalV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModules6AnimalV_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModules6AnimalV_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending Animal) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let _ = param0.bridgeJSLowerParameter()
+            invoke_js_callback_TestModule_10TestModules6AnimalV_y(callbackValue)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending Animal) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending Animal) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModules6AnimalV_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModules6AnimalV_y")
+@_cdecl("invoke_swift_closure_TestModule_10TestModules6AnimalV_y")
+public func _invoke_swift_closure_TestModule_10TestModules6AnimalV_y(_ boxPtr: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending Animal) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(Animal.bridgeJSLiftParameter())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModules7JSValueV_y")
+fileprivate func invoke_js_callback_TestModule_10TestModules7JSValueV_y_extern(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModules7JSValueV_y_extern(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModules7JSValueV_y(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void {
+    return invoke_js_callback_TestModule_10TestModules7JSValueV_y_extern(callback, param0Kind, param0Payload1, param0Payload2)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModules7JSValueV_y")
+fileprivate func make_swift_closure_TestModule_10TestModules7JSValueV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModules7JSValueV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModules7JSValueV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModules7JSValueV_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModules7JSValueV_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending JSValue) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let (param0Kind, param0Payload1, param0Payload2) = param0.bridgeJSLowerParameter()
+            invoke_js_callback_TestModule_10TestModules7JSValueV_y(callbackValue, param0Kind, param0Payload1, param0Payload2)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending JSValue) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending JSValue) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModules7JSValueV_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModules7JSValueV_y")
+@_cdecl("invoke_swift_closure_TestModule_10TestModules7JSValueV_y")
+public func _invoke_swift_closure_TestModule_10TestModules7JSValueV_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending JSValue) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(JSValue.bridgeJSLiftParameter(param0Kind, param0Payload1, param0Payload2))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModules9APIResultO_y")
+fileprivate func invoke_js_callback_TestModule_10TestModules9APIResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModules9APIResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModules9APIResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModules9APIResultO_y_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModules9APIResultO_y")
+fileprivate func make_swift_closure_TestModule_10TestModules9APIResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModules9APIResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModules9APIResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModules9APIResultO_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModules9APIResultO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending APIResult) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0CaseId = param0.bridgeJSLowerParameter()
+            invoke_js_callback_TestModule_10TestModules9APIResultO_y(callbackValue, param0CaseId)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending APIResult) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending APIResult) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModules9APIResultO_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModules9APIResultO_y")
+@_cdecl("invoke_swift_closure_TestModule_10TestModules9APIResultO_y")
+public func _invoke_swift_closure_TestModule_10TestModules9APIResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending APIResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(APIResult.bridgeJSLiftParameter(param0))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModulesSS_y")
+fileprivate func invoke_js_callback_TestModule_10TestModulesSS_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModulesSS_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModulesSS_y(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModulesSS_y_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModulesSS_y")
+fileprivate func make_swift_closure_TestModule_10TestModulesSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModulesSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModulesSS_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModulesSS_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModulesSS_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending String) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                invoke_js_callback_TestModule_10TestModulesSS_y(callbackValue, param0Bytes, param0Length)
+            }
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending String) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending String) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModulesSS_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModulesSS_y")
+@_cdecl("invoke_swift_closure_TestModule_10TestModulesSS_y")
+public func _invoke_swift_closure_TestModule_10TestModulesSS_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending String) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 extension Direction: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
@@ -1695,6 +2389,71 @@ public func _bjs_roundtripOptionalPerson(_ personClosure: Int32) -> Int32 {
     #endif
 }
 
+@_expose(wasm, "bjs_makeThrowingParser")
+@_cdecl("bjs_makeThrowingParser")
+public func _bjs_makeThrowingParser() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeThrowingParser()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_validateWith")
+@_cdecl("bjs_validateWith")
+public func _bjs_validateWith(_ validate: Int32) -> Void {
+    #if arch(wasm32)
+    validateWith(_: _BJS_Closure_10TestModuleKSS_Sb.bridgeJSLift(validate))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeFetcher")
+@_cdecl("bjs_makeFetcher")
+public func _bjs_makeFetcher() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeFetcher()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncEcho")
+@_cdecl("bjs_makeAsyncEcho")
+public func _bjs_makeAsyncEcho() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncEcho()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAnimalLoader")
+@_cdecl("bjs_makeAnimalLoader")
+public func _bjs_makeAnimalLoader() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAnimalLoader()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeResultLoader")
+@_cdecl("bjs_makeResultLoader")
+public func _bjs_makeResultLoader() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeResultLoader()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
 @_expose(wasm, "bjs_roundtripDirection")
 @_cdecl("bjs_roundtripDirection")
 public func _bjs_roundtripDirection(_ callback: Int32) -> Int32 {
@@ -1876,4 +2635,89 @@ fileprivate func _bjs_TestProcessor_wrap_extern(_ pointer: UnsafeMutableRawPoint
 #endif
 @inline(never) fileprivate func _bjs_TestProcessor_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     return _bjs_TestProcessor_wrap_extern(pointer)
+}
+
+@JSFunction func Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_reject_TestModule")
+fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void
+#else
+fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_reject_TestModule(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    return promise_reject_TestModule_extern(promise, valueKind, valuePayload1, valuePayload2)
+}
+
+func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    promise_reject_TestModule(promiseValue, valueKind, valuePayload1, valuePayload2)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_SS")
+fileprivate func promise_resolve_TestModule_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_SS(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_TestModule_SS_extern(promise, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        promise_resolve_TestModule_SS(promiseValue, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_6AnimalV(_ promise: JSObject, _ value: Animal) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_6AnimalV")
+fileprivate func promise_resolve_TestModule_6AnimalV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_6AnimalV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_6AnimalV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_6AnimalV_extern(promise, value)
+}
+
+func _$Promise_resolve_6AnimalV(_ promise: JSObject, _ value: Animal) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueObjectId = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_6AnimalV(promiseValue, valueObjectId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_9APIResultO(_ promise: JSObject, _ value: APIResult) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_9APIResultO")
+fileprivate func promise_resolve_TestModule_9APIResultO_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_9APIResultO_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_9APIResultO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_9APIResultO_extern(promise, value)
+}
+
+func _$Promise_resolve_9APIResultO(_ promise: JSObject, _ value: APIResult) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueCaseId = value.bridgeJSLowerParameter()
+    promise_resolve_TestModule_9APIResultO(promiseValue, valueCaseId)
+    if let error = _swift_js_take_exception() { throw error }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.json
@@ -1,4 +1,109 @@
 {
+  "exported" : {
+    "classes" : [
+
+    ],
+    "enums" : [
+
+    ],
+    "exposeToGlobal" : false,
+    "functions" : [
+      {
+        "abiName" : "bjs_runValidator",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "runValidator",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "cb",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : false,
+                  "isThrows" : true,
+                  "mangleName" : "10TestModuleKSS_Sb",
+                  "moduleName" : "TestModule",
+                  "parameters" : [
+                    {
+                      "string" : {
+
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "bool" : {
+
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "void" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_loadEach",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "loadEach",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "fetch",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : true,
+                  "isThrows" : true,
+                  "mangleName" : "10TestModuleYaKSS_SS",
+                  "moduleName" : "TestModule",
+                  "parameters" : [
+                    {
+                      "string" : {
+
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "string" : {
+
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "void" : {
+
+          }
+        }
+      }
+    ],
+    "protocols" : [
+
+    ],
+    "structs" : [
+
+    ]
+  },
   "imported" : {
     "children" : [
       {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.swift
@@ -1,4 +1,87 @@
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleKSS_Sb")
+fileprivate func invoke_js_callback_TestModule_10TestModuleKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleKSS_Sb(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModuleKSS_Sb_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleKSS_Sb")
+fileprivate func make_swift_closure_TestModule_10TestModuleKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleKSS_Sb_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleKSS_Sb {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) throws(JSException) -> Bool {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) throws(JSException) -> Bool in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let ret = invoke_js_callback_TestModule_10TestModuleKSS_Sb(callbackValue, param0Bytes, param0Length)
+                return ret
+            }
+            let ret = ret0
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return Bool.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) throws(JSException) -> Bool {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) throws(JSException) -> Bool) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleKSS_Sb,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleKSS_Sb")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleKSS_Sb")
+public func _invoke_swift_closure_TestModule_10TestModuleKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) throws(JSException) -> Bool>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    do {
+        let result = try closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+        return result.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: error.description)
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSi_Si")
 fileprivate func invoke_js_callback_TestModule_10TestModuleSi_Si_extern(_ callback: Int32, _ param0: Int32) -> Int32
 #else
@@ -59,6 +142,263 @@ public func _invoke_swift_closure_TestModule_10TestModuleSi_Si(_ boxPtr: UnsafeM
     #else
     fatalError("Only available on WebAssembly")
     #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleYaKSS_SS")
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSS_SS(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleYaKSS_SS_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleYaKSS_SS")
+fileprivate func make_swift_closure_TestModule_10TestModuleYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleYaKSS_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleYaKSS_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async throws(JSException) -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async throws(JSException) -> String in
+            #if arch(wasm32)
+            let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending String) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_TestModule_10TestModuleYaKSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async throws(JSException) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async throws(JSException) -> String) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleYaKSS_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleYaKSS_SS")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleYaKSS_SS")
+public func _invoke_swift_closure_TestModule_10TestModuleYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async throws(JSException) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
+        return try await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModules7JSValueV_y")
+fileprivate func invoke_js_callback_TestModule_10TestModules7JSValueV_y_extern(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModules7JSValueV_y_extern(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModules7JSValueV_y(_ callback: Int32, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void {
+    return invoke_js_callback_TestModule_10TestModules7JSValueV_y_extern(callback, param0Kind, param0Payload1, param0Payload2)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModules7JSValueV_y")
+fileprivate func make_swift_closure_TestModule_10TestModules7JSValueV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModules7JSValueV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModules7JSValueV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModules7JSValueV_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModules7JSValueV_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending JSValue) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let (param0Kind, param0Payload1, param0Payload2) = param0.bridgeJSLowerParameter()
+            invoke_js_callback_TestModule_10TestModules7JSValueV_y(callbackValue, param0Kind, param0Payload1, param0Payload2)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending JSValue) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending JSValue) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModules7JSValueV_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModules7JSValueV_y")
+@_cdecl("invoke_swift_closure_TestModule_10TestModules7JSValueV_y")
+public func _invoke_swift_closure_TestModule_10TestModules7JSValueV_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Kind: Int32, _ param0Payload1: Int32, _ param0Payload2: Float64) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending JSValue) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(JSValue.bridgeJSLiftParameter(param0Kind, param0Payload1, param0Payload2))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModulesSS_y")
+fileprivate func invoke_js_callback_TestModule_10TestModulesSS_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModulesSS_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModulesSS_y(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModulesSS_y_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModulesSS_y")
+fileprivate func make_swift_closure_TestModule_10TestModulesSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModulesSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModulesSS_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModulesSS_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModulesSS_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending String) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                invoke_js_callback_TestModule_10TestModulesSS_y(callbackValue, param0Bytes, param0Length)
+            }
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending String) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending String) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModulesSS_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModulesSS_y")
+@_cdecl("invoke_swift_closure_TestModule_10TestModulesSS_y")
+public func _invoke_swift_closure_TestModule_10TestModulesSS_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending String) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_runValidator")
+@_cdecl("bjs_runValidator")
+public func _bjs_runValidator(_ cb: Int32) -> Void {
+    #if arch(wasm32)
+    runValidator(_: _BJS_Closure_10TestModuleKSS_Sb.bridgeJSLift(cb))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_loadEach")
+@_cdecl("bjs_loadEach")
+public func _bjs_loadEach(_ fetch: Int32) -> Void {
+    #if arch(wasm32)
+    loadEach(_: _BJS_Closure_10TestModuleYaKSS_SS.bridgeJSLift(fetch))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@JSFunction func Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_reject_TestModule")
+fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void
+#else
+fileprivate func promise_reject_TestModule_extern(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_reject_TestModule(_ promise: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+    return promise_reject_TestModule_extern(promise, valueKind, valuePayload1, valuePayload2)
+}
+
+func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let (valueKind, valuePayload1, valuePayload2) = value.bridgeJSLowerParameter()
+    promise_reject_TestModule(promiseValue, valueKind, valuePayload1, valuePayload2)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
+@JSFunction func Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_SS")
+fileprivate func promise_resolve_TestModule_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+#else
+fileprivate func promise_resolve_TestModule_SS_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_TestModule_SS(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_TestModule_SS_extern(promise, valueBytes, valueLength)
+}
+
+func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
+        promise_resolve_TestModule_SS(promiseValue, valueBytes, valueLength)
+    }
+    if let error = _swift_js_take_exception() { throw error }
 }
 
 #if arch(wasm32)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.d.ts
@@ -84,6 +84,12 @@ export type Exports = {
     roundtripOptionalDouble(doubleClosure: (arg0: number | null) => number | null): (arg0: number | null) => number | null;
     roundtripPerson(personClosure: (arg0: Person) => Person): (arg0: Person) => Person;
     roundtripOptionalPerson(personClosure: (arg0: Person | null) => Person | null): (arg0: Person | null) => Person | null;
+    makeThrowingParser(): (arg0: string) => number;
+    validateWith(validate: (arg0: string) => boolean): void;
+    makeFetcher(): (arg0: string) => Promise<string>;
+    makeAsyncEcho(): (arg0: string) => Promise<string>;
+    makeAnimalLoader(): (arg0: string) => Promise<Animal>;
+    makeResultLoader(): (arg0: boolean) => Promise<APIResultTag>;
     roundtripDirection(callback: (arg0: DirectionTag) => DirectionTag): (arg0: DirectionTag) => DirectionTag;
     roundtripTheme(callback: (arg0: ThemeTag) => ThemeTag): (arg0: ThemeTag) => ThemeTag;
     roundtripHttpStatus(callback: (arg0: HttpStatusTag) => HttpStatusTag): (arg0: HttpStatusTag) => HttpStatusTag;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -61,6 +61,95 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
+    function __bjs_jsValueLower(value) {
+        let kind;
+        let payload1;
+        let payload2;
+        if (value === null) {
+            kind = 4;
+            payload1 = 0;
+            payload2 = 0;
+        } else {
+            switch (typeof value) {
+                case "boolean":
+                    kind = 0;
+                    payload1 = value ? 1 : 0;
+                    payload2 = 0;
+                    break;
+                case "number":
+                    kind = 2;
+                    payload1 = 0;
+                    payload2 = value;
+                    break;
+                case "string":
+                    kind = 1;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "undefined":
+                    kind = 5;
+                    payload1 = 0;
+                    payload2 = 0;
+                    break;
+                case "object":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "function":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "symbol":
+                    kind = 7;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "bigint":
+                    kind = 8;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                default:
+                    throw new TypeError("Unsupported JSValue type");
+            }
+        }
+        return [kind, payload1, payload2];
+    }
+    function __bjs_jsValueLift(kind, payload1, payload2) {
+        let jsValue;
+        switch (kind) {
+            case 0:
+                jsValue = payload1 !== 0;
+                break;
+            case 1:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 2:
+                jsValue = payload2;
+                break;
+            case 3:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 4:
+                jsValue = null;
+                break;
+            case 5:
+                jsValue = undefined;
+                break;
+            case 7:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 8:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            default:
+                throw new TypeError("Unsupported JSValue kind " + kind);
+        }
+        return jsValue;
+    }
+
     const swiftClosureRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
         if (state.unregistered) { return; }
         instance?.exports?.bjs_release_swift_closure(state.pointer);
@@ -247,6 +336,39 @@ export async function createInstantiator(options, swift) {
                 const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
                 promise[__bjs_promiseSettlers] = { resolve, reject };
                 return swift.memory.retain(promise);
+            }
+            bjs["promise_resolve_TestModule_SS"] = function(promise, valueBytes, valueCount) {
+                try {
+                    const string = decodeString(valueBytes, valueCount);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(string);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_6AnimalV"] = function(promise, value) {
+                try {
+                    const value1 = swift.memory.getObject(value);
+                    swift.memory.release(value);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(value1);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_resolve_TestModule_9APIResultO"] = function(promise, value) {
+                try {
+                    const enumValue = enumHelpers.APIResult.lift(value);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(enumValue);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_reject_TestModule"] = function(promise, valueKind, valuePayload1, valuePayload2) {
+                try {
+                    const jsValue = __bjs_jsValueLift(valueKind, valuePayload1, valuePayload2);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].reject(jsValue);
+                } catch (error) {
+                    setException(error);
+                }
             }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
@@ -489,6 +611,58 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule9DirectionO_9DirectionO);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuleKSS_Sb"] = function(callbackId, param0Bytes, param0Count) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const string = decodeString(param0Bytes, param0Count);
+                    let ret = callback(string);
+                    return ret ? 1 : 0;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleKSS_Sb"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleKSS_Sb = function(param0) {
+                    const param0Bytes = textEncoder.encode(param0);
+                    const param0Id = swift.memory.retain(param0Bytes);
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleKSS_Sb(boxPtr, param0Id, param0Bytes.length);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret !== 0;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleKSS_Sb);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuleKSS_Si"] = function(callbackId, param0Bytes, param0Count) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const string = decodeString(param0Bytes, param0Count);
+                    let ret = callback(string);
+                    return ret;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleKSS_Si"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleKSS_Si = function(param0) {
+                    const param0Bytes = textEncoder.encode(param0);
+                    const param0Id = swift.memory.retain(param0Bytes);
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleKSS_Si(boxPtr, param0Id, param0Bytes.length);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleKSS_Si);
             }
             bjs["invoke_js_callback_TestModule_10TestModuleSS_SS"] = function(callbackId, param0Bytes, param0Count) {
                 try {
@@ -970,6 +1144,176 @@ export async function createInstantiator(options, swift) {
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSqSi_SqSi);
             }
+            bjs["invoke_js_callback_TestModule_10TestModuleYaKSS_SS"] = function(resolveRef, rejectRef, callbackId, param0Bytes, param0Count) {
+                const resolve = swift.memory.getObject(resolveRef);
+                const reject = swift.memory.getObject(rejectRef);
+                const callback = swift.memory.getObject(callbackId);
+                const string = decodeString(param0Bytes, param0Count);
+                callback(string).then(resolve, reject);
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleYaKSS_SS"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleYaKSS_SS = function(param0) {
+                    const param0Bytes = textEncoder.encode(param0);
+                    const param0Id = swift.memory.retain(param0Bytes);
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleYaKSS_SS(boxPtr, param0Id, param0Bytes.length);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret1;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaKSS_SS);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO"] = function(resolveRef, rejectRef, callbackId, param0) {
+                const resolve = swift.memory.getObject(resolveRef);
+                const reject = swift.memory.getObject(rejectRef);
+                const callback = swift.memory.getObject(callbackId);
+                callback(param0 !== 0).then(resolve, reject);
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleYaKSb_9APIResultO = function(param0) {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO(boxPtr, param0);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret1;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaKSb_9APIResultO);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV"] = function(resolveRef, rejectRef, callbackId, param0Bytes, param0Count) {
+                const resolve = swift.memory.getObject(resolveRef);
+                const reject = swift.memory.getObject(rejectRef);
+                const callback = swift.memory.getObject(callbackId);
+                const string = decodeString(param0Bytes, param0Count);
+                callback(string).then(resolve, reject);
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleYaSS_6AnimalV = function(param0) {
+                    const param0Bytes = textEncoder.encode(param0);
+                    const param0Id = swift.memory.retain(param0Bytes);
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleYaSS_6AnimalV(boxPtr, param0Id, param0Bytes.length);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaSS_6AnimalV);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuleYaSS_SS"] = function(resolveRef, rejectRef, callbackId, param0Bytes, param0Count) {
+                const resolve = swift.memory.getObject(resolveRef);
+                const reject = swift.memory.getObject(rejectRef);
+                const callback = swift.memory.getObject(callbackId);
+                const string = decodeString(param0Bytes, param0Count);
+                callback(string).then(resolve, reject);
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleYaSS_SS"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleYaSS_SS = function(param0) {
+                    const param0Bytes = textEncoder.encode(param0);
+                    const param0Id = swift.memory.retain(param0Bytes);
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleYaSS_SS(boxPtr, param0Id, param0Bytes.length);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    return ret1;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaSS_SS);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModules6AnimalV_y"] = function(callbackId) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const structValue = structHelpers.Animal.lift();
+                    callback(structValue);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModules6AnimalV_y"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModules6AnimalV_y = function(param0) {
+                    structHelpers.Animal.lower(param0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModules6AnimalV_y(boxPtr);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModules6AnimalV_y);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModules7JSValueV_y"] = function(callbackId, param0Kind, param0Payload1, param0Payload2) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const jsValue = __bjs_jsValueLift(param0Kind, param0Payload1, param0Payload2);
+                    callback(jsValue);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModules7JSValueV_y"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModules7JSValueV_y = function(param0) {
+                    const [param0Kind, param0Payload1, param0Payload2] = __bjs_jsValueLower(param0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModules7JSValueV_y(boxPtr, param0Kind, param0Payload1, param0Payload2);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModules7JSValueV_y);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModules9APIResultO_y"] = function(callbackId, param0) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const enumValue = enumHelpers.APIResult.lift(param0);
+                    callback(enumValue);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModules9APIResultO_y"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModules9APIResultO_y = function(param0) {
+                    const param0CaseId = enumHelpers.APIResult.lower(param0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModules9APIResultO_y(boxPtr, param0CaseId);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModules9APIResultO_y);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModulesSS_y"] = function(callbackId, param0Bytes, param0Count) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const string = decodeString(param0Bytes, param0Count);
+                    callback(string);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModulesSS_y"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModulesSS_y = function(param0) {
+                    const param0Bytes = textEncoder.encode(param0);
+                    const param0Id = swift.memory.retain(param0Bytes);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModulesSS_y(boxPtr, param0Id, param0Bytes.length);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModulesSS_y);
+            }
             // Wrapper functions for module: TestModule
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
@@ -1147,6 +1491,30 @@ export async function createInstantiator(options, swift) {
                 roundtripOptionalPerson: function bjs_roundtripOptionalPerson(personClosure) {
                     const callbackId = swift.memory.retain(personClosure);
                     const ret = instance.exports.bjs_roundtripOptionalPerson(callbackId);
+                    return swift.memory.getObject(ret);
+                },
+                makeThrowingParser: function bjs_makeThrowingParser() {
+                    const ret = instance.exports.bjs_makeThrowingParser();
+                    return swift.memory.getObject(ret);
+                },
+                validateWith: function bjs_validateWith(validate) {
+                    const callbackId = swift.memory.retain(validate);
+                    instance.exports.bjs_validateWith(callbackId);
+                },
+                makeFetcher: function bjs_makeFetcher() {
+                    const ret = instance.exports.bjs_makeFetcher();
+                    return swift.memory.getObject(ret);
+                },
+                makeAsyncEcho: function bjs_makeAsyncEcho() {
+                    const ret = instance.exports.bjs_makeAsyncEcho();
+                    return swift.memory.getObject(ret);
+                },
+                makeAnimalLoader: function bjs_makeAnimalLoader() {
+                    const ret = instance.exports.bjs_makeAnimalLoader();
+                    return swift.memory.getObject(ret);
+                },
+                makeResultLoader: function bjs_makeResultLoader() {
+                    const ret = instance.exports.bjs_makeResultLoader();
                     return swift.memory.getObject(ret);
                 },
                 roundtripDirection: function bjs_roundtripDirection(callback) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.d.ts
@@ -5,6 +5,8 @@
 // `swift package bridge-js`.
 
 export type Exports = {
+    runValidator(cb: (arg0: string) => boolean): void;
+    loadEach(fetch: (arg0: string) => Promise<string>): void;
 }
 export type Imports = {
     applyInt(value: number, transform: (arg0: number) => number): number;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
@@ -31,6 +31,95 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
+    function __bjs_jsValueLower(value) {
+        let kind;
+        let payload1;
+        let payload2;
+        if (value === null) {
+            kind = 4;
+            payload1 = 0;
+            payload2 = 0;
+        } else {
+            switch (typeof value) {
+                case "boolean":
+                    kind = 0;
+                    payload1 = value ? 1 : 0;
+                    payload2 = 0;
+                    break;
+                case "number":
+                    kind = 2;
+                    payload1 = 0;
+                    payload2 = value;
+                    break;
+                case "string":
+                    kind = 1;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "undefined":
+                    kind = 5;
+                    payload1 = 0;
+                    payload2 = 0;
+                    break;
+                case "object":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "function":
+                    kind = 3;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "symbol":
+                    kind = 7;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                case "bigint":
+                    kind = 8;
+                    payload1 = swift.memory.retain(value);
+                    payload2 = 0;
+                    break;
+                default:
+                    throw new TypeError("Unsupported JSValue type");
+            }
+        }
+        return [kind, payload1, payload2];
+    }
+    function __bjs_jsValueLift(kind, payload1, payload2) {
+        let jsValue;
+        switch (kind) {
+            case 0:
+                jsValue = payload1 !== 0;
+                break;
+            case 1:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 2:
+                jsValue = payload2;
+                break;
+            case 3:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 4:
+                jsValue = null;
+                break;
+            case 5:
+                jsValue = undefined;
+                break;
+            case 7:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            case 8:
+                jsValue = swift.memory.getObject(payload1);
+                break;
+            default:
+                throw new TypeError("Unsupported JSValue kind " + kind);
+        }
+        return jsValue;
+    }
+
     const swiftClosureRegistry = (typeof FinalizationRegistry === "undefined") ? { register: () => {}, unregister: () => {} } : new FinalizationRegistry((state) => {
         if (state.unregistered) { return; }
         instance?.exports?.bjs_release_swift_closure(state.pointer);
@@ -139,6 +228,22 @@ export async function createInstantiator(options, swift) {
                 promise[__bjs_promiseSettlers] = { resolve, reject };
                 return swift.memory.retain(promise);
             }
+            bjs["promise_resolve_TestModule_SS"] = function(promise, valueBytes, valueCount) {
+                try {
+                    const string = decodeString(valueBytes, valueCount);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(string);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["promise_reject_TestModule"] = function(promise, valueKind, valuePayload1, valuePayload2) {
+                try {
+                    const jsValue = __bjs_jsValueLift(valueKind, valuePayload1, valuePayload2);
+                    swift.memory.getObject(promise)[__bjs_promiseSettlers].reject(jsValue);
+                } catch (error) {
+                    setException(error);
+                }
+            }
             bjs["swift_js_return_optional_bool"] = function(isSome, value) {
                 if (isSome === 0) {
                     tmpRetOptionalBool = null;
@@ -233,6 +338,32 @@ export async function createInstantiator(options, swift) {
                 const func = swift.memory.getObject(funcRef);
                 func.__unregister();
             }
+            bjs["invoke_js_callback_TestModule_10TestModuleKSS_Sb"] = function(callbackId, param0Bytes, param0Count) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const string = decodeString(param0Bytes, param0Count);
+                    let ret = callback(string);
+                    return ret ? 1 : 0;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleKSS_Sb"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleKSS_Sb = function(param0) {
+                    const param0Bytes = textEncoder.encode(param0);
+                    const param0Id = swift.memory.retain(param0Bytes);
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleKSS_Sb(boxPtr, param0Id, param0Bytes.length);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret !== 0;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleKSS_Sb);
+            }
             bjs["invoke_js_callback_TestModule_10TestModuleSi_Si"] = function(callbackId, param0) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
@@ -255,6 +386,75 @@ export async function createInstantiator(options, swift) {
                     return ret;
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSi_Si);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuleYaKSS_SS"] = function(resolveRef, rejectRef, callbackId, param0Bytes, param0Count) {
+                const resolve = swift.memory.getObject(resolveRef);
+                const reject = swift.memory.getObject(rejectRef);
+                const callback = swift.memory.getObject(callbackId);
+                const string = decodeString(param0Bytes, param0Count);
+                callback(string).then(resolve, reject);
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleYaKSS_SS"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleYaKSS_SS = function(param0) {
+                    const param0Bytes = textEncoder.encode(param0);
+                    const param0Id = swift.memory.retain(param0Bytes);
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleYaKSS_SS(boxPtr, param0Id, param0Bytes.length);
+                    const ret1 = swift.memory.getObject(ret);
+                    swift.memory.release(ret);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret1;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaKSS_SS);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModules7JSValueV_y"] = function(callbackId, param0Kind, param0Payload1, param0Payload2) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const jsValue = __bjs_jsValueLift(param0Kind, param0Payload1, param0Payload2);
+                    callback(jsValue);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModules7JSValueV_y"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModules7JSValueV_y = function(param0) {
+                    const [param0Kind, param0Payload1, param0Payload2] = __bjs_jsValueLower(param0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModules7JSValueV_y(boxPtr, param0Kind, param0Payload1, param0Payload2);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModules7JSValueV_y);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModulesSS_y"] = function(callbackId, param0Bytes, param0Count) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const string = decodeString(param0Bytes, param0Count);
+                    callback(string);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModulesSS_y"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModulesSS_y = function(param0) {
+                    const param0Bytes = textEncoder.encode(param0);
+                    const param0Id = swift.memory.retain(param0Bytes);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModulesSS_y(boxPtr, param0Id, param0Bytes.length);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModulesSS_y);
             }
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_applyInt"] = function bjs_applyInt(value, transform) {
@@ -293,6 +493,14 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
+                runValidator: function bjs_runValidator(cb) {
+                    const callbackId = swift.memory.retain(cb);
+                    instance.exports.bjs_runValidator(callbackId);
+                },
+                loadEach: function bjs_loadEach(fetch) {
+                    const callbackId = swift.memory.retain(fetch);
+                    instance.exports.bjs_loadEach(callbackId);
+                },
             };
             _exports = exports;
             return exports;

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Bringing-Swift-Closures-to-JavaScript.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Bringing-Swift-Closures-to-JavaScript.md
@@ -38,6 +38,48 @@ let log = JSTypedClosure<(String) -> Void> { print($0) }
 defer { log.release() }
 ```
 
+## Throwing typed closures
+
+A ``JSTypedClosure`` signature can be `throws(JSException)`. Exceptions propagate across the boundary: a Swift closure that throws surfaces as a thrown JS error (caught with `try/catch` in JavaScript), and a throwing JS callback surfaces back into Swift as a `JSException`.
+
+```swift
+import JavaScriptKit
+
+let parse = JSTypedClosure<(String) throws(JSException) -> Int> { text in
+    guard let value = Int(text) else {
+        throw JSException(JSError(message: "Not a number: \(text)").jsValue)
+    }
+    return value
+}
+defer { parse.release() }
+```
+
+Only `throws(JSException)` is supported. Plain `throws` is rejected at build time with a diagnostic, consistent with the rest of BridgeJS (see <doc:Exporting-Swift-Function>).
+
+## Async typed closures
+
+A ``JSTypedClosure`` signature can be `async`. JavaScript receives a function that returns a `Promise`, so the TypeScript shape is `(args) => Promise<R>`. Supported return types mirror `async` functions: `ConvertibleToJSValue` types, `@JS struct`, raw-value / case-only enums, `Void`, and their `Optional` / `Array` / `Dictionary` compositions. Unsupported async return types (associated-value enums, protocols, namespace enums) are diagnosed at build time.
+
+```swift
+import JavaScriptKit
+
+let fetchCount = JSTypedClosure<(String) async -> Int> { endpoint in
+    try? await Task.sleep(nanoseconds: 10_000_000)
+    return endpoint.count
+}
+defer { fetchCount.release() }
+```
+
+```javascript
+const count = await fetchCount("/items"); // Promise<number>
+```
+
+> Important: Async closures require the JavaScript event loop executor, exactly like `async` functions. Call `JavaScriptEventLoop.installGlobalExecutor()` once during startup before invoking them. There is no special handling for closures.
+
+**Cancellation is a non-goal.** There is no propagation between a Swift `Task` and a JavaScript `Promise` in either direction.
+
+> Note: The reject path of async throwing typed closures is affected by a Swift compiler bug ([swiftlang/swift#89320](https://github.com/swiftlang/swift/issues/89320)); BridgeJS emits a build-time warning for this signature. See <doc:Exporting-Swift-Closure> for details.
+
 ## Lifetime and release()
 
 A ``JSTypedClosure`` keeps the Swift closure alive and exposes a JavaScript function that calls into it. To avoid leaks and use-after-free:

--- a/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Closure.md
+++ b/Sources/JavaScriptKit/Documentation.docc/Articles/BridgeJS/Exporting-Swift/Exporting-Swift-Closure.md
@@ -103,6 +103,144 @@ This differs from structs and arrays, which use copy semantics and transfer data
 
 When you **return** a closure to JavaScript, we recommend using ``JSTypedClosure`` and calling `release()` when the closure is no longer needed, instead of returning a plain closure type. See <doc:Bringing-Swift-Closures-to-JavaScript>.
 
+## Throwing closures
+
+Closures can throw JavaScript errors across the boundary using `throws(JSException)`, in both directions. Exceptions propagate just like they do for throwing functions (see <doc:Exporting-Swift-Function>).
+
+A Swift closure handed to JavaScript that throws surfaces as a thrown JS error, so JavaScript catches it with `try/catch`:
+
+```swift
+import JavaScriptKit
+
+@JS func makeParser() -> (String) throws(JSException) -> Int {
+    return { text in
+        guard let value = Int(text) else {
+            throw JSException(JSError(message: "Not a number: \(text)").jsValue)
+        }
+        return value
+    }
+}
+```
+
+```javascript
+const parse = exports.makeParser();
+try {
+    console.log(parse("42")); // 42
+    parse("oops");            // throws
+} catch (e) {
+    console.error("parse failed:", e);
+}
+```
+
+A throwing JavaScript callback passed into Swift surfaces back into Swift as a `JSException`, which the Swift call site rethrows:
+
+```swift
+import JavaScriptKit
+
+@JS func runValidator(_ input: String, validate: (String) throws(JSException) -> Bool) throws(JSException) -> Bool {
+    return try validate(input)
+}
+```
+
+```javascript
+exports.runValidator("ok", (value) => {
+    if (value.length === 0) {
+        throw new Error("empty input");
+    }
+    return true;
+});
+```
+
+Notes:
+- Only `throws(JSException)` is supported. Plain `throws` is rejected at build time with a diagnostic.
+- Thrown values are surfaced to JS as normal JS exceptions, and JS exceptions thrown by callbacks are surfaced into Swift as a `JSException`.
+
+## Async closures
+
+Closures can be `async` in both directions, just like `async` functions (see <doc:Exporting-Swift-Function>). An async closure is exposed to JavaScript as a function that returns a `Promise`, so its TypeScript shape is `(args) => Promise<R>`.
+
+> Important: Async closures require the JavaScript event loop executor to be installed, exactly like `async` functions. Call `JavaScriptEventLoop.installGlobalExecutor()` once during startup before invoking async closures.
+
+### Direction A - Swift awaits a JavaScript async callback
+
+A Swift `@JS func` can take a JavaScript async callback typed as `(A) async throws(JSException) -> R`. Swift `await`s the `Promise` the callback returns. Both resolution and rejection work: a rejected `Promise` surfaces into Swift as a `JSException`.
+
+```swift
+import JavaScriptKit
+
+@JS func loadAll(_ keys: [String], fetch: (String) async throws(JSException) -> String) async throws(JSException) -> [String] {
+    var results: [String] = []
+    for key in keys {
+        results.append(try await fetch(key))
+    }
+    return results
+}
+```
+
+```javascript
+const values = await exports.loadAll(["a", "b"], async (key) => {
+    const response = await fetch(`/items/${key}`);
+    if (!response.ok) throw new Error(`failed: ${key}`); // rejects → JSException in Swift
+    return response.text();
+});
+```
+
+### Direction B - a Swift async closure handed to JavaScript
+
+A Swift async closure returned to JavaScript (as a plain async closure type or a ``JSTypedClosure``) becomes a function JavaScript `await`s. Supported return types mirror async functions: `ConvertibleToJSValue` types, `@JS struct`, raw-value / case-only enums, `Void`, and their `Optional` / `Array` / `Dictionary` compositions. Unsupported async return types (associated-value enums, protocols, namespace enums) are diagnosed at build time.
+
+```swift
+import JavaScriptKit
+
+@JS struct Point {
+    let x: Double
+    let y: Double
+}
+
+// Async closure returning a @JS struct
+@JS func makePointLoader() -> JSTypedClosure<(Double, Double) async -> Point> {
+    let loader = JSTypedClosure<(Double, Double) async -> Point> { x, y in
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        return Point(x: x, y: y)
+    }
+    return loader
+}
+
+// Async closure returning Void
+@JS func makeLogger() -> JSTypedClosure<(String) async -> Void> {
+    return JSTypedClosure<(String) async -> Void> { message in
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        print(message)
+    }
+}
+```
+
+```javascript
+const loadPoint = exports.makePointLoader();
+const point = await loadPoint(1, 2); // Promise<Point>
+console.log(point.x, point.y);       // 1 2
+loadPoint.release();
+
+const log = exports.makeLogger();
+await log("hello"); // Promise<void>
+log.release();
+```
+
+The generated TypeScript declarations:
+
+```typescript
+export type Exports = {
+    makePointLoader(): (arg0: number, arg1: number) => Promise<Point>;
+    makeLogger(): (arg0: string) => Promise<void>;
+}
+```
+
+Notes:
+- The same `JavaScriptEventLoop.installGlobalExecutor()` requirement applies as for async functions; there is no special handling for closures.
+- **Cancellation is a non-goal.** There is no propagation between a Swift `Task` and a JavaScript `Promise` in either direction; cancelling one side does not cancel the other.
+
+> Warning: When an async throwing closure handed to JavaScript throws, the error is currently lost instead of rejecting the `Promise` with it, due to a Swift compiler bug on `wasm32` ([swiftlang/swift#89320](https://github.com/swiftlang/swift/issues/89320), fix in progress in [swiftlang/swift#89715](https://github.com/swiftlang/swift/pull/89715)). Closures that capture state are unaffected, as are throwing JavaScript callbacks passed into Swift. BridgeJS emits a build-time warning for this signature.
+
 ## Supported Features
 
 | Swift Feature | Status |
@@ -112,8 +250,9 @@ When you **return** a closure to JavaScript, we recommend using ``JSTypedClosure
 | `@escaping` closures | ✅ |
 | Optional types in closures |  ✅ |
 | Closure-typed `@JS` properties | ❌ |
-| Async closures | ❌ |
-| Throwing closures | ❌ |
+| Async closures `(A) async -> B` | ✅ |
+| Async throwing closures `(A) async throws(JSException) -> B` | ✅ (reject path of closures handed to JS pending [swiftlang/swift#89320](https://github.com/swiftlang/swift/issues/89320)) |
+| Throwing closures `(A) throws(JSException) -> B` | ✅ |
 
 ## See Also
 

--- a/Tests/BridgeJSRuntimeTests/ClosureAsyncAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ClosureAsyncAPIs.swift
@@ -1,0 +1,89 @@
+import XCTest
+import JavaScriptKit
+import JavaScriptEventLoop
+
+// MARK: - Direction A: Swift awaits a JS async callback
+
+@JS func awaitAsyncCallback(_ fetch: (String) async throws(JSException) -> String) async throws(JSException) -> String {
+    let resolved = try await fetch("request")
+    return "swift-saw:\(resolved)"
+}
+
+// MARK: - Direction B: a Swift async closure handed to JS
+
+@JS func makeAsyncParser() -> JSTypedClosure<(String) async throws(JSException) -> String> {
+    return JSTypedClosure { (text: String) async throws(JSException) -> String in
+        await Task.yield()
+        guard let value = Int(text) else {
+            throw JSException(JSError(message: "AsyncParseError: \(text)").jsValue)
+        }
+        return "parsed:\(value)"
+    }
+}
+
+@JS func makeAsyncEcho() -> JSTypedClosure<(String) async -> String> {
+    return JSTypedClosure { (text: String) async -> String in
+        await Task.yield()
+        return "echo:\(text)"
+    }
+}
+
+@JS func makeAsyncRecorder() -> JSTypedClosure<(String) async throws(JSException) -> Void> {
+    return JSTypedClosure { (text: String) async throws(JSException) -> Void in
+        await Task.yield()
+        if text == "boom" {
+            throw JSException(JSError(message: "AsyncRecorderError").jsValue)
+        }
+        AsyncRecorderState.lastRecorded = text
+    }
+}
+
+@JS func lastRecordedValue() -> String {
+    return AsyncRecorderState.lastRecorded
+}
+
+@JS func makeAsyncPayloadLoader() -> JSTypedClosure<(Bool) async throws(JSException) -> AsyncPayloadResult> {
+    return JSTypedClosure { (succeed: Bool) async throws(JSException) -> AsyncPayloadResult in
+        await Task.yield()
+        return succeed ? .success("loaded") : .failure(42)
+    }
+}
+
+@JS func awaitPayloadCallback(
+    _ load: (Bool) async throws(JSException) -> AsyncPayloadResult
+) async throws(JSException) -> String {
+    let first = try await load(true)
+    let second = try await load(false)
+    return "\(payloadSummary(first))|\(payloadSummary(second))"
+}
+
+private func payloadSummary(_ result: AsyncPayloadResult) -> String {
+    switch result {
+    case .success(let value): return "success:\(value)"
+    case .failure(let code): return "failure:\(code)"
+    case .idle: return "idle"
+    }
+}
+
+@JS func makeAsyncPointMaker() -> JSTypedClosure<(Double) async -> DataPoint> {
+    return JSTypedClosure { (seed: Double) async -> DataPoint in
+        await Task.yield()
+        return DataPoint(x: seed, y: seed * 2, label: "async:\(seed)", optCount: nil, optFlag: nil)
+    }
+}
+
+enum AsyncRecorderState {
+    nonisolated(unsafe) static var lastRecorded: String = ""
+}
+
+// MARK: - XCTest entry point
+
+final class ClosureAsyncTests: XCTestCase {
+    func testRunJsClosureAsyncTests() async throws {
+        try await ClosureAsyncImports.runJsClosureAsyncTests()
+    }
+}
+
+@JSClass struct ClosureAsyncImports {
+    @JSFunction static func runJsClosureAsyncTests() async throws(JSException)
+}

--- a/Tests/BridgeJSRuntimeTests/ClosureThrowsAPIs.swift
+++ b/Tests/BridgeJSRuntimeTests/ClosureThrowsAPIs.swift
@@ -1,0 +1,31 @@
+import XCTest
+import JavaScriptKit
+
+// MARK: - Direction B: Swift closure (throws) called from JS
+
+@JS func makeThrowingParser() -> JSTypedClosure<(String) throws(JSException) -> Int> {
+    return JSTypedClosure { (text: String) throws(JSException) -> Int in
+        guard let value = Int(text) else {
+            throw JSException(JSError(message: "ParseError: \(text)").jsValue)
+        }
+        return value
+    }
+}
+
+// MARK: - Direction A: JS callback (throws) called from Swift
+
+@JS func runValidator(_ validate: (String) throws(JSException) -> Bool) throws(JSException) -> Bool {
+    return try validate("input")
+}
+
+// MARK: - XCTest entry point
+
+final class ClosureThrowsTests: XCTestCase {
+    func testRunJsClosureThrowsTests() throws {
+        try ClosureThrowsImports.runJsClosureThrowsTests()
+    }
+}
+
+@JSClass struct ClosureThrowsImports {
+    @JSFunction static func runJsClosureThrowsTests() throws(JSException)
+}

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -645,6 +645,172 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9Di
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsKSS_Sb {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) throws(JSException) -> Bool {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) throws(JSException) -> Bool in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(callbackValue, param0Bytes, param0Length)
+                return ret
+            }
+            let ret = ret0
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return Bool.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) throws(JSException) -> Bool {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) throws(JSException) -> Bool) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Sb(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) throws(JSException) -> Bool>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    do {
+        let result = try closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+        return result.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: error.description)
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsKSS_Si {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) throws(JSException) -> Int {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) throws(JSException) -> Int in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(callbackValue, param0Bytes, param0Length)
+                return ret
+            }
+            let ret = ret0
+            if let error = _swift_js_take_exception() {
+                throw error
+            }
+            return Int.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) throws(JSException) -> Int {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) throws(JSException) -> Int) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) throws(JSException) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    do {
+        let result = try closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+        return result.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: error.description)
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC")
 fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> UnsafeMutableRawPointer
 #else
@@ -1802,6 +1968,358 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSqS
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async throws(JSException) -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async throws(JSException) -> String in
+            #if arch(wasm32)
+            let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending String) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async throws(JSException) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async throws(JSException) -> String) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async throws(JSException) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
+        return try await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async throws(JSException) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async throws(JSException) -> Void in
+            #if arch(wasm32)
+            try await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<() -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async throws(JSException) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async throws(JSException) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSS_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async throws(JSException) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_y, reject: Promise_reject) { () async throws(JSException) in
+        try await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(resolveRef, rejectRef, callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Bool) async throws(JSException) -> AsyncPayloadResult {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: Bool) async throws(JSException) -> AsyncPayloadResult in
+            #if arch(wasm32)
+            let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending AsyncPayloadResult) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                let param0Value = param0.bridgeJSLowerParameter()
+                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(resolveRef, rejectRef, callbackValue, param0Value)
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> AsyncPayloadResult {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Bool) async throws(JSException) -> AsyncPayloadResult) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Bool) async throws(JSException) -> AsyncPayloadResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_18AsyncPayloadResultO, reject: Promise_reject) { () async throws(JSException) -> AsyncPayloadResult in
+        return try await closure(Bool.bridgeJSLiftParameter(param0))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSS_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: String) async -> String in
+            #if arch(wasm32)
+            let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending String) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                    invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                }
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (String) async -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async -> String) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSS_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
+        return await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(resolveRef, rejectRef, callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSd_9DataPointV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Double) async -> DataPoint {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] (param0: Double) async -> DataPoint in
+            #if arch(wasm32)
+            let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
+                    JSTypedClosure<(sending DataPoint) -> Void>($0)
+                }, makeRejectClosure: {
+                    JSTypedClosure<(sending JSValue) -> Void>($0)
+                }) { resolveRef, rejectRef in
+                let callbackValue = callback.bridgeJSLowerParameter()
+                let param0Value = param0.bridgeJSLowerParameter()
+                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(resolveRef, rejectRef, callbackValue, param0Value)
+            }
+            return resolved
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Double) async -> DataPoint {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) async -> DataPoint) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) async -> DataPoint>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_9DataPointV, reject: Promise_reject) {
+        return await closure(Double.bridgeJSLiftParameter(param0))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y")
 fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
 #else
@@ -1925,6 +2443,67 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending AsyncPayloadResult) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0CaseId = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(callbackValue, param0CaseId)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending AsyncPayloadResult) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending AsyncPayloadResult) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending AsyncPayloadResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(AsyncPayloadResult.bridgeJSLiftParameter(param0))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
 fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
 #else
@@ -2041,6 +2620,67 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss7J
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending JSValue) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     closure(JSValue.bridgeJSLiftParameter(param0Kind, param0Payload1, param0Payload2))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ callback: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ callback: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ callback: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(callback)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestss9DataPointV_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending DataPoint) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let _ = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(callbackValue)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending DataPoint) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending DataPoint) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ boxPtr: UnsafeMutableRawPointer) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending DataPoint) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(DataPoint.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -6969,6 +7609,132 @@ public func _bjs_ArrayMembers_firstString() -> Void {
     #if arch(wasm32)
     let ret = ArrayMembers.bridgeJSLiftParameter().firstString(_: [String].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_awaitAsyncCallback")
+@_cdecl("bjs_awaitAsyncCallback")
+public func _bjs_awaitAsyncCallback(_ fetch: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
+        return try await awaitAsyncCallback(_: _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_SS.bridgeJSLift(fetch))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncParser")
+@_cdecl("bjs_makeAsyncParser")
+public func _bjs_makeAsyncParser() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncParser()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncEcho")
+@_cdecl("bjs_makeAsyncEcho")
+public func _bjs_makeAsyncEcho() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncEcho()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncRecorder")
+@_cdecl("bjs_makeAsyncRecorder")
+public func _bjs_makeAsyncRecorder() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncRecorder()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_lastRecordedValue")
+@_cdecl("bjs_lastRecordedValue")
+public func _bjs_lastRecordedValue() -> Void {
+    #if arch(wasm32)
+    let ret = lastRecordedValue()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncPayloadLoader")
+@_cdecl("bjs_makeAsyncPayloadLoader")
+public func _bjs_makeAsyncPayloadLoader() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncPayloadLoader()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_awaitPayloadCallback")
+@_cdecl("bjs_awaitPayloadCallback")
+public func _bjs_awaitPayloadCallback(_ load: Int32) -> Int32 {
+    #if arch(wasm32)
+    return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
+        return try await awaitPayloadCallback(_: _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO.bridgeJSLift(load))
+    }
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeAsyncPointMaker")
+@_cdecl("bjs_makeAsyncPointMaker")
+public func _bjs_makeAsyncPointMaker() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeAsyncPointMaker()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_makeThrowingParser")
+@_cdecl("bjs_makeThrowingParser")
+public func _bjs_makeThrowingParser() -> Int32 {
+    #if arch(wasm32)
+    let ret = makeThrowingParser()
+    return ret.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_runValidator")
+@_cdecl("bjs_runValidator")
+public func _bjs_runValidator(_ validate: Int32) -> Int32 {
+    #if arch(wasm32)
+    do {
+        let ret = try runValidator(_: _BJS_Closure_20BridgeJSRuntimeTestsKSS_Sb.bridgeJSLift(validate))
+        return ret.bridgeJSLowerReturn()
+    } catch let error {
+        if let error = error.thrownValue.object {
+            withExtendedLifetime(error) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        } else {
+            let jsError = JSError(message: error.description)
+            withExtendedLifetime(jsError.jsObject) {
+                _swift_js_throw(Int32(bitPattern: $0.id))
+            }
+        }
+        return 0
+    }
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -12176,6 +12942,27 @@ func _$Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: P
     if let error = _swift_js_take_exception() { throw error }
 }
 
+@JSFunction func Promise_resolve_9DataPointV(_ promise: JSObject, _ value: DataPoint) throws(JSException)
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_9DataPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+#else
+fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(promise, value)
+}
+
+func _$Promise_resolve_9DataPointV(_ promise: JSObject, _ value: DataPoint) throws(JSException) -> Void {
+    let promiseValue = promise.bridgeJSLowerParameter()
+    let valueObjectId = value.bridgeJSLowerParameter()
+    promise_resolve_BridgeJSRuntimeTests_9DataPointV(promiseValue, valueObjectId)
+    if let error = _swift_js_take_exception() { throw error }
+}
+
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ArrayElementObject_init")
 fileprivate func bjs_ArrayElementObject_init_extern(_ idBytes: Int32, _ idLength: Int32) -> Int32
@@ -12865,6 +13652,28 @@ func _$AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum(_ v: Optio
 }
 
 #if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ClosureAsyncImports_runJsClosureAsyncTests_static")
+fileprivate func bjs_ClosureAsyncImports_runJsClosureAsyncTests_static_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void
+#else
+fileprivate func bjs_ClosureAsyncImports_runJsClosureAsyncTests_static_extern(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_ClosureAsyncImports_runJsClosureAsyncTests_static(_ resolveRef: Int32, _ rejectRef: Int32) -> Void {
+    return bjs_ClosureAsyncImports_runJsClosureAsyncTests_static_extern(resolveRef, rejectRef)
+}
+
+func _$ClosureAsyncImports_runJsClosureAsyncTests() async throws(JSException) -> Void {
+    try await _bjs_awaitPromise(makeResolveClosure: {
+            JSTypedClosure<() -> Void>($0)
+        }, makeRejectClosure: {
+            JSTypedClosure<(sending JSValue) -> Void>($0)
+        }) { resolveRef, rejectRef in
+        bjs_ClosureAsyncImports_runJsClosureAsyncTests_static(resolveRef, rejectRef)
+    }
+}
+
+#if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ClosureSupportImports_jsApplyVoid_static")
 fileprivate func bjs_ClosureSupportImports_jsApplyVoid_static_extern(_ callback: Int32) -> Void
 #else
@@ -13241,6 +14050,25 @@ func _$ClosureSupportImports_jsHeapCount() throws(JSException) -> Int {
 
 func _$ClosureSupportImports_runJsClosureSupportTests() throws(JSException) -> Void {
     bjs_ClosureSupportImports_runJsClosureSupportTests_static()
+    if let error = _swift_js_take_exception() {
+        throw error
+    }
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ClosureThrowsImports_runJsClosureThrowsTests_static")
+fileprivate func bjs_ClosureThrowsImports_runJsClosureThrowsTests_static_extern() -> Void
+#else
+fileprivate func bjs_ClosureThrowsImports_runJsClosureThrowsTests_static_extern() -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func bjs_ClosureThrowsImports_runJsClosureThrowsTests_static() -> Void {
+    return bjs_ClosureThrowsImports_runJsClosureThrowsTests_static_extern()
+}
+
+func _$ClosureThrowsImports_runJsClosureThrowsTests() throws(JSException) -> Void {
+    bjs_ClosureThrowsImports_runJsClosureThrowsTests_static()
     if let error = _swift_js_take_exception() {
         throw error
     }

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -11605,6 +11605,374 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
+        "abiName" : "bjs_awaitAsyncCallback",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "awaitAsyncCallback",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "fetch",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : true,
+                  "isThrows" : true,
+                  "mangleName" : "20BridgeJSRuntimeTestsYaKSS_SS",
+                  "moduleName" : "BridgeJSRuntimeTests",
+                  "parameters" : [
+                    {
+                      "string" : {
+
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "string" : {
+
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncParser",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncParser",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : true,
+              "mangleName" : "20BridgeJSRuntimeTestsYaKSS_SS",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "string" : {
+
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncEcho",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncEcho",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : false,
+              "mangleName" : "20BridgeJSRuntimeTestsYaSS_SS",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "string" : {
+
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncRecorder",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncRecorder",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : true,
+              "mangleName" : "20BridgeJSRuntimeTestsYaKSS_y",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "void" : {
+
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_lastRecordedValue",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "lastRecordedValue",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncPayloadLoader",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncPayloadLoader",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : true,
+              "mangleName" : "20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "bool" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "associatedValueEnum" : {
+                  "_0" : "AsyncPayloadResult"
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_awaitPayloadCallback",
+        "effects" : {
+          "isAsync" : true,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "awaitPayloadCallback",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "load",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : true,
+                  "isThrows" : true,
+                  "mangleName" : "20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO",
+                  "moduleName" : "BridgeJSRuntimeTests",
+                  "parameters" : [
+                    {
+                      "bool" : {
+
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "associatedValueEnum" : {
+                      "_0" : "AsyncPayloadResult"
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "string" : {
+
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeAsyncPointMaker",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeAsyncPointMaker",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : true,
+              "isThrows" : false,
+              "mangleName" : "20BridgeJSRuntimeTestsYaSd_9DataPointV",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "double" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "swiftStruct" : {
+                  "_0" : "DataPoint"
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_makeThrowingParser",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : false
+        },
+        "name" : "makeThrowingParser",
+        "parameters" : [
+
+        ],
+        "returnType" : {
+          "closure" : {
+            "_0" : {
+              "isAsync" : false,
+              "isThrows" : true,
+              "mangleName" : "20BridgeJSRuntimeTestsKSS_Si",
+              "moduleName" : "BridgeJSRuntimeTests",
+              "parameters" : [
+                {
+                  "string" : {
+
+                  }
+                }
+              ],
+              "returnType" : {
+                "integer" : {
+                  "_0" : {
+                    "isSigned" : true,
+                    "width" : "word"
+                  }
+                }
+              },
+              "sendingParameters" : false
+            },
+            "useJSTypedClosure" : true
+          }
+        }
+      },
+      {
+        "abiName" : "bjs_runValidator",
+        "effects" : {
+          "isAsync" : false,
+          "isStatic" : false,
+          "isThrows" : true
+        },
+        "name" : "runValidator",
+        "parameters" : [
+          {
+            "label" : "_",
+            "name" : "validate",
+            "type" : {
+              "closure" : {
+                "_0" : {
+                  "isAsync" : false,
+                  "isThrows" : true,
+                  "mangleName" : "20BridgeJSRuntimeTestsKSS_Sb",
+                  "moduleName" : "BridgeJSRuntimeTests",
+                  "parameters" : [
+                    {
+                      "string" : {
+
+                      }
+                    }
+                  ],
+                  "returnType" : {
+                    "bool" : {
+
+                    }
+                  },
+                  "sendingParameters" : false
+                },
+                "useJSTypedClosure" : false
+              }
+            }
+          }
+        ],
+        "returnType" : {
+          "bool" : {
+
+          }
+        }
+      },
+      {
         "abiName" : "bjs_roundTripVoid",
         "effects" : {
           "isAsync" : false,
@@ -18719,6 +19087,45 @@
             "methods" : [
 
             ],
+            "name" : "ClosureAsyncImports",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : true,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "runJsClosureAsyncTests",
+                "parameters" : [
+
+                ],
+                "returnType" : {
+                  "void" : {
+
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "functions" : [
+
+        ],
+        "types" : [
+          {
+            "accessLevel" : "internal",
+            "getters" : [
+
+            ],
+            "methods" : [
+
+            ],
             "name" : "ClosureSupportImports",
             "setters" : [
 
@@ -19511,6 +19918,45 @@
                   "isThrows" : true
                 },
                 "name" : "runJsClosureSupportTests",
+                "parameters" : [
+
+                ],
+                "returnType" : {
+                  "void" : {
+
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "functions" : [
+
+        ],
+        "types" : [
+          {
+            "accessLevel" : "internal",
+            "getters" : [
+
+            ],
+            "methods" : [
+
+            ],
+            "name" : "ClosureThrowsImports",
+            "setters" : [
+
+            ],
+            "staticMethods" : [
+              {
+                "accessLevel" : "internal",
+                "effects" : {
+                  "isAsync" : false,
+                  "isStatic" : false,
+                  "isThrows" : true
+                },
+                "name" : "runJsClosureThrowsTests",
                 "parameters" : [
 
                 ],

--- a/Tests/BridgeJSRuntimeTests/JavaScript/ClosureAsyncTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/ClosureAsyncTests.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert";
+import { AsyncPayloadResultValues } from '../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.js';
+
+/**
+ * @returns {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Imports["ClosureAsyncImports"]}
+ */
+export function getImports(importsContext) {
+    return {
+        runJsClosureAsyncTests: async () => {
+            const exports = importsContext.getExports();
+            if (!exports) {
+                throw new Error("No exports!?");
+            }
+            await runJsClosureAsyncTests(exports);
+        },
+    };
+}
+
+/** @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports */
+export async function runJsClosureAsyncTests(exports) {
+    assert.equal(
+        await exports.awaitAsyncCallback(async (req) => {
+            await Promise.resolve();
+            return `js-${req}`;
+        }),
+        "swift-saw:js-request",
+    );
+
+    let directionAReject = null;
+    try {
+        await exports.awaitAsyncCallback(async () => {
+            throw new Error("CallbackRejected");
+        });
+        assert.fail("Expected awaitAsyncCallback to reject when the JS callback rejects");
+    } catch (error) {
+        directionAReject = error;
+    }
+    assert.notEqual(directionAReject, null);
+    assert.equal(directionAReject.message, "CallbackRejected");
+
+    const parser = exports.makeAsyncParser();
+
+    const parsed = parser("42");
+    assert.ok(parsed instanceof Promise, "async closure must return a Promise");
+    assert.equal(await parsed, "parsed:42");
+    assert.equal(await parser("-7"), "parsed:-7");
+
+    // Blocked by swiftlang/swift#89320 (wasm32 typed-throws async miscompile for captureless closures); re-enable once swiftlang/swift#89715 lands.
+    const ASYNC_THROWS_CLOSURE_REJECT_BLOCKED = true;
+    if (!ASYNC_THROWS_CLOSURE_REJECT_BLOCKED) {
+    let directionBReject = null;
+    try {
+        await parser("not-a-number");
+        assert.fail("Expected makeAsyncParser closure to reject for invalid input");
+    } catch (error) {
+        directionBReject = error;
+    }
+    assert.notEqual(directionBReject, null);
+    assert.equal(directionBReject.message, "AsyncParseError: not-a-number");
+    }
+
+    assert.equal(await parser("100"), "parsed:100");
+
+    const echo = exports.makeAsyncEcho();
+    const echoed = echo("hi");
+    assert.ok(echoed instanceof Promise, "non-throwing async closure must return a Promise");
+    assert.equal(await echoed, "echo:hi");
+
+    const recorder = exports.makeAsyncRecorder();
+    const recorded = recorder("logged-value");
+    assert.ok(recorded instanceof Promise, "Void async closure must return a Promise");
+    assert.equal(await recorded, undefined);
+    assert.equal(exports.lastRecordedValue(), "logged-value");
+
+    if (!ASYNC_THROWS_CLOSURE_REJECT_BLOCKED) {
+    let voidReject = null;
+    try {
+        await recorder("boom");
+        assert.fail("Expected makeAsyncRecorder closure to reject for 'boom'");
+    } catch (error) {
+        voidReject = error;
+    }
+    assert.notEqual(voidReject, null);
+    assert.equal(voidReject.message, "AsyncRecorderError");
+    }
+
+    const payloadLoader = exports.makeAsyncPayloadLoader();
+    const payloadPromise = payloadLoader(true);
+    assert.ok(payloadPromise instanceof Promise, "associated-value enum async closure must return a Promise");
+    assert.deepEqual(await payloadPromise, { tag: AsyncPayloadResultValues.Tag.Success, param0: "loaded" });
+    assert.deepEqual(await payloadLoader(false), { tag: AsyncPayloadResultValues.Tag.Failure, param0: 42 });
+
+    assert.equal(
+        await exports.awaitPayloadCallback(async (succeed) => {
+            await Promise.resolve();
+            return succeed
+                ? { tag: AsyncPayloadResultValues.Tag.Success, param0: "js" }
+                : { tag: AsyncPayloadResultValues.Tag.Idle };
+        }),
+        "success:js|idle",
+    );
+
+    const pointMaker = exports.makeAsyncPointMaker();
+    const pointPromise = pointMaker(3);
+    assert.ok(pointPromise instanceof Promise, "struct-returning async closure must return a Promise");
+    const point = await pointPromise;
+    assert.equal(point.x, 3);
+    assert.equal(point.y, 6);
+    assert.equal(point.label, "async:3.0");
+
+    {
+        const racer = exports.makeAsyncEcho();
+        const inFlight = racer("race");
+        if (typeof racer.release === "function") {
+            racer.release();
+        }
+        if (typeof global !== "undefined" && typeof global.gc === "function") {
+            global.gc();
+        }
+        assert.equal(await inFlight, "echo:race");
+    }
+
+    {
+        const concurrent = exports.makeAsyncEcho();
+        const promises = [];
+        for (let i = 0; i < 16; i++) {
+            promises.push(concurrent("c" + i));
+        }
+        const results = await Promise.all(promises);
+        for (let i = 0; i < 16; i++) {
+            assert.equal(results[i], "echo:c" + i);
+        }
+        if (typeof concurrent.release === "function") {
+            concurrent.release();
+        }
+    }
+}

--- a/Tests/BridgeJSRuntimeTests/JavaScript/ClosureThrowsTests.mjs
+++ b/Tests/BridgeJSRuntimeTests/JavaScript/ClosureThrowsTests.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert";
+
+/**
+ * @returns {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Imports["ClosureThrowsImports"]}
+ */
+export function getImports(importsContext) {
+    return {
+        runJsClosureThrowsTests: () => {
+            const exports = importsContext.getExports();
+            if (!exports) {
+                throw new Error("No exports!?");
+            }
+            runJsClosureThrowsTests(exports);
+        },
+    };
+}
+
+/** @param {import('../../../.build/plugins/PackageToJS/outputs/PackageTests/bridge-js.d.ts').Exports} exports */
+export function runJsClosureThrowsTests(exports) {
+    const parser = exports.makeThrowingParser();
+
+    assert.equal(parser("42"), 42);
+    assert.equal(parser("-7"), -7);
+
+    let caught = null;
+    try {
+        parser("not-a-number");
+        assert.fail("Expected makeThrowingParser closure to throw for invalid input");
+    } catch (error) {
+        caught = error;
+    }
+    assert.notEqual(caught, null);
+    assert.equal(caught.message, "ParseError: not-a-number");
+
+    assert.equal(parser("100"), 100);
+
+    assert.equal(
+        exports.runValidator((value) => value === "input"),
+        true,
+    );
+    assert.equal(
+        exports.runValidator((value) => value === "something-else"),
+        false,
+    );
+
+    let propagated = null;
+    try {
+        exports.runValidator(() => {
+            throw new Error("ValidatorError");
+        });
+        assert.fail("Expected runValidator to propagate the JS callback error");
+    } catch (error) {
+        propagated = error;
+    }
+    assert.notEqual(propagated, null);
+    assert.equal(propagated.message, "ValidatorError");
+}

--- a/Tests/BridgeJSRuntimeTests/TypedThrowsAsyncClosureBugTests.swift
+++ b/Tests/BridgeJSRuntimeTests/TypedThrowsAsyncClosureBugTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+import JavaScriptKit
+import JavaScriptEventLoop
+
+/// Reproducer for swiftlang/swift#89320 (fix in flight: swiftlang/swift#89715):
+/// on wasm32, a typed error thrown from a CAPTURELESS async closure value or
+/// function reference (lowered via `thin_to_thick_function`) is lost across the
+/// async unwind when the error type is too large for the direct error convention.
+/// Capturing closures, direct async function calls, and small error payloads are
+/// unaffected. The bug cases below assert the current (incorrect) behavior so the
+/// suite stays green; flip them once swiftlang/swift#89715 lands.
+
+// MARK: - Payload types
+
+struct PlainValuePayloadError: Error, Equatable {
+    let marker: String
+}
+
+/// Intentionally limited to trivially-copyable fields: the corrupted error produced by
+/// swiftlang/swift#89320 is unsafe to read through String or class-reference payloads.
+struct LargePayloadError: Error, Equatable {
+    let first: UInt64
+    let second: UInt64
+    let third: UInt64
+    let marker: UInt64
+}
+
+final class MarkerBox: @unchecked Sendable {
+    let marker: String
+    init(_ marker: String) { self.marker = marker }
+}
+struct ReferencePayloadError: Error {
+    let box: MarkerBox
+}
+
+// MARK: - Control "async function" forms (payload must survive)
+
+private func asyncFunctionThrowsValue() async throws(PlainValuePayloadError) {
+    throw PlainValuePayloadError(marker: "ALIVE")
+}
+
+private func asyncFunctionThrowsReference() async throws(ReferencePayloadError) {
+    throw ReferencePayloadError(box: MarkerBox("ALIVE"))
+}
+
+private func asyncFunctionThrowsJSException() async throws(JSException) {
+    throw JSException(JSError(message: "ALIVE").jsValue)
+}
+
+@inline(never)
+private func largePayloadAfterThrow(
+    _ closure: () async throws(LargePayloadError) -> Void
+) async -> LargePayloadError? {
+    do {
+        try await closure()
+        return nil
+    } catch {
+        return error
+    }
+}
+
+final class TypedThrowsAsyncClosureBugTests: XCTestCase {
+
+    func testControl_valuePayload_asyncFunction() async throws {
+        do {
+            try await asyncFunctionThrowsValue()
+            XCTFail("expected throw")
+        } catch let error as PlainValuePayloadError {
+            print("[REPRO] value / async function           payload: \(error.marker)")
+            XCTAssertEqual(error.marker, "ALIVE")
+        }
+    }
+
+    func testControl_valuePayload_typedThrowsAsyncClosure() async throws {
+        let closure: () async throws(PlainValuePayloadError) -> Void = {
+            () async throws(PlainValuePayloadError) -> Void in
+            throw PlainValuePayloadError(marker: "ALIVE")
+        }
+        do {
+            try await closure()
+            XCTFail("expected throw")
+        } catch let error as PlainValuePayloadError {
+            print("[REPRO] value / typed-throws async closure payload: \(error.marker)")
+            XCTAssertEqual(error.marker, "ALIVE")
+        }
+    }
+
+    func testControl_valuePayload_untypedAsyncClosure() async throws {
+        let closure: () async throws -> Void = {
+            throw PlainValuePayloadError(marker: "ALIVE")
+        }
+        do {
+            try await closure()
+            XCTFail("expected throw")
+        } catch let error as PlainValuePayloadError {
+            print("[REPRO] value / untyped async closure     payload: \(error.marker)")
+            XCTAssertEqual(error.marker, "ALIVE")
+        }
+    }
+
+    func testControl_referencePayload_asyncFunction() async throws {
+        do {
+            try await asyncFunctionThrowsReference()
+            XCTFail("expected throw")
+        } catch let error as ReferencePayloadError {
+            print("[REPRO] ref   / async function           payload: \(error.box.marker)")
+            XCTAssertEqual(error.box.marker, "ALIVE")
+        }
+    }
+
+    func testControl_referencePayload_typedThrowsAsyncClosure() async throws {
+        let closure: () async throws(ReferencePayloadError) -> Void = {
+            () async throws(ReferencePayloadError) -> Void in
+            throw ReferencePayloadError(box: MarkerBox("ALIVE"))
+        }
+        do {
+            try await closure()
+            XCTFail("expected throw")
+        } catch let error as ReferencePayloadError {
+            print("[REPRO] ref   / typed-throws async closure payload: \(error.box.marker)")
+            XCTAssertEqual(error.box.marker, "ALIVE")
+        }
+    }
+
+    func testControl_jsException_asyncFunction() async throws {
+        do {
+            try await asyncFunctionThrowsJSException()
+            XCTFail("expected throw")
+        } catch let error as JSException {
+            let alive = error.thrownValue.object != nil
+            print("[REPRO] jsexc / async function           object!=nil: \(alive)")
+            XCTAssertTrue(alive, "async function should preserve the thrown JS object")
+            XCTAssertEqual(error.thrownValue.object?.message.string, "ALIVE")
+        }
+    }
+
+    func testControl_jsException_untypedAsyncClosure() async throws {
+        let closure: () async throws -> Void = {
+            throw JSException(JSError(message: "ALIVE").jsValue)
+        }
+        do {
+            try await closure()
+            XCTFail("expected throw")
+        } catch let error as JSException {
+            let alive = error.thrownValue.object != nil
+            print("[REPRO] jsexc / untyped async closure     object!=nil: \(alive)")
+            XCTAssertTrue(alive, "untyped async closure should preserve the thrown JS object")
+            XCTAssertEqual(error.thrownValue.object?.message.string, "ALIVE")
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    func testControl_jsException_capturingTypedThrowsAsyncClosure() async throws {
+        let capturedMarker = "ALIVE"
+        let closure: () async throws(JSException) -> Void = { () async throws(JSException) -> Void in
+            throw JSException(JSError(message: capturedMarker).jsValue)
+        }
+        do {
+            try await closure()
+            XCTFail("expected throw")
+        } catch let error as JSException {
+            let alive = error.thrownValue.object != nil
+            print("[REPRO] jsexc / capturing typed-throws closure object!=nil: \(alive)")
+            XCTAssertTrue(alive, "capturing typed-throws async closure should preserve the thrown JS object")
+            XCTAssertEqual(error.thrownValue.object?.message.string, "ALIVE")
+        }
+    }
+
+    /// Asserts the current (buggy) behavior of swiftlang/swift#89320: the JSException payload is lost.
+    /// When the compiler is fixed this test will fail; flip to XCTAssertTrue(alive).
+    func testBug_jsException_typedThrowsAsyncClosure() async throws {
+        let closure: () async throws(JSException) -> Void = { () async throws(JSException) -> Void in
+            throw JSException(JSError(message: "ALIVE").jsValue)
+        }
+        do {
+            try await closure()
+            XCTFail("expected throw")
+        } catch let error as JSException {
+            let alive = error.thrownValue.object != nil
+            print("[REPRO] jsexc / typed-throws async closure object!=nil: \(alive)  <-- BUG: payload lost")
+
+            XCTAssertFalse(
+                alive,
+                """
+                swiftlang/swift#89320 is expected to LOSE the JSException payload \
+                thrown from a captureless typed-throws async closure. If this \
+                assertion now fails, the compiler bug appears fixed -- flip this to \
+                XCTAssertTrue(alive) and re-enable the message round-trip check.
+                """
+            )
+        }
+    }
+
+    /// Asserts the current (buggy) behavior of swiftlang/swift#89320 with a plain Swift
+    /// error larger than the direct error convention: no JavaScriptKit types involved.
+    func testBug_largePlainPayload_typedThrowsAsyncClosure() async throws {
+        let expected = LargePayloadError(
+            first: 0x1111_1111_1111_1111,
+            second: 0x2222_2222_2222_2222,
+            third: 0x3333_3333_3333_3333,
+            marker: 0xA11FE
+        )
+        let closure: () async throws(LargePayloadError) -> Void = { () async throws(LargePayloadError) -> Void in
+            throw LargePayloadError(
+                first: 0x1111_1111_1111_1111,
+                second: 0x2222_2222_2222_2222,
+                third: 0x3333_3333_3333_3333,
+                marker: 0xA11FE
+            )
+        }
+        let observed = await largePayloadAfterThrow(closure)
+        XCTAssertNotNil(observed, "expected throw")
+        let observedDescription = observed.map {
+            "first: \(String($0.first, radix: 16)) second: \(String($0.second, radix: 16)) "
+                + "third: \(String($0.third, radix: 16)) marker: \(String($0.marker, radix: 16))"
+        }
+        print("[REPRO] large / typed-throws async closure \(observedDescription ?? "nil")  <-- BUG: payload lost")
+
+        XCTAssertNotEqual(
+            observed,
+            expected,
+            """
+            swiftlang/swift#89320 is expected to LOSE the large plain-Swift error \
+            payload thrown from a captureless typed-throws async closure. If this \
+            assertion now fails, the compiler bug appears fixed -- flip this to \
+            assert the payload is preserved.
+            """
+        )
+    }
+}

--- a/Tests/prelude.mjs
+++ b/Tests/prelude.mjs
@@ -6,6 +6,8 @@ import {
 import { ImportedFoo } from './BridgeJSRuntimeTests/JavaScript/Types.mjs';
 import { runJsOptionalSupportTests } from './BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs';
 import { getImports as getClosureSupportImports } from './BridgeJSRuntimeTests/JavaScript/ClosureSupportTests.mjs';
+import { getImports as getClosureThrowsImports } from './BridgeJSRuntimeTests/JavaScript/ClosureThrowsTests.mjs';
+import { getImports as getClosureAsyncImports } from './BridgeJSRuntimeTests/JavaScript/ClosureAsyncTests.mjs';
 import { getImports as getSwiftClassSupportImports } from './BridgeJSRuntimeTests/JavaScript/SwiftClassSupportTests.mjs';
 import { getImports as getOptionalSupportImports } from './BridgeJSRuntimeTests/JavaScript/OptionalSupportTests.mjs';
 import { getImports as getArraySupportImports, ArrayElementObject } from './BridgeJSRuntimeTests/JavaScript/ArraySupportTests.mjs';
@@ -160,6 +162,8 @@ export async function setupOptions(options, context) {
                     runJsOptionalSupportTests(exports);
                 },
                 ClosureSupportImports: getClosureSupportImports(importsContext),
+                ClosureThrowsImports: getClosureThrowsImports(importsContext),
+                ClosureAsyncImports: getClosureAsyncImports(importsContext),
                 SwiftClassSupportImports: getSwiftClassSupportImports(importsContext),
                 OptionalSupportImports: getOptionalSupportImports(importsContext),
                 ArraySupportImports: getArraySupportImports(importsContext),


### PR DESCRIPTION
## Overview

A standalone, runnable reproducer for the Swift compiler bug that blocks the Swift-to-JS `async throws` reject path in the closures work (the "Known limitation" in the feature PR). This branch is stacked on top of that feature branch so reviewers see only the reproducer test in the diff.

**Root cause identified: this is [swiftlang/swift#89320](https://github.com/swiftlang/swift/issues/89320)** ("Crash with typed/untyped throwing `async` functions on Wasm"), with a fix in progress in **[swiftlang/swift#89715](https://github.com/swiftlang/swift/pull/89715)** (IRGen: fix async typed throws miscompiles on Wasm). On wasm32, IRGen places the indirect typed-error pointer after `swiftself` at thick call sites, but a captureless closure or function reference goes through `thin_to_thick_function` whose thin signature has no `swiftself`; LLVM's wasm swiftcc padding appends the missing parameters, producing equal-arity but permuted signatures. The callee writes the thrown error through the caller's null `swiftself`, and the caller reads a never-written slot.

The bug triggers only when both conditions hold:

1. the typed error is too large for the direct error convention (roughly >16 bytes on wasm32; `JSException` is ~36 bytes), and
2. the closure value was produced by `thin_to_thick_function` (a captureless closure literal or a function reference).

`Tests/BridgeJSRuntimeTests/TypedThrowsAsyncClosureBugTests.swift` demonstrates both conditions with labelled `[REPRO]` output. The suite stays green: the buggy cases are encoded as current-behaviour assertions with a comment to flip once swiftlang/swift#89715 lands (`XCTExpectFailure` is not available in the wasm XCTest runtime).

## What it shows

```
[REPRO] jsexc / typed-throws async closure   object!=nil: false   <- payload lost
[REPRO] large / typed-throws async closure   garbage values       <- payload lost (no JavaScriptKit types involved)
[REPRO] jsexc / async function               object!=nil: true
[REPRO] jsexc / capturing typed-throws closure object!=nil: true  <- capturing closures are unaffected
[REPRO] jsexc / untyped async closure        object!=nil: true
[REPRO] value / typed-throws async closure   payload: ALIVE       <- small errors ride the direct convention
[REPRO] ref   / typed-throws async closure   payload: ALIVE
```

| case | error size | callee shape | result |
|---|---|---|---|
| `JSException` from captureless async closure | ~36 B | thin_to_thick | LOST |
| 32-byte plain-Swift error from captureless async closure | 32 B | thin_to_thick | LOST |
| `JSException` from async function | ~36 B | direct | preserved |
| `JSException` from capturing async closure | ~36 B | partial apply | preserved |
| `JSException` from untyped async closure | ~36 B | untyped convention | preserved |
| small struct / class-reference errors | 4-12 B | thin_to_thick | preserved |

Two additional observations that raise severity beyond the trap documented in swiftlang/swift#89320:

- the corruption is silent: the caller observes a zeroed or stale-garbage error value instead of trapping;
- the garbage is dangerous to even read: a corrupted error carrying a `String` field trapped with `UnsafeBufferPointer has a nil start and nonzero count` during interpolation, and releasing corrupted references crashes in `swift_release`.

## Relationship to existing Swift issues

- [swiftlang/swift#89320](https://github.com/swiftlang/swift/issues/89320): same root cause; that issue documents the trap manifestation, this reproducer adds the silent-corruption manifestation.
- [swiftlang/swift#89715](https://github.com/swiftlang/swift/pull/89715): the in-flight IRGen fix (orders the indirect error before `swiftself` so thin and thick signatures agree).
- [swiftlang/swift#89155](https://github.com/swiftlang/swift/issues/89155): `Result.init(catching:)` async trap on wasm, same root cause, used as a regression guard by the fix.
- [swiftlang/swift#89416](https://github.com/swiftlang/swift/pull/89416) / [#89541](https://github.com/swiftlang/swift/pull/89541): an earlier SIL-level band-aid and its revert.
- The known compile-time typed-throws inference issues (swiftlang/swift#77718, #76169, #78880, #83773, #87556, #76807) are a distinct class: those fail to compile, this compiles and miscompiles at runtime.

## Purpose

Internal review artifact to confirm the characterization before coordinating with the maintainers on the preferred path (merge with the documented limitation, box `JSException` storage to fit the direct error convention, or wait for swiftlang/swift#89715). Run with `make unittest`.
