### PR TITLE
BridgeJS: Unify optional stack encoding to presence-flag form

### DIFF
--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -2195,35 +2195,6 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) throws -> IntrinsicJSFragment {
-        if case .associatedValueEnum(let fullName) = wrappedType {
-            let base = fullName.components(separatedBy: ".").last ?? fullName
-            let absenceLiteral = kind.absenceLiteral
-            return IntrinsicJSFragment(
-                parameters: [],
-                printCode: { arguments, context in
-                    let (scope, printer) = (context.scope, context.printer)
-                    let caseIdVar = scope.variable("caseId")
-                    let resultVar = scope.variable("optValue")
-
-                    printer.write("const \(caseIdVar) = \(scope.popI32());")
-                    printer.write("let \(resultVar);")
-                    printer.write("if (\(caseIdVar) === -1) {")
-                    printer.indent {
-                        printer.write("\(resultVar) = \(absenceLiteral);")
-                    }
-                    printer.write("} else {")
-                    printer.indent {
-                        printer.write(
-                            "\(resultVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lift(\(caseIdVar));"
-                        )
-                    }
-                    printer.write("}")
-
-                    return [resultVar]
-                }
-            )
-        }
-
         let absenceLiteral = kind.absenceLiteral
         return IntrinsicJSFragment(
             parameters: [],
@@ -2261,36 +2232,6 @@ struct IntrinsicJSFragment: Sendable {
         wrappedType: BridgeType,
         kind: JSOptionalKind
     ) throws -> IntrinsicJSFragment {
-        if case .associatedValueEnum(let fullName) = wrappedType {
-            let base = fullName.components(separatedBy: ".").last ?? fullName
-            return IntrinsicJSFragment(
-                parameters: ["value"],
-                printCode: { arguments, context in
-                    let (scope, printer) = (context.scope, context.printer)
-                    let value = arguments[0]
-                    let isSomeVar = scope.variable("isSome")
-                    let presenceExpr = kind.presenceCheck(value: value)
-
-                    printer.write("const \(isSomeVar) = \(presenceExpr) ? 1 : 0;")
-                    printer.write("if (\(isSomeVar)) {")
-                    printer.indent {
-                        let caseIdVar = scope.variable("caseId")
-                        printer.write(
-                            "const \(caseIdVar) = \(JSGlueVariableScope.reservedEnumHelpers).\(base).lower(\(value));"
-                        )
-                        scope.emitPushI32Parameter(caseIdVar, printer: printer)
-                    }
-                    printer.write("} else {")
-                    printer.indent {
-                        scope.emitPushI32Parameter("-1", printer: printer)
-                    }
-                    printer.write("}")
-
-                    return []
-                }
-            )
-        }
-
         return IntrinsicJSFragment(
             parameters: ["value"],
             printCode: { arguments, context in

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
@@ -482,9 +482,8 @@ export async function createInstantiator(options, swift) {
                         if (isSome) {
                             const caseId = enumHelpers.InnerTag.lower(elem);
                             i32Stack.push(caseId);
-                        } else {
-                            i32Stack.push(-1);
                         }
+                        i32Stack.push(isSome);
                     }
                     i32Stack.push(xs.length);
                     instance.exports.bjs_roundtripTags();
@@ -495,12 +494,13 @@ export async function createInstantiator(options, swift) {
                     } else {
                         arrayResult = [];
                         for (let i = 0; i < arrayLen; i++) {
-                            const caseId1 = i32Stack.pop();
+                            const isSome1 = i32Stack.pop();
                             let optValue;
-                            if (caseId1 === -1) {
+                            if (isSome1 === 0) {
                                 optValue = null;
                             } else {
-                                optValue = enumHelpers.InnerTag.lift(caseId1);
+                                const enumValue = enumHelpers.InnerTag.lift(i32Stack.pop());
+                                optValue = enumValue;
                             }
                             arrayResult.push(optValue);
                         }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -676,9 +676,8 @@ export async function createInstantiator(options, swift) {
                     if (isSome) {
                         const caseId = enumHelpers.APIResult.lower(value.param0);
                         i32Stack.push(caseId);
-                    } else {
-                        i32Stack.push(-1);
                     }
+                    i32Stack.push(isSome);
                     return OptionalAllTypesResultValues.Tag.OptNestedEnum;
                 }
                 case OptionalAllTypesResultValues.Tag.OptArray: {
@@ -738,12 +737,13 @@ export async function createInstantiator(options, swift) {
                     return { tag: OptionalAllTypesResultValues.Tag.OptJSObject, param0: optValue };
                 }
                 case OptionalAllTypesResultValues.Tag.OptNestedEnum: {
-                    const caseId = i32Stack.pop();
+                    const isSome = i32Stack.pop();
                     let optValue;
-                    if (caseId === -1) {
+                    if (isSome === 0) {
                         optValue = null;
                     } else {
-                        optValue = enumHelpers.APIResult.lift(caseId);
+                        const enumValue = enumHelpers.APIResult.lift(i32Stack.pop());
+                        optValue = enumValue;
                     }
                     return { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: optValue };
                 }

--- a/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
+++ b/Sources/JavaScriptKit/BridgeJSIntrinsics.swift
@@ -1100,23 +1100,6 @@ extension _BridgedSwiftAssociatedValueEnum {
         _swift_js_push_i32(bridgeJSStackPushPayload())
     }
 
-    public static func bridgeJSStackPopAsOptional() -> Self? {
-        let discriminator = _swift_js_pop_i32()
-        if discriminator == -1 {
-            return nil
-        }
-        return bridgeJSStackPopPayload(discriminator)
-    }
-
-    public static func bridgeJSStackPushAsOptional(_ value: consuming Self?) {
-        switch consume value {
-        case .none:
-            _swift_js_push_i32(-1)
-        case .some(let value):
-            _swift_js_push_i32(value.bridgeJSStackPushPayload())
-        }
-    }
-
     @_spi(BridgeJS) public static func bridgeJSLiftParameter(_ caseId: Int32) -> Self {
         return bridgeJSStackPopPayload(caseId)
     }
@@ -2378,7 +2361,12 @@ extension _BridgedAsOptional where Wrapped: _BridgedSwiftAssociatedValueEnum {
     }
 
     @_spi(BridgeJS) public consuming func bridgeJSLowerReturn() {
-        Wrapped.bridgeJSStackPushAsOptional(asOptional)
+        switch asOptional {
+        case .none:
+            _swift_js_push_i32(-1)
+        case .some(let value):
+            _swift_js_push_i32(value.bridgeJSStackPushPayload())
+        }
     }
 }
 


### PR DESCRIPTION
## Overview

Unifies the stack encoding of `Optional` values to a single presence-flag form. Previously, associated-value enums were the one type with a specialized optional stack encoding: the presence signal was merged into the case-ID slot, with `-1` meaning `nil`. Every other type uses a `0`/`1` presence flag followed by the value. After this change, associated-value enums use the same flag form as everything else when crossing in stack positions (array elements, struct fields, dictionary values, nested enum payloads).

```
before:  caseId | -1            (one i32, meaning depends on the wrapped type)
after:   flag, then caseId      (flag is 0/1 for every type)
```

**1. Swift runtime.** The `bridgeJSStackPop/PushAsOptional` override on `_BridgedSwiftAssociatedValueEnum` is removed; the protocol defaults now serve every type. The direct return slot keeps the merged `caseId`/`-1` convention (it is a separate ABI position, shared with other enum returns); the previous implementation delegated to the stack helper, so the merged form is now inlined there with a comment.

**2. JS glue.** The associated-value enum special cases in `optionalElementRaiseFragment` / `optionalElementLowerFragment` are removed; associated-value enums flow through the same general path as all other wrapped types, which composes the existing per-type element fragments behind a presence flag.

## Cost

Optional associated-value enums in stack positions carry one extra `i32` (the flag) per crossing. Direct parameter and return conventions are unchanged.

## Motivation

This removes the only optional stack encoding that cannot be decoded without knowing the wrapped type: a popped `0` meant `nil` for most types but "case 0, payload follows" for associated-value enums. A type-agnostic consumer of the stack encoding needs one uniform optional form; this prepares for generic function support (#398), where a runtime codec decodes optionals without static knowledge of `T`. A follow-up PR adds that support.

## Test plan

- Host snapshot tests and `npm run check:bridgejs-dts` pass; only two `.js` snapshots change, showing the flag-form encoding.
- WebAssembly runtime tests pass, including `testRoundTripOptionalAssociatedValueEnum` and `asyncRoundTripOptionalAssociatedValueEnum`, which exercise the changed encoding end to end.
