### PR TITLE
BridgeJS: Module-qualify internal ABI names to fix cross-module type collisions

### DIFF
--- a/Benchmarks/Sources/Generated/BridgeJS.swift
+++ b/Benchmarks/Sources/Generated/BridgeJS.swift
@@ -8,8 +8,8 @@
 
 @_spi(BridgeJS) import JavaScriptKit
 
-extension APIResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
+extension Benchmarks.APIResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Benchmarks.APIResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -24,7 +24,7 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         case 5:
             return .info
         default:
-            fatalError("Unknown APIResult case ID: \(caseId)")
+            fatalError("Unknown Benchmarks.APIResult case ID: \(caseId)")
         }
     }
 
@@ -51,8 +51,8 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ComplexResult {
+extension Benchmarks.ComplexResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Benchmarks.ComplexResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -69,7 +69,7 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
         case 6:
             return .info
         default:
-            fatalError("Unknown ComplexResult case ID: \(caseId)")
+            fatalError("Unknown Benchmarks.ComplexResult case ID: \(caseId)")
         }
     }
 
@@ -114,14 +114,14 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension SimpleStruct: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> SimpleStruct {
+extension Benchmarks.SimpleStruct: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Benchmarks.SimpleStruct {
         let precise = Double.bridgeJSStackPop()
         let rate = Float.bridgeJSStackPop()
         let flag = Bool.bridgeJSStackPop()
         let count = Int.bridgeJSStackPop()
         let name = String.bridgeJSStackPop()
-        return SimpleStruct(name: name, count: count, flag: flag, rate: rate, precise: precise)
+        return Benchmarks.SimpleStruct(name: name, count: count, flag: flag, rate: rate, precise: precise)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -133,47 +133,47 @@ extension SimpleStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_SimpleStruct(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_Benchmarks_SimpleStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_SimpleStruct()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Benchmarks_SimpleStruct()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SimpleStruct")
-fileprivate func _bjs_struct_lower_SimpleStruct_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Benchmarks_SimpleStruct")
+fileprivate func _bjs_struct_lower_Benchmarks_SimpleStruct_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_SimpleStruct_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_Benchmarks_SimpleStruct_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_SimpleStruct(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_SimpleStruct_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_Benchmarks_SimpleStruct(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_Benchmarks_SimpleStruct_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_SimpleStruct")
-fileprivate func _bjs_struct_lift_SimpleStruct_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Benchmarks_SimpleStruct")
+fileprivate func _bjs_struct_lift_Benchmarks_SimpleStruct_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_SimpleStruct_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_Benchmarks_SimpleStruct_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_SimpleStruct() -> Int32 {
-    return _bjs_struct_lift_SimpleStruct_extern()
+@inline(never) fileprivate func _bjs_struct_lift_Benchmarks_SimpleStruct() -> Int32 {
+    return _bjs_struct_lift_Benchmarks_SimpleStruct_extern()
 }
 
-extension Address: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Address {
+extension Benchmarks.Address: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Benchmarks.Address {
         let zipCode = Int.bridgeJSStackPop()
         let city = String.bridgeJSStackPop()
         let street = String.bridgeJSStackPop()
-        return Address(street: street, city: city, zipCode: zipCode)
+        return Benchmarks.Address(street: street, city: city, zipCode: zipCode)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -183,48 +183,48 @@ extension Address: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_Benchmarks_Address(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Address()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Benchmarks_Address()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
-fileprivate func _bjs_struct_lower_Address_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Benchmarks_Address")
+fileprivate func _bjs_struct_lower_Benchmarks_Address_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Address_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_Benchmarks_Address_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Address_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_Benchmarks_Address(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_Benchmarks_Address_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Address")
-fileprivate func _bjs_struct_lift_Address_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Benchmarks_Address")
+fileprivate func _bjs_struct_lift_Benchmarks_Address_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Address_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_Benchmarks_Address_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Address() -> Int32 {
-    return _bjs_struct_lift_Address_extern()
+@inline(never) fileprivate func _bjs_struct_lift_Benchmarks_Address() -> Int32 {
+    return _bjs_struct_lift_Benchmarks_Address_extern()
 }
 
-extension Person: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Person {
+extension Benchmarks.Person: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Benchmarks.Person {
         let email = Optional<String>.bridgeJSStackPop()
-        let address = Address.bridgeJSStackPop()
+        let address = Benchmarks.Address.bridgeJSStackPop()
         let age = Int.bridgeJSStackPop()
         let name = String.bridgeJSStackPop()
-        return Person(name: name, age: age, address: address, email: email)
+        return Benchmarks.Person(name: name, age: age, address: address, email: email)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -235,50 +235,50 @@ extension Person: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_Benchmarks_Person(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Person()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Benchmarks_Person()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Person")
-fileprivate func _bjs_struct_lower_Person_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Benchmarks_Person")
+fileprivate func _bjs_struct_lower_Benchmarks_Person_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Person_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_Benchmarks_Person_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Person_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_Benchmarks_Person(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_Benchmarks_Person_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Person")
-fileprivate func _bjs_struct_lift_Person_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Benchmarks_Person")
+fileprivate func _bjs_struct_lift_Benchmarks_Person_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Person_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_Benchmarks_Person_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Person() -> Int32 {
-    return _bjs_struct_lift_Person_extern()
+@inline(never) fileprivate func _bjs_struct_lift_Benchmarks_Person() -> Int32 {
+    return _bjs_struct_lift_Benchmarks_Person_extern()
 }
 
-extension ComplexStruct: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ComplexStruct {
+extension Benchmarks.ComplexStruct: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Benchmarks.ComplexStruct {
         let metadata = String.bridgeJSStackPop()
         let tags = String.bridgeJSStackPop()
         let score = Double.bridgeJSStackPop()
         let active = Bool.bridgeJSStackPop()
         let title = String.bridgeJSStackPop()
         let id = Int.bridgeJSStackPop()
-        return ComplexStruct(id: id, title: title, active: active, score: score, tags: tags, metadata: metadata)
+        return Benchmarks.ComplexStruct(id: id, title: title, active: active, score: score, tags: tags, metadata: metadata)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -291,46 +291,46 @@ extension ComplexStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_ComplexStruct(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_Benchmarks_ComplexStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ComplexStruct()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Benchmarks_ComplexStruct()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ComplexStruct")
-fileprivate func _bjs_struct_lower_ComplexStruct_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Benchmarks_ComplexStruct")
+fileprivate func _bjs_struct_lower_Benchmarks_ComplexStruct_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ComplexStruct_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_Benchmarks_ComplexStruct_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_ComplexStruct(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_ComplexStruct_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_Benchmarks_ComplexStruct(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_Benchmarks_ComplexStruct_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ComplexStruct")
-fileprivate func _bjs_struct_lift_ComplexStruct_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Benchmarks_ComplexStruct")
+fileprivate func _bjs_struct_lift_Benchmarks_ComplexStruct_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_ComplexStruct_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_Benchmarks_ComplexStruct_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_ComplexStruct() -> Int32 {
-    return _bjs_struct_lift_ComplexStruct_extern()
+@inline(never) fileprivate func _bjs_struct_lift_Benchmarks_ComplexStruct() -> Int32 {
+    return _bjs_struct_lift_Benchmarks_ComplexStruct_extern()
 }
 
-extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+extension Benchmarks.Point: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Benchmarks.Point {
         let y = Double.bridgeJSStackPop()
         let x = Double.bridgeJSStackPop()
-        return Point(x: x, y: y)
+        return Benchmarks.Point(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -339,44 +339,44 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_Benchmarks_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Benchmarks_Point()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Benchmarks_Point")
+fileprivate func _bjs_struct_lower_Benchmarks_Point_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_Benchmarks_Point_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Point_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_Benchmarks_Point(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_Benchmarks_Point_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Point")
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Benchmarks_Point")
+fileprivate func _bjs_struct_lift_Benchmarks_Point_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_Benchmarks_Point_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Point() -> Int32 {
-    return _bjs_struct_lift_Point_extern()
+@inline(never) fileprivate func _bjs_struct_lift_Benchmarks_Point() -> Int32 {
+    return _bjs_struct_lift_Benchmarks_Point_extern()
 }
 
-@_expose(wasm, "bjs_run")
-@_cdecl("bjs_run")
-public func _bjs_run() -> Void {
+@_expose(wasm, "bjs_Benchmarks_run")
+@_cdecl("bjs_Benchmarks_run")
+public func _bjs_Benchmarks_run() -> Void {
     #if arch(wasm32)
     run()
     #else
@@ -384,1799 +384,1799 @@ public func _bjs_run() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_init")
-@_cdecl("bjs_EnumRoundtrip_init")
-public func _bjs_EnumRoundtrip_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_init")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_init")
+public func _bjs_Benchmarks_EnumRoundtrip_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = EnumRoundtrip()
+    let ret = Benchmarks.EnumRoundtrip()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_take")
-@_cdecl("bjs_EnumRoundtrip_take")
-public func _bjs_EnumRoundtrip_take(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_take")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_take")
+public func _bjs_Benchmarks_EnumRoundtrip_take(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    EnumRoundtrip.bridgeJSLiftParameter(_self).take(_: APIResult.bridgeJSLiftParameter(value))
+    Benchmarks.EnumRoundtrip.bridgeJSLiftParameter(_self).take(_: Benchmarks.APIResult.bridgeJSLiftParameter(value))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_makeSuccess")
-@_cdecl("bjs_EnumRoundtrip_makeSuccess")
-public func _bjs_EnumRoundtrip_makeSuccess(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_makeSuccess")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_makeSuccess")
+public func _bjs_Benchmarks_EnumRoundtrip_makeSuccess(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = EnumRoundtrip.bridgeJSLiftParameter(_self).makeSuccess()
+    let ret = Benchmarks.EnumRoundtrip.bridgeJSLiftParameter(_self).makeSuccess()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_makeFailure")
-@_cdecl("bjs_EnumRoundtrip_makeFailure")
-public func _bjs_EnumRoundtrip_makeFailure(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_makeFailure")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_makeFailure")
+public func _bjs_Benchmarks_EnumRoundtrip_makeFailure(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = EnumRoundtrip.bridgeJSLiftParameter(_self).makeFailure()
+    let ret = Benchmarks.EnumRoundtrip.bridgeJSLiftParameter(_self).makeFailure()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_makeFlag")
-@_cdecl("bjs_EnumRoundtrip_makeFlag")
-public func _bjs_EnumRoundtrip_makeFlag(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_makeFlag")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_makeFlag")
+public func _bjs_Benchmarks_EnumRoundtrip_makeFlag(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = EnumRoundtrip.bridgeJSLiftParameter(_self).makeFlag()
+    let ret = Benchmarks.EnumRoundtrip.bridgeJSLiftParameter(_self).makeFlag()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_makeRate")
-@_cdecl("bjs_EnumRoundtrip_makeRate")
-public func _bjs_EnumRoundtrip_makeRate(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_makeRate")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_makeRate")
+public func _bjs_Benchmarks_EnumRoundtrip_makeRate(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = EnumRoundtrip.bridgeJSLiftParameter(_self).makeRate()
+    let ret = Benchmarks.EnumRoundtrip.bridgeJSLiftParameter(_self).makeRate()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_makePrecise")
-@_cdecl("bjs_EnumRoundtrip_makePrecise")
-public func _bjs_EnumRoundtrip_makePrecise(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_makePrecise")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_makePrecise")
+public func _bjs_Benchmarks_EnumRoundtrip_makePrecise(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = EnumRoundtrip.bridgeJSLiftParameter(_self).makePrecise()
+    let ret = Benchmarks.EnumRoundtrip.bridgeJSLiftParameter(_self).makePrecise()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_makeInfo")
-@_cdecl("bjs_EnumRoundtrip_makeInfo")
-public func _bjs_EnumRoundtrip_makeInfo(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_makeInfo")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_makeInfo")
+public func _bjs_Benchmarks_EnumRoundtrip_makeInfo(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = EnumRoundtrip.bridgeJSLiftParameter(_self).makeInfo()
+    let ret = Benchmarks.EnumRoundtrip.bridgeJSLiftParameter(_self).makeInfo()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_roundtrip")
-@_cdecl("bjs_EnumRoundtrip_roundtrip")
-public func _bjs_EnumRoundtrip_roundtrip(_ _self: UnsafeMutableRawPointer, _ result: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_roundtrip")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_roundtrip")
+public func _bjs_Benchmarks_EnumRoundtrip_roundtrip(_ _self: UnsafeMutableRawPointer, _ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = EnumRoundtrip.bridgeJSLiftParameter(_self).roundtrip(_: APIResult.bridgeJSLiftParameter(result))
+    let ret = Benchmarks.EnumRoundtrip.bridgeJSLiftParameter(_self).roundtrip(_: Benchmarks.APIResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EnumRoundtrip_deinit")
-@_cdecl("bjs_EnumRoundtrip_deinit")
-public func _bjs_EnumRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_EnumRoundtrip_deinit")
+@_cdecl("bjs_Benchmarks_EnumRoundtrip_deinit")
+public func _bjs_Benchmarks_EnumRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<EnumRoundtrip>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.EnumRoundtrip>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension EnumRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.EnumRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_EnumRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_EnumRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_EnumRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_EnumRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_EnumRoundtrip_wrap")
-fileprivate func _bjs_EnumRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_EnumRoundtrip_wrap")
+fileprivate func _bjs_Benchmarks_EnumRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_EnumRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_EnumRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_EnumRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_EnumRoundtrip_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_EnumRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_EnumRoundtrip_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_init")
-@_cdecl("bjs_ComplexResultRoundtrip_init")
-public func _bjs_ComplexResultRoundtrip_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_init")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_init")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ComplexResultRoundtrip()
+    let ret = Benchmarks.ComplexResultRoundtrip()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_take")
-@_cdecl("bjs_ComplexResultRoundtrip_take")
-public func _bjs_ComplexResultRoundtrip_take(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_take")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_take")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_take(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    ComplexResultRoundtrip.bridgeJSLiftParameter(_self).take(_: ComplexResult.bridgeJSLiftParameter(value))
+    Benchmarks.ComplexResultRoundtrip.bridgeJSLiftParameter(_self).take(_: Benchmarks.ComplexResult.bridgeJSLiftParameter(value))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_makeSuccess")
-@_cdecl("bjs_ComplexResultRoundtrip_makeSuccess")
-public func _bjs_ComplexResultRoundtrip_makeSuccess(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_makeSuccess")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_makeSuccess")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_makeSuccess(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeSuccess()
+    let ret = Benchmarks.ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeSuccess()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_makeError")
-@_cdecl("bjs_ComplexResultRoundtrip_makeError")
-public func _bjs_ComplexResultRoundtrip_makeError(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_makeError")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_makeError")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_makeError(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeError()
+    let ret = Benchmarks.ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeError()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_makeLocation")
-@_cdecl("bjs_ComplexResultRoundtrip_makeLocation")
-public func _bjs_ComplexResultRoundtrip_makeLocation(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_makeLocation")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_makeLocation")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_makeLocation(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeLocation()
+    let ret = Benchmarks.ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeLocation()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_makeStatus")
-@_cdecl("bjs_ComplexResultRoundtrip_makeStatus")
-public func _bjs_ComplexResultRoundtrip_makeStatus(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_makeStatus")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_makeStatus")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_makeStatus(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeStatus()
+    let ret = Benchmarks.ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeStatus()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_makeCoordinates")
-@_cdecl("bjs_ComplexResultRoundtrip_makeCoordinates")
-public func _bjs_ComplexResultRoundtrip_makeCoordinates(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_makeCoordinates")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_makeCoordinates")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_makeCoordinates(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeCoordinates()
+    let ret = Benchmarks.ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeCoordinates()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_makeComprehensive")
-@_cdecl("bjs_ComplexResultRoundtrip_makeComprehensive")
-public func _bjs_ComplexResultRoundtrip_makeComprehensive(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_makeComprehensive")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_makeComprehensive")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_makeComprehensive(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeComprehensive()
+    let ret = Benchmarks.ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeComprehensive()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_makeInfo")
-@_cdecl("bjs_ComplexResultRoundtrip_makeInfo")
-public func _bjs_ComplexResultRoundtrip_makeInfo(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_makeInfo")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_makeInfo")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_makeInfo(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeInfo()
+    let ret = Benchmarks.ComplexResultRoundtrip.bridgeJSLiftParameter(_self).makeInfo()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_roundtrip")
-@_cdecl("bjs_ComplexResultRoundtrip_roundtrip")
-public func _bjs_ComplexResultRoundtrip_roundtrip(_ _self: UnsafeMutableRawPointer, _ result: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_roundtrip")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_roundtrip")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_roundtrip(_ _self: UnsafeMutableRawPointer, _ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = ComplexResultRoundtrip.bridgeJSLiftParameter(_self).roundtrip(_: ComplexResult.bridgeJSLiftParameter(result))
+    let ret = Benchmarks.ComplexResultRoundtrip.bridgeJSLiftParameter(_self).roundtrip(_: Benchmarks.ComplexResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ComplexResultRoundtrip_deinit")
-@_cdecl("bjs_ComplexResultRoundtrip_deinit")
-public func _bjs_ComplexResultRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ComplexResultRoundtrip_deinit")
+@_cdecl("bjs_Benchmarks_ComplexResultRoundtrip_deinit")
+public func _bjs_Benchmarks_ComplexResultRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ComplexResultRoundtrip>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.ComplexResultRoundtrip>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ComplexResultRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.ComplexResultRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ComplexResultRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_ComplexResultRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ComplexResultRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_ComplexResultRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_ComplexResultRoundtrip_wrap")
-fileprivate func _bjs_ComplexResultRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_ComplexResultRoundtrip_wrap")
+fileprivate func _bjs_Benchmarks_ComplexResultRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ComplexResultRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_ComplexResultRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ComplexResultRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ComplexResultRoundtrip_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_ComplexResultRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_ComplexResultRoundtrip_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_StringRoundtrip_init")
-@_cdecl("bjs_StringRoundtrip_init")
-public func _bjs_StringRoundtrip_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_StringRoundtrip_init")
+@_cdecl("bjs_Benchmarks_StringRoundtrip_init")
+public func _bjs_Benchmarks_StringRoundtrip_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = StringRoundtrip()
+    let ret = Benchmarks.StringRoundtrip()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StringRoundtrip_take")
-@_cdecl("bjs_StringRoundtrip_take")
-public func _bjs_StringRoundtrip_take(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StringRoundtrip_take")
+@_cdecl("bjs_Benchmarks_StringRoundtrip_take")
+public func _bjs_Benchmarks_StringRoundtrip_take(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    StringRoundtrip.bridgeJSLiftParameter(_self).take(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    Benchmarks.StringRoundtrip.bridgeJSLiftParameter(_self).take(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StringRoundtrip_make")
-@_cdecl("bjs_StringRoundtrip_make")
-public func _bjs_StringRoundtrip_make(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StringRoundtrip_make")
+@_cdecl("bjs_Benchmarks_StringRoundtrip_make")
+public func _bjs_Benchmarks_StringRoundtrip_make(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = StringRoundtrip.bridgeJSLiftParameter(_self).make()
+    let ret = Benchmarks.StringRoundtrip.bridgeJSLiftParameter(_self).make()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StringRoundtrip_deinit")
-@_cdecl("bjs_StringRoundtrip_deinit")
-public func _bjs_StringRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StringRoundtrip_deinit")
+@_cdecl("bjs_Benchmarks_StringRoundtrip_deinit")
+public func _bjs_Benchmarks_StringRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<StringRoundtrip>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.StringRoundtrip>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension StringRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.StringRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_StringRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_StringRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_StringRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_StringRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_StringRoundtrip_wrap")
-fileprivate func _bjs_StringRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_StringRoundtrip_wrap")
+fileprivate func _bjs_Benchmarks_StringRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_StringRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_StringRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_StringRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_StringRoundtrip_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_StringRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_StringRoundtrip_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_init")
-@_cdecl("bjs_OptionalReturnRoundtrip_init")
-public func _bjs_OptionalReturnRoundtrip_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_init")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_init")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = OptionalReturnRoundtrip()
+    let ret = Benchmarks.OptionalReturnRoundtrip()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_makeIntSome")
-@_cdecl("bjs_OptionalReturnRoundtrip_makeIntSome")
-public func _bjs_OptionalReturnRoundtrip_makeIntSome(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_makeIntSome")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_makeIntSome")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_makeIntSome(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeIntSome()
+    let ret = Benchmarks.OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeIntSome()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_makeIntNone")
-@_cdecl("bjs_OptionalReturnRoundtrip_makeIntNone")
-public func _bjs_OptionalReturnRoundtrip_makeIntNone(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_makeIntNone")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_makeIntNone")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_makeIntNone(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeIntNone()
+    let ret = Benchmarks.OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeIntNone()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_makeBoolSome")
-@_cdecl("bjs_OptionalReturnRoundtrip_makeBoolSome")
-public func _bjs_OptionalReturnRoundtrip_makeBoolSome(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_makeBoolSome")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_makeBoolSome")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_makeBoolSome(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeBoolSome()
+    let ret = Benchmarks.OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeBoolSome()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_makeBoolNone")
-@_cdecl("bjs_OptionalReturnRoundtrip_makeBoolNone")
-public func _bjs_OptionalReturnRoundtrip_makeBoolNone(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_makeBoolNone")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_makeBoolNone")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_makeBoolNone(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeBoolNone()
+    let ret = Benchmarks.OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeBoolNone()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_makeDoubleSome")
-@_cdecl("bjs_OptionalReturnRoundtrip_makeDoubleSome")
-public func _bjs_OptionalReturnRoundtrip_makeDoubleSome(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_makeDoubleSome")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_makeDoubleSome")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_makeDoubleSome(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeDoubleSome()
+    let ret = Benchmarks.OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeDoubleSome()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_makeDoubleNone")
-@_cdecl("bjs_OptionalReturnRoundtrip_makeDoubleNone")
-public func _bjs_OptionalReturnRoundtrip_makeDoubleNone(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_makeDoubleNone")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_makeDoubleNone")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_makeDoubleNone(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeDoubleNone()
+    let ret = Benchmarks.OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeDoubleNone()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_makeStringSome")
-@_cdecl("bjs_OptionalReturnRoundtrip_makeStringSome")
-public func _bjs_OptionalReturnRoundtrip_makeStringSome(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_makeStringSome")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_makeStringSome")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_makeStringSome(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeStringSome()
+    let ret = Benchmarks.OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeStringSome()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_makeStringNone")
-@_cdecl("bjs_OptionalReturnRoundtrip_makeStringNone")
-public func _bjs_OptionalReturnRoundtrip_makeStringNone(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_makeStringNone")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_makeStringNone")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_makeStringNone(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeStringNone()
+    let ret = Benchmarks.OptionalReturnRoundtrip.bridgeJSLiftParameter(_self).makeStringNone()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalReturnRoundtrip_deinit")
-@_cdecl("bjs_OptionalReturnRoundtrip_deinit")
-public func _bjs_OptionalReturnRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_OptionalReturnRoundtrip_deinit")
+@_cdecl("bjs_Benchmarks_OptionalReturnRoundtrip_deinit")
+public func _bjs_Benchmarks_OptionalReturnRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<OptionalReturnRoundtrip>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.OptionalReturnRoundtrip>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension OptionalReturnRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.OptionalReturnRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_OptionalReturnRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_OptionalReturnRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_OptionalReturnRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_OptionalReturnRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_OptionalReturnRoundtrip_wrap")
-fileprivate func _bjs_OptionalReturnRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_OptionalReturnRoundtrip_wrap")
+fileprivate func _bjs_Benchmarks_OptionalReturnRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_OptionalReturnRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_OptionalReturnRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_OptionalReturnRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_OptionalReturnRoundtrip_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_OptionalReturnRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_OptionalReturnRoundtrip_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_init")
-@_cdecl("bjs_StructRoundtrip_init")
-public func _bjs_StructRoundtrip_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_init")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_init")
+public func _bjs_Benchmarks_StructRoundtrip_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = StructRoundtrip()
+    let ret = Benchmarks.StructRoundtrip()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_takeSimple")
-@_cdecl("bjs_StructRoundtrip_takeSimple")
-public func _bjs_StructRoundtrip_takeSimple(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_takeSimple")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_takeSimple")
+public func _bjs_Benchmarks_StructRoundtrip_takeSimple(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    StructRoundtrip.bridgeJSLiftParameter(_self).takeSimple(_: SimpleStruct.bridgeJSLiftParameter())
+    Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).takeSimple(_: Benchmarks.SimpleStruct.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_makeSimple")
-@_cdecl("bjs_StructRoundtrip_makeSimple")
-public func _bjs_StructRoundtrip_makeSimple(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_makeSimple")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_makeSimple")
+public func _bjs_Benchmarks_StructRoundtrip_makeSimple(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).makeSimple()
+    let ret = Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).makeSimple()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_roundtripSimple")
-@_cdecl("bjs_StructRoundtrip_roundtripSimple")
-public func _bjs_StructRoundtrip_roundtripSimple(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_roundtripSimple")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_roundtripSimple")
+public func _bjs_Benchmarks_StructRoundtrip_roundtripSimple(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).roundtripSimple(_: SimpleStruct.bridgeJSLiftParameter())
+    let ret = Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).roundtripSimple(_: Benchmarks.SimpleStruct.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_takeAddress")
-@_cdecl("bjs_StructRoundtrip_takeAddress")
-public func _bjs_StructRoundtrip_takeAddress(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_takeAddress")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_takeAddress")
+public func _bjs_Benchmarks_StructRoundtrip_takeAddress(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    StructRoundtrip.bridgeJSLiftParameter(_self).takeAddress(_: Address.bridgeJSLiftParameter())
+    Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).takeAddress(_: Benchmarks.Address.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_makeAddress")
-@_cdecl("bjs_StructRoundtrip_makeAddress")
-public func _bjs_StructRoundtrip_makeAddress(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_makeAddress")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_makeAddress")
+public func _bjs_Benchmarks_StructRoundtrip_makeAddress(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).makeAddress()
+    let ret = Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).makeAddress()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_roundtripAddress")
-@_cdecl("bjs_StructRoundtrip_roundtripAddress")
-public func _bjs_StructRoundtrip_roundtripAddress(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_roundtripAddress")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_roundtripAddress")
+public func _bjs_Benchmarks_StructRoundtrip_roundtripAddress(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).roundtripAddress(_: Address.bridgeJSLiftParameter())
+    let ret = Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).roundtripAddress(_: Benchmarks.Address.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_takePerson")
-@_cdecl("bjs_StructRoundtrip_takePerson")
-public func _bjs_StructRoundtrip_takePerson(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_takePerson")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_takePerson")
+public func _bjs_Benchmarks_StructRoundtrip_takePerson(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    StructRoundtrip.bridgeJSLiftParameter(_self).takePerson(_: Person.bridgeJSLiftParameter())
+    Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).takePerson(_: Benchmarks.Person.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_makePerson")
-@_cdecl("bjs_StructRoundtrip_makePerson")
-public func _bjs_StructRoundtrip_makePerson(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_makePerson")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_makePerson")
+public func _bjs_Benchmarks_StructRoundtrip_makePerson(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).makePerson()
+    let ret = Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).makePerson()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_roundtripPerson")
-@_cdecl("bjs_StructRoundtrip_roundtripPerson")
-public func _bjs_StructRoundtrip_roundtripPerson(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_roundtripPerson")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_roundtripPerson")
+public func _bjs_Benchmarks_StructRoundtrip_roundtripPerson(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).roundtripPerson(_: Person.bridgeJSLiftParameter())
+    let ret = Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).roundtripPerson(_: Benchmarks.Person.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_takeComplex")
-@_cdecl("bjs_StructRoundtrip_takeComplex")
-public func _bjs_StructRoundtrip_takeComplex(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_takeComplex")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_takeComplex")
+public func _bjs_Benchmarks_StructRoundtrip_takeComplex(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    StructRoundtrip.bridgeJSLiftParameter(_self).takeComplex(_: ComplexStruct.bridgeJSLiftParameter())
+    Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).takeComplex(_: Benchmarks.ComplexStruct.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_makeComplex")
-@_cdecl("bjs_StructRoundtrip_makeComplex")
-public func _bjs_StructRoundtrip_makeComplex(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_makeComplex")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_makeComplex")
+public func _bjs_Benchmarks_StructRoundtrip_makeComplex(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).makeComplex()
+    let ret = Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).makeComplex()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_roundtripComplex")
-@_cdecl("bjs_StructRoundtrip_roundtripComplex")
-public func _bjs_StructRoundtrip_roundtripComplex(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_roundtripComplex")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_roundtripComplex")
+public func _bjs_Benchmarks_StructRoundtrip_roundtripComplex(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = StructRoundtrip.bridgeJSLiftParameter(_self).roundtripComplex(_: ComplexStruct.bridgeJSLiftParameter())
+    let ret = Benchmarks.StructRoundtrip.bridgeJSLiftParameter(_self).roundtripComplex(_: Benchmarks.ComplexStruct.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StructRoundtrip_deinit")
-@_cdecl("bjs_StructRoundtrip_deinit")
-public func _bjs_StructRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_StructRoundtrip_deinit")
+@_cdecl("bjs_Benchmarks_StructRoundtrip_deinit")
+public func _bjs_Benchmarks_StructRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<StructRoundtrip>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.StructRoundtrip>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension StructRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.StructRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_StructRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_StructRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_StructRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_StructRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_StructRoundtrip_wrap")
-fileprivate func _bjs_StructRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_StructRoundtrip_wrap")
+fileprivate func _bjs_Benchmarks_StructRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_StructRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_StructRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_StructRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_StructRoundtrip_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_StructRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_StructRoundtrip_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_SimpleClass_init")
-@_cdecl("bjs_SimpleClass_init")
-public func _bjs_SimpleClass_init(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ flag: Int32, _ rate: Float32, _ precise: Float64) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_init")
+@_cdecl("bjs_Benchmarks_SimpleClass_init")
+public func _bjs_Benchmarks_SimpleClass_init(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ flag: Int32, _ rate: Float32, _ precise: Float64) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = SimpleClass(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), flag: Bool.bridgeJSLiftParameter(flag), rate: Float.bridgeJSLiftParameter(rate), precise: Double.bridgeJSLiftParameter(precise))
+    let ret = Benchmarks.SimpleClass(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), flag: Bool.bridgeJSLiftParameter(flag), rate: Float.bridgeJSLiftParameter(rate), precise: Double.bridgeJSLiftParameter(precise))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_name_get")
-@_cdecl("bjs_SimpleClass_name_get")
-public func _bjs_SimpleClass_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_name_get")
+@_cdecl("bjs_Benchmarks_SimpleClass_name_get")
+public func _bjs_Benchmarks_SimpleClass_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SimpleClass.bridgeJSLiftParameter(_self).name
+    let ret = Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_name_set")
-@_cdecl("bjs_SimpleClass_name_set")
-public func _bjs_SimpleClass_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_name_set")
+@_cdecl("bjs_Benchmarks_SimpleClass_name_set")
+public func _bjs_Benchmarks_SimpleClass_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    SimpleClass.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_count_get")
-@_cdecl("bjs_SimpleClass_count_get")
-public func _bjs_SimpleClass_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_count_get")
+@_cdecl("bjs_Benchmarks_SimpleClass_count_get")
+public func _bjs_Benchmarks_SimpleClass_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = SimpleClass.bridgeJSLiftParameter(_self).count
+    let ret = Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).count
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_count_set")
-@_cdecl("bjs_SimpleClass_count_set")
-public func _bjs_SimpleClass_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_count_set")
+@_cdecl("bjs_Benchmarks_SimpleClass_count_set")
+public func _bjs_Benchmarks_SimpleClass_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    SimpleClass.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
+    Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_flag_get")
-@_cdecl("bjs_SimpleClass_flag_get")
-public func _bjs_SimpleClass_flag_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_flag_get")
+@_cdecl("bjs_Benchmarks_SimpleClass_flag_get")
+public func _bjs_Benchmarks_SimpleClass_flag_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = SimpleClass.bridgeJSLiftParameter(_self).flag
+    let ret = Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).flag
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_flag_set")
-@_cdecl("bjs_SimpleClass_flag_set")
-public func _bjs_SimpleClass_flag_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_flag_set")
+@_cdecl("bjs_Benchmarks_SimpleClass_flag_set")
+public func _bjs_Benchmarks_SimpleClass_flag_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    SimpleClass.bridgeJSLiftParameter(_self).flag = Bool.bridgeJSLiftParameter(value)
+    Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).flag = Bool.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_rate_get")
-@_cdecl("bjs_SimpleClass_rate_get")
-public func _bjs_SimpleClass_rate_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_rate_get")
+@_cdecl("bjs_Benchmarks_SimpleClass_rate_get")
+public func _bjs_Benchmarks_SimpleClass_rate_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
     #if arch(wasm32)
-    let ret = SimpleClass.bridgeJSLiftParameter(_self).rate
+    let ret = Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).rate
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_rate_set")
-@_cdecl("bjs_SimpleClass_rate_set")
-public func _bjs_SimpleClass_rate_set(_ _self: UnsafeMutableRawPointer, _ value: Float32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_rate_set")
+@_cdecl("bjs_Benchmarks_SimpleClass_rate_set")
+public func _bjs_Benchmarks_SimpleClass_rate_set(_ _self: UnsafeMutableRawPointer, _ value: Float32) -> Void {
     #if arch(wasm32)
-    SimpleClass.bridgeJSLiftParameter(_self).rate = Float.bridgeJSLiftParameter(value)
+    Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).rate = Float.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_precise_get")
-@_cdecl("bjs_SimpleClass_precise_get")
-public func _bjs_SimpleClass_precise_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_precise_get")
+@_cdecl("bjs_Benchmarks_SimpleClass_precise_get")
+public func _bjs_Benchmarks_SimpleClass_precise_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
     #if arch(wasm32)
-    let ret = SimpleClass.bridgeJSLiftParameter(_self).precise
+    let ret = Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).precise
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_precise_set")
-@_cdecl("bjs_SimpleClass_precise_set")
-public func _bjs_SimpleClass_precise_set(_ _self: UnsafeMutableRawPointer, _ value: Float64) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_precise_set")
+@_cdecl("bjs_Benchmarks_SimpleClass_precise_set")
+public func _bjs_Benchmarks_SimpleClass_precise_set(_ _self: UnsafeMutableRawPointer, _ value: Float64) -> Void {
     #if arch(wasm32)
-    SimpleClass.bridgeJSLiftParameter(_self).precise = Double.bridgeJSLiftParameter(value)
+    Benchmarks.SimpleClass.bridgeJSLiftParameter(_self).precise = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClass_deinit")
-@_cdecl("bjs_SimpleClass_deinit")
-public func _bjs_SimpleClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClass_deinit")
+@_cdecl("bjs_Benchmarks_SimpleClass_deinit")
+public func _bjs_Benchmarks_SimpleClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<SimpleClass>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.SimpleClass>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension SimpleClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.SimpleClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_SimpleClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_SimpleClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_SimpleClass_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_SimpleClass_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_SimpleClass_wrap")
-fileprivate func _bjs_SimpleClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_SimpleClass_wrap")
+fileprivate func _bjs_Benchmarks_SimpleClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_SimpleClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_SimpleClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_SimpleClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_SimpleClass_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_SimpleClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_SimpleClass_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_AddressClass_init")
-@_cdecl("bjs_AddressClass_init")
-public func _bjs_AddressClass_init(_ streetBytes: Int32, _ streetLength: Int32, _ cityBytes: Int32, _ cityLength: Int32, _ zipCode: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_AddressClass_init")
+@_cdecl("bjs_Benchmarks_AddressClass_init")
+public func _bjs_Benchmarks_AddressClass_init(_ streetBytes: Int32, _ streetLength: Int32, _ cityBytes: Int32, _ cityLength: Int32, _ zipCode: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = AddressClass(street: String.bridgeJSLiftParameter(streetBytes, streetLength), city: String.bridgeJSLiftParameter(cityBytes, cityLength), zipCode: Int.bridgeJSLiftParameter(zipCode))
+    let ret = Benchmarks.AddressClass(street: String.bridgeJSLiftParameter(streetBytes, streetLength), city: String.bridgeJSLiftParameter(cityBytes, cityLength), zipCode: Int.bridgeJSLiftParameter(zipCode))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_AddressClass_street_get")
-@_cdecl("bjs_AddressClass_street_get")
-public func _bjs_AddressClass_street_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_AddressClass_street_get")
+@_cdecl("bjs_Benchmarks_AddressClass_street_get")
+public func _bjs_Benchmarks_AddressClass_street_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = AddressClass.bridgeJSLiftParameter(_self).street
+    let ret = Benchmarks.AddressClass.bridgeJSLiftParameter(_self).street
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_AddressClass_street_set")
-@_cdecl("bjs_AddressClass_street_set")
-public func _bjs_AddressClass_street_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_AddressClass_street_set")
+@_cdecl("bjs_Benchmarks_AddressClass_street_set")
+public func _bjs_Benchmarks_AddressClass_street_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    AddressClass.bridgeJSLiftParameter(_self).street = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    Benchmarks.AddressClass.bridgeJSLiftParameter(_self).street = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_AddressClass_city_get")
-@_cdecl("bjs_AddressClass_city_get")
-public func _bjs_AddressClass_city_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_AddressClass_city_get")
+@_cdecl("bjs_Benchmarks_AddressClass_city_get")
+public func _bjs_Benchmarks_AddressClass_city_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = AddressClass.bridgeJSLiftParameter(_self).city
+    let ret = Benchmarks.AddressClass.bridgeJSLiftParameter(_self).city
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_AddressClass_city_set")
-@_cdecl("bjs_AddressClass_city_set")
-public func _bjs_AddressClass_city_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_AddressClass_city_set")
+@_cdecl("bjs_Benchmarks_AddressClass_city_set")
+public func _bjs_Benchmarks_AddressClass_city_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    AddressClass.bridgeJSLiftParameter(_self).city = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    Benchmarks.AddressClass.bridgeJSLiftParameter(_self).city = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_AddressClass_zipCode_get")
-@_cdecl("bjs_AddressClass_zipCode_get")
-public func _bjs_AddressClass_zipCode_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_Benchmarks_AddressClass_zipCode_get")
+@_cdecl("bjs_Benchmarks_AddressClass_zipCode_get")
+public func _bjs_Benchmarks_AddressClass_zipCode_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = AddressClass.bridgeJSLiftParameter(_self).zipCode
+    let ret = Benchmarks.AddressClass.bridgeJSLiftParameter(_self).zipCode
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_AddressClass_zipCode_set")
-@_cdecl("bjs_AddressClass_zipCode_set")
-public func _bjs_AddressClass_zipCode_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_AddressClass_zipCode_set")
+@_cdecl("bjs_Benchmarks_AddressClass_zipCode_set")
+public func _bjs_Benchmarks_AddressClass_zipCode_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    AddressClass.bridgeJSLiftParameter(_self).zipCode = Int.bridgeJSLiftParameter(value)
+    Benchmarks.AddressClass.bridgeJSLiftParameter(_self).zipCode = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_AddressClass_deinit")
-@_cdecl("bjs_AddressClass_deinit")
-public func _bjs_AddressClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_AddressClass_deinit")
+@_cdecl("bjs_Benchmarks_AddressClass_deinit")
+public func _bjs_Benchmarks_AddressClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<AddressClass>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.AddressClass>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension AddressClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.AddressClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_AddressClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_AddressClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_AddressClass_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_AddressClass_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_AddressClass_wrap")
-fileprivate func _bjs_AddressClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_AddressClass_wrap")
+fileprivate func _bjs_Benchmarks_AddressClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_AddressClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_AddressClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_AddressClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_AddressClass_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_AddressClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_AddressClass_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ClassRoundtrip_init")
-@_cdecl("bjs_ClassRoundtrip_init")
-public func _bjs_ClassRoundtrip_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtrip_init")
+@_cdecl("bjs_Benchmarks_ClassRoundtrip_init")
+public func _bjs_Benchmarks_ClassRoundtrip_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassRoundtrip()
+    let ret = Benchmarks.ClassRoundtrip()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtrip_takeSimpleClass")
-@_cdecl("bjs_ClassRoundtrip_takeSimpleClass")
-public func _bjs_ClassRoundtrip_takeSimpleClass(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtrip_takeSimpleClass")
+@_cdecl("bjs_Benchmarks_ClassRoundtrip_takeSimpleClass")
+public func _bjs_Benchmarks_ClassRoundtrip_takeSimpleClass(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ClassRoundtrip.bridgeJSLiftParameter(_self).takeSimpleClass(_: SimpleClass.bridgeJSLiftParameter(value))
+    Benchmarks.ClassRoundtrip.bridgeJSLiftParameter(_self).takeSimpleClass(_: Benchmarks.SimpleClass.bridgeJSLiftParameter(value))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtrip_makeSimpleClass")
-@_cdecl("bjs_ClassRoundtrip_makeSimpleClass")
-public func _bjs_ClassRoundtrip_makeSimpleClass(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtrip_makeSimpleClass")
+@_cdecl("bjs_Benchmarks_ClassRoundtrip_makeSimpleClass")
+public func _bjs_Benchmarks_ClassRoundtrip_makeSimpleClass(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassRoundtrip.bridgeJSLiftParameter(_self).makeSimpleClass()
+    let ret = Benchmarks.ClassRoundtrip.bridgeJSLiftParameter(_self).makeSimpleClass()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtrip_roundtripSimpleClass")
-@_cdecl("bjs_ClassRoundtrip_roundtripSimpleClass")
-public func _bjs_ClassRoundtrip_roundtripSimpleClass(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtrip_roundtripSimpleClass")
+@_cdecl("bjs_Benchmarks_ClassRoundtrip_roundtripSimpleClass")
+public func _bjs_Benchmarks_ClassRoundtrip_roundtripSimpleClass(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassRoundtrip.bridgeJSLiftParameter(_self).roundtripSimpleClass(_: SimpleClass.bridgeJSLiftParameter(value))
+    let ret = Benchmarks.ClassRoundtrip.bridgeJSLiftParameter(_self).roundtripSimpleClass(_: Benchmarks.SimpleClass.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtrip_takeAddressClass")
-@_cdecl("bjs_ClassRoundtrip_takeAddressClass")
-public func _bjs_ClassRoundtrip_takeAddressClass(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtrip_takeAddressClass")
+@_cdecl("bjs_Benchmarks_ClassRoundtrip_takeAddressClass")
+public func _bjs_Benchmarks_ClassRoundtrip_takeAddressClass(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ClassRoundtrip.bridgeJSLiftParameter(_self).takeAddressClass(_: AddressClass.bridgeJSLiftParameter(value))
+    Benchmarks.ClassRoundtrip.bridgeJSLiftParameter(_self).takeAddressClass(_: Benchmarks.AddressClass.bridgeJSLiftParameter(value))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtrip_makeAddressClass")
-@_cdecl("bjs_ClassRoundtrip_makeAddressClass")
-public func _bjs_ClassRoundtrip_makeAddressClass(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtrip_makeAddressClass")
+@_cdecl("bjs_Benchmarks_ClassRoundtrip_makeAddressClass")
+public func _bjs_Benchmarks_ClassRoundtrip_makeAddressClass(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassRoundtrip.bridgeJSLiftParameter(_self).makeAddressClass()
+    let ret = Benchmarks.ClassRoundtrip.bridgeJSLiftParameter(_self).makeAddressClass()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtrip_roundtripAddressClass")
-@_cdecl("bjs_ClassRoundtrip_roundtripAddressClass")
-public func _bjs_ClassRoundtrip_roundtripAddressClass(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtrip_roundtripAddressClass")
+@_cdecl("bjs_Benchmarks_ClassRoundtrip_roundtripAddressClass")
+public func _bjs_Benchmarks_ClassRoundtrip_roundtripAddressClass(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassRoundtrip.bridgeJSLiftParameter(_self).roundtripAddressClass(_: AddressClass.bridgeJSLiftParameter(value))
+    let ret = Benchmarks.ClassRoundtrip.bridgeJSLiftParameter(_self).roundtripAddressClass(_: Benchmarks.AddressClass.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtrip_deinit")
-@_cdecl("bjs_ClassRoundtrip_deinit")
-public func _bjs_ClassRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtrip_deinit")
+@_cdecl("bjs_Benchmarks_ClassRoundtrip_deinit")
+public func _bjs_Benchmarks_ClassRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ClassRoundtrip>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.ClassRoundtrip>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ClassRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.ClassRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ClassRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_ClassRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ClassRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_ClassRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_ClassRoundtrip_wrap")
-fileprivate func _bjs_ClassRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_ClassRoundtrip_wrap")
+fileprivate func _bjs_Benchmarks_ClassRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ClassRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_ClassRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ClassRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ClassRoundtrip_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_ClassRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_ClassRoundtrip_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ClassArrayRoundtrip_init")
-@_cdecl("bjs_ClassArrayRoundtrip_init")
-public func _bjs_ClassArrayRoundtrip_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ClassArrayRoundtrip_init")
+@_cdecl("bjs_Benchmarks_ClassArrayRoundtrip_init")
+public func _bjs_Benchmarks_ClassArrayRoundtrip_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassArrayRoundtrip()
+    let ret = Benchmarks.ClassArrayRoundtrip()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassArrayRoundtrip_setupPool")
-@_cdecl("bjs_ClassArrayRoundtrip_setupPool")
-public func _bjs_ClassArrayRoundtrip_setupPool(_ _self: UnsafeMutableRawPointer, _ count: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassArrayRoundtrip_setupPool")
+@_cdecl("bjs_Benchmarks_ClassArrayRoundtrip_setupPool")
+public func _bjs_Benchmarks_ClassArrayRoundtrip_setupPool(_ _self: UnsafeMutableRawPointer, _ count: Int32) -> Void {
     #if arch(wasm32)
-    ClassArrayRoundtrip.bridgeJSLiftParameter(_self).setupPool(_: Int.bridgeJSLiftParameter(count))
+    Benchmarks.ClassArrayRoundtrip.bridgeJSLiftParameter(_self).setupPool(_: Int.bridgeJSLiftParameter(count))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassArrayRoundtrip_getPool")
-@_cdecl("bjs_ClassArrayRoundtrip_getPool")
-public func _bjs_ClassArrayRoundtrip_getPool(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassArrayRoundtrip_getPool")
+@_cdecl("bjs_Benchmarks_ClassArrayRoundtrip_getPool")
+public func _bjs_Benchmarks_ClassArrayRoundtrip_getPool(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ClassArrayRoundtrip.bridgeJSLiftParameter(_self).getPool()
+    let ret = Benchmarks.ClassArrayRoundtrip.bridgeJSLiftParameter(_self).getPool()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassArrayRoundtrip_makeClassArray")
-@_cdecl("bjs_ClassArrayRoundtrip_makeClassArray")
-public func _bjs_ClassArrayRoundtrip_makeClassArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassArrayRoundtrip_makeClassArray")
+@_cdecl("bjs_Benchmarks_ClassArrayRoundtrip_makeClassArray")
+public func _bjs_Benchmarks_ClassArrayRoundtrip_makeClassArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ClassArrayRoundtrip.bridgeJSLiftParameter(_self).makeClassArray()
+    let ret = Benchmarks.ClassArrayRoundtrip.bridgeJSLiftParameter(_self).makeClassArray()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassArrayRoundtrip_takeClassArray")
-@_cdecl("bjs_ClassArrayRoundtrip_takeClassArray")
-public func _bjs_ClassArrayRoundtrip_takeClassArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassArrayRoundtrip_takeClassArray")
+@_cdecl("bjs_Benchmarks_ClassArrayRoundtrip_takeClassArray")
+public func _bjs_Benchmarks_ClassArrayRoundtrip_takeClassArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ClassArrayRoundtrip.bridgeJSLiftParameter(_self).takeClassArray(_: [SimpleClass].bridgeJSStackPop())
+    Benchmarks.ClassArrayRoundtrip.bridgeJSLiftParameter(_self).takeClassArray(_: [Benchmarks.SimpleClass].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassArrayRoundtrip_roundtripClassArray")
-@_cdecl("bjs_ClassArrayRoundtrip_roundtripClassArray")
-public func _bjs_ClassArrayRoundtrip_roundtripClassArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassArrayRoundtrip_roundtripClassArray")
+@_cdecl("bjs_Benchmarks_ClassArrayRoundtrip_roundtripClassArray")
+public func _bjs_Benchmarks_ClassArrayRoundtrip_roundtripClassArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ClassArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripClassArray(_: [SimpleClass].bridgeJSStackPop())
+    let ret = Benchmarks.ClassArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripClassArray(_: [Benchmarks.SimpleClass].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassArrayRoundtrip_deinit")
-@_cdecl("bjs_ClassArrayRoundtrip_deinit")
-public func _bjs_ClassArrayRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassArrayRoundtrip_deinit")
+@_cdecl("bjs_Benchmarks_ClassArrayRoundtrip_deinit")
+public func _bjs_Benchmarks_ClassArrayRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ClassArrayRoundtrip>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.ClassArrayRoundtrip>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ClassArrayRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.ClassArrayRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ClassArrayRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_ClassArrayRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ClassArrayRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_ClassArrayRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_ClassArrayRoundtrip_wrap")
-fileprivate func _bjs_ClassArrayRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_ClassArrayRoundtrip_wrap")
+fileprivate func _bjs_Benchmarks_ClassArrayRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ClassArrayRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_ClassArrayRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ClassArrayRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ClassArrayRoundtrip_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_ClassArrayRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_ClassArrayRoundtrip_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_IdentityCacheBenchmark_init")
-@_cdecl("bjs_IdentityCacheBenchmark_init")
-public func _bjs_IdentityCacheBenchmark_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_IdentityCacheBenchmark_init")
+@_cdecl("bjs_Benchmarks_IdentityCacheBenchmark_init")
+public func _bjs_Benchmarks_IdentityCacheBenchmark_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = IdentityCacheBenchmark()
+    let ret = Benchmarks.IdentityCacheBenchmark()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityCacheBenchmark_setupPool")
-@_cdecl("bjs_IdentityCacheBenchmark_setupPool")
-public func _bjs_IdentityCacheBenchmark_setupPool(_ _self: UnsafeMutableRawPointer, _ count: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_IdentityCacheBenchmark_setupPool")
+@_cdecl("bjs_Benchmarks_IdentityCacheBenchmark_setupPool")
+public func _bjs_Benchmarks_IdentityCacheBenchmark_setupPool(_ _self: UnsafeMutableRawPointer, _ count: Int32) -> Void {
     #if arch(wasm32)
-    IdentityCacheBenchmark.bridgeJSLiftParameter(_self).setupPool(_: Int.bridgeJSLiftParameter(count))
+    Benchmarks.IdentityCacheBenchmark.bridgeJSLiftParameter(_self).setupPool(_: Int.bridgeJSLiftParameter(count))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityCacheBenchmark_getPoolRepeated")
-@_cdecl("bjs_IdentityCacheBenchmark_getPoolRepeated")
-public func _bjs_IdentityCacheBenchmark_getPoolRepeated(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_IdentityCacheBenchmark_getPoolRepeated")
+@_cdecl("bjs_Benchmarks_IdentityCacheBenchmark_getPoolRepeated")
+public func _bjs_Benchmarks_IdentityCacheBenchmark_getPoolRepeated(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = IdentityCacheBenchmark.bridgeJSLiftParameter(_self).getPoolRepeated()
+    let ret = Benchmarks.IdentityCacheBenchmark.bridgeJSLiftParameter(_self).getPoolRepeated()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityCacheBenchmark_deinit")
-@_cdecl("bjs_IdentityCacheBenchmark_deinit")
-public func _bjs_IdentityCacheBenchmark_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_IdentityCacheBenchmark_deinit")
+@_cdecl("bjs_Benchmarks_IdentityCacheBenchmark_deinit")
+public func _bjs_Benchmarks_IdentityCacheBenchmark_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<IdentityCacheBenchmark>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.IdentityCacheBenchmark>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension IdentityCacheBenchmark: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.IdentityCacheBenchmark: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_IdentityCacheBenchmark_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_IdentityCacheBenchmark_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_IdentityCacheBenchmark_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_IdentityCacheBenchmark_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_IdentityCacheBenchmark_wrap")
-fileprivate func _bjs_IdentityCacheBenchmark_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_IdentityCacheBenchmark_wrap")
+fileprivate func _bjs_Benchmarks_IdentityCacheBenchmark_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_IdentityCacheBenchmark_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_IdentityCacheBenchmark_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_IdentityCacheBenchmark_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_IdentityCacheBenchmark_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_IdentityCacheBenchmark_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_IdentityCacheBenchmark_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_init")
-@_cdecl("bjs_SimpleClassIdentity_init")
-public func _bjs_SimpleClassIdentity_init(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ flag: Int32, _ rate: Float32, _ precise: Float64) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_init")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_init")
+public func _bjs_Benchmarks_SimpleClassIdentity_init(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ flag: Int32, _ rate: Float32, _ precise: Float64) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = SimpleClassIdentity(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), flag: Bool.bridgeJSLiftParameter(flag), rate: Float.bridgeJSLiftParameter(rate), precise: Double.bridgeJSLiftParameter(precise))
+    let ret = Benchmarks.SimpleClassIdentity(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), flag: Bool.bridgeJSLiftParameter(flag), rate: Float.bridgeJSLiftParameter(rate), precise: Double.bridgeJSLiftParameter(precise))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_name_get")
-@_cdecl("bjs_SimpleClassIdentity_name_get")
-public func _bjs_SimpleClassIdentity_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_name_get")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_name_get")
+public func _bjs_Benchmarks_SimpleClassIdentity_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SimpleClassIdentity.bridgeJSLiftParameter(_self).name
+    let ret = Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_name_set")
-@_cdecl("bjs_SimpleClassIdentity_name_set")
-public func _bjs_SimpleClassIdentity_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_name_set")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_name_set")
+public func _bjs_Benchmarks_SimpleClassIdentity_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    SimpleClassIdentity.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_count_get")
-@_cdecl("bjs_SimpleClassIdentity_count_get")
-public func _bjs_SimpleClassIdentity_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_count_get")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_count_get")
+public func _bjs_Benchmarks_SimpleClassIdentity_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = SimpleClassIdentity.bridgeJSLiftParameter(_self).count
+    let ret = Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).count
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_count_set")
-@_cdecl("bjs_SimpleClassIdentity_count_set")
-public func _bjs_SimpleClassIdentity_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_count_set")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_count_set")
+public func _bjs_Benchmarks_SimpleClassIdentity_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    SimpleClassIdentity.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
+    Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_flag_get")
-@_cdecl("bjs_SimpleClassIdentity_flag_get")
-public func _bjs_SimpleClassIdentity_flag_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_flag_get")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_flag_get")
+public func _bjs_Benchmarks_SimpleClassIdentity_flag_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = SimpleClassIdentity.bridgeJSLiftParameter(_self).flag
+    let ret = Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).flag
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_flag_set")
-@_cdecl("bjs_SimpleClassIdentity_flag_set")
-public func _bjs_SimpleClassIdentity_flag_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_flag_set")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_flag_set")
+public func _bjs_Benchmarks_SimpleClassIdentity_flag_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    SimpleClassIdentity.bridgeJSLiftParameter(_self).flag = Bool.bridgeJSLiftParameter(value)
+    Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).flag = Bool.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_rate_get")
-@_cdecl("bjs_SimpleClassIdentity_rate_get")
-public func _bjs_SimpleClassIdentity_rate_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_rate_get")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_rate_get")
+public func _bjs_Benchmarks_SimpleClassIdentity_rate_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
     #if arch(wasm32)
-    let ret = SimpleClassIdentity.bridgeJSLiftParameter(_self).rate
+    let ret = Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).rate
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_rate_set")
-@_cdecl("bjs_SimpleClassIdentity_rate_set")
-public func _bjs_SimpleClassIdentity_rate_set(_ _self: UnsafeMutableRawPointer, _ value: Float32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_rate_set")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_rate_set")
+public func _bjs_Benchmarks_SimpleClassIdentity_rate_set(_ _self: UnsafeMutableRawPointer, _ value: Float32) -> Void {
     #if arch(wasm32)
-    SimpleClassIdentity.bridgeJSLiftParameter(_self).rate = Float.bridgeJSLiftParameter(value)
+    Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).rate = Float.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_precise_get")
-@_cdecl("bjs_SimpleClassIdentity_precise_get")
-public func _bjs_SimpleClassIdentity_precise_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_precise_get")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_precise_get")
+public func _bjs_Benchmarks_SimpleClassIdentity_precise_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
     #if arch(wasm32)
-    let ret = SimpleClassIdentity.bridgeJSLiftParameter(_self).precise
+    let ret = Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).precise
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_precise_set")
-@_cdecl("bjs_SimpleClassIdentity_precise_set")
-public func _bjs_SimpleClassIdentity_precise_set(_ _self: UnsafeMutableRawPointer, _ value: Float64) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_precise_set")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_precise_set")
+public func _bjs_Benchmarks_SimpleClassIdentity_precise_set(_ _self: UnsafeMutableRawPointer, _ value: Float64) -> Void {
     #if arch(wasm32)
-    SimpleClassIdentity.bridgeJSLiftParameter(_self).precise = Double.bridgeJSLiftParameter(value)
+    Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(_self).precise = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimpleClassIdentity_deinit")
-@_cdecl("bjs_SimpleClassIdentity_deinit")
-public func _bjs_SimpleClassIdentity_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_SimpleClassIdentity_deinit")
+@_cdecl("bjs_Benchmarks_SimpleClassIdentity_deinit")
+public func _bjs_Benchmarks_SimpleClassIdentity_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<SimpleClassIdentity>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.SimpleClassIdentity>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension SimpleClassIdentity: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.SimpleClassIdentity: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_SimpleClassIdentity_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_SimpleClassIdentity_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_SimpleClassIdentity_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_SimpleClassIdentity_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_SimpleClassIdentity_wrap")
-fileprivate func _bjs_SimpleClassIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_SimpleClassIdentity_wrap")
+fileprivate func _bjs_Benchmarks_SimpleClassIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_SimpleClassIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_SimpleClassIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_SimpleClassIdentity_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_SimpleClassIdentity_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_SimpleClassIdentity_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_SimpleClassIdentity_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ClassRoundtripIdentity_init")
-@_cdecl("bjs_ClassRoundtripIdentity_init")
-public func _bjs_ClassRoundtripIdentity_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtripIdentity_init")
+@_cdecl("bjs_Benchmarks_ClassRoundtripIdentity_init")
+public func _bjs_Benchmarks_ClassRoundtripIdentity_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassRoundtripIdentity()
+    let ret = Benchmarks.ClassRoundtripIdentity()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtripIdentity_roundtripSimpleClassIdentity")
-@_cdecl("bjs_ClassRoundtripIdentity_roundtripSimpleClassIdentity")
-public func _bjs_ClassRoundtripIdentity_roundtripSimpleClassIdentity(_ _self: UnsafeMutableRawPointer, _ obj: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtripIdentity_roundtripSimpleClassIdentity")
+@_cdecl("bjs_Benchmarks_ClassRoundtripIdentity_roundtripSimpleClassIdentity")
+public func _bjs_Benchmarks_ClassRoundtripIdentity_roundtripSimpleClassIdentity(_ _self: UnsafeMutableRawPointer, _ obj: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassRoundtripIdentity.bridgeJSLiftParameter(_self).roundtripSimpleClassIdentity(_: SimpleClassIdentity.bridgeJSLiftParameter(obj))
+    let ret = Benchmarks.ClassRoundtripIdentity.bridgeJSLiftParameter(_self).roundtripSimpleClassIdentity(_: Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(obj))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtripIdentity_makeSimpleClassIdentity")
-@_cdecl("bjs_ClassRoundtripIdentity_makeSimpleClassIdentity")
-public func _bjs_ClassRoundtripIdentity_makeSimpleClassIdentity(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtripIdentity_makeSimpleClassIdentity")
+@_cdecl("bjs_Benchmarks_ClassRoundtripIdentity_makeSimpleClassIdentity")
+public func _bjs_Benchmarks_ClassRoundtripIdentity_makeSimpleClassIdentity(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassRoundtripIdentity.bridgeJSLiftParameter(_self).makeSimpleClassIdentity()
+    let ret = Benchmarks.ClassRoundtripIdentity.bridgeJSLiftParameter(_self).makeSimpleClassIdentity()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtripIdentity_takeSimpleClassIdentity")
-@_cdecl("bjs_ClassRoundtripIdentity_takeSimpleClassIdentity")
-public func _bjs_ClassRoundtripIdentity_takeSimpleClassIdentity(_ _self: UnsafeMutableRawPointer, _ obj: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtripIdentity_takeSimpleClassIdentity")
+@_cdecl("bjs_Benchmarks_ClassRoundtripIdentity_takeSimpleClassIdentity")
+public func _bjs_Benchmarks_ClassRoundtripIdentity_takeSimpleClassIdentity(_ _self: UnsafeMutableRawPointer, _ obj: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ClassRoundtripIdentity.bridgeJSLiftParameter(_self).takeSimpleClassIdentity(_: SimpleClassIdentity.bridgeJSLiftParameter(obj))
+    Benchmarks.ClassRoundtripIdentity.bridgeJSLiftParameter(_self).takeSimpleClassIdentity(_: Benchmarks.SimpleClassIdentity.bridgeJSLiftParameter(obj))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassRoundtripIdentity_deinit")
-@_cdecl("bjs_ClassRoundtripIdentity_deinit")
-public func _bjs_ClassRoundtripIdentity_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ClassRoundtripIdentity_deinit")
+@_cdecl("bjs_Benchmarks_ClassRoundtripIdentity_deinit")
+public func _bjs_Benchmarks_ClassRoundtripIdentity_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ClassRoundtripIdentity>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.ClassRoundtripIdentity>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ClassRoundtripIdentity: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.ClassRoundtripIdentity: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ClassRoundtripIdentity_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_ClassRoundtripIdentity_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ClassRoundtripIdentity_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_ClassRoundtripIdentity_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_ClassRoundtripIdentity_wrap")
-fileprivate func _bjs_ClassRoundtripIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_ClassRoundtripIdentity_wrap")
+fileprivate func _bjs_Benchmarks_ClassRoundtripIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ClassRoundtripIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_ClassRoundtripIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ClassRoundtripIdentity_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ClassRoundtripIdentity_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_ClassRoundtripIdentity_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_ClassRoundtripIdentity_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_IdentityCacheBenchmarkIdentity_init")
-@_cdecl("bjs_IdentityCacheBenchmarkIdentity_init")
-public func _bjs_IdentityCacheBenchmarkIdentity_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_IdentityCacheBenchmarkIdentity_init")
+@_cdecl("bjs_Benchmarks_IdentityCacheBenchmarkIdentity_init")
+public func _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = IdentityCacheBenchmarkIdentity()
+    let ret = Benchmarks.IdentityCacheBenchmarkIdentity()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityCacheBenchmarkIdentity_setupPool")
-@_cdecl("bjs_IdentityCacheBenchmarkIdentity_setupPool")
-public func _bjs_IdentityCacheBenchmarkIdentity_setupPool(_ _self: UnsafeMutableRawPointer, _ count: Int32) -> Void {
+@_expose(wasm, "bjs_Benchmarks_IdentityCacheBenchmarkIdentity_setupPool")
+@_cdecl("bjs_Benchmarks_IdentityCacheBenchmarkIdentity_setupPool")
+public func _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_setupPool(_ _self: UnsafeMutableRawPointer, _ count: Int32) -> Void {
     #if arch(wasm32)
-    IdentityCacheBenchmarkIdentity.bridgeJSLiftParameter(_self).setupPool(_: Int.bridgeJSLiftParameter(count))
+    Benchmarks.IdentityCacheBenchmarkIdentity.bridgeJSLiftParameter(_self).setupPool(_: Int.bridgeJSLiftParameter(count))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityCacheBenchmarkIdentity_getPoolRepeated")
-@_cdecl("bjs_IdentityCacheBenchmarkIdentity_getPoolRepeated")
-public func _bjs_IdentityCacheBenchmarkIdentity_getPoolRepeated(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_IdentityCacheBenchmarkIdentity_getPoolRepeated")
+@_cdecl("bjs_Benchmarks_IdentityCacheBenchmarkIdentity_getPoolRepeated")
+public func _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_getPoolRepeated(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = IdentityCacheBenchmarkIdentity.bridgeJSLiftParameter(_self).getPoolRepeated()
+    let ret = Benchmarks.IdentityCacheBenchmarkIdentity.bridgeJSLiftParameter(_self).getPoolRepeated()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityCacheBenchmarkIdentity_deinit")
-@_cdecl("bjs_IdentityCacheBenchmarkIdentity_deinit")
-public func _bjs_IdentityCacheBenchmarkIdentity_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_IdentityCacheBenchmarkIdentity_deinit")
+@_cdecl("bjs_Benchmarks_IdentityCacheBenchmarkIdentity_deinit")
+public func _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<IdentityCacheBenchmarkIdentity>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.IdentityCacheBenchmarkIdentity>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension IdentityCacheBenchmarkIdentity: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.IdentityCacheBenchmarkIdentity: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_IdentityCacheBenchmarkIdentity_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_IdentityCacheBenchmarkIdentity_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_IdentityCacheBenchmarkIdentity_wrap")
-fileprivate func _bjs_IdentityCacheBenchmarkIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_IdentityCacheBenchmarkIdentity_wrap")
+fileprivate func _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_IdentityCacheBenchmarkIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_IdentityCacheBenchmarkIdentity_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_IdentityCacheBenchmarkIdentity_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_IdentityCacheBenchmarkIdentity_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_init")
-@_cdecl("bjs_ArrayRoundtrip_init")
-public func _bjs_ArrayRoundtrip_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_init")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_init")
+public func _bjs_Benchmarks_ArrayRoundtrip_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip()
+    let ret = Benchmarks.ArrayRoundtrip()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_takeIntArray")
-@_cdecl("bjs_ArrayRoundtrip_takeIntArray")
-public func _bjs_ArrayRoundtrip_takeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_takeIntArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_takeIntArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_takeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeIntArray(_: [Int].bridgeJSStackPop())
+    Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).takeIntArray(_: [Int].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeIntArray")
-@_cdecl("bjs_ArrayRoundtrip_makeIntArray")
-public func _bjs_ArrayRoundtrip_makeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeIntArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeIntArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArray()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArray()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_roundtripIntArray")
-@_cdecl("bjs_ArrayRoundtrip_roundtripIntArray")
-public func _bjs_ArrayRoundtrip_roundtripIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_roundtripIntArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_roundtripIntArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_roundtripIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripIntArray(_: [Int].bridgeJSStackPop())
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripIntArray(_: [Int].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeIntArrayLarge")
-@_cdecl("bjs_ArrayRoundtrip_makeIntArrayLarge")
-public func _bjs_ArrayRoundtrip_makeIntArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeIntArrayLarge")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeIntArrayLarge")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeIntArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArrayLarge()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeIntArrayLarge()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_takeDoubleArray")
-@_cdecl("bjs_ArrayRoundtrip_takeDoubleArray")
-public func _bjs_ArrayRoundtrip_takeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_takeDoubleArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_takeDoubleArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_takeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeDoubleArray(_: [Double].bridgeJSStackPop())
+    Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).takeDoubleArray(_: [Double].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeDoubleArray")
-@_cdecl("bjs_ArrayRoundtrip_makeDoubleArray")
-public func _bjs_ArrayRoundtrip_makeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeDoubleArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeDoubleArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeDoubleArray()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeDoubleArray()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_roundtripDoubleArray")
-@_cdecl("bjs_ArrayRoundtrip_roundtripDoubleArray")
-public func _bjs_ArrayRoundtrip_roundtripDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_roundtripDoubleArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_roundtripDoubleArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_roundtripDoubleArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripDoubleArray(_: [Double].bridgeJSStackPop())
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripDoubleArray(_: [Double].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_takeStringArray")
-@_cdecl("bjs_ArrayRoundtrip_takeStringArray")
-public func _bjs_ArrayRoundtrip_takeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_takeStringArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_takeStringArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_takeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeStringArray(_: [String].bridgeJSStackPop())
+    Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).takeStringArray(_: [String].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeStringArray")
-@_cdecl("bjs_ArrayRoundtrip_makeStringArray")
-public func _bjs_ArrayRoundtrip_makeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeStringArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeStringArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeStringArray()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeStringArray()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_roundtripStringArray")
-@_cdecl("bjs_ArrayRoundtrip_roundtripStringArray")
-public func _bjs_ArrayRoundtrip_roundtripStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_roundtripStringArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_roundtripStringArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_roundtripStringArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripStringArray(_: [String].bridgeJSStackPop())
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripStringArray(_: [String].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_takePointArray")
-@_cdecl("bjs_ArrayRoundtrip_takePointArray")
-public func _bjs_ArrayRoundtrip_takePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_takePointArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_takePointArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_takePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takePointArray(_: [Point].bridgeJSStackPop())
+    Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).takePointArray(_: [Benchmarks.Point].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makePointArray")
-@_cdecl("bjs_ArrayRoundtrip_makePointArray")
-public func _bjs_ArrayRoundtrip_makePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makePointArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makePointArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_makePointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArray()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArray()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_roundtripPointArray")
-@_cdecl("bjs_ArrayRoundtrip_roundtripPointArray")
-public func _bjs_ArrayRoundtrip_roundtripPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_roundtripPointArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_roundtripPointArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_roundtripPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripPointArray(_: [Point].bridgeJSStackPop())
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripPointArray(_: [Benchmarks.Point].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makePointArrayLarge")
-@_cdecl("bjs_ArrayRoundtrip_makePointArrayLarge")
-public func _bjs_ArrayRoundtrip_makePointArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makePointArrayLarge")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makePointArrayLarge")
+public func _bjs_Benchmarks_ArrayRoundtrip_makePointArrayLarge(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArrayLarge()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makePointArrayLarge()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_takeNestedIntArray")
-@_cdecl("bjs_ArrayRoundtrip_takeNestedIntArray")
-public func _bjs_ArrayRoundtrip_takeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_takeNestedIntArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_takeNestedIntArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_takeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedIntArray(_: [[Int]].bridgeJSStackPop())
+    Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedIntArray(_: [[Int]].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeNestedIntArray")
-@_cdecl("bjs_ArrayRoundtrip_makeNestedIntArray")
-public func _bjs_ArrayRoundtrip_makeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeNestedIntArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeNestedIntArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedIntArray()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedIntArray()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_roundtripNestedIntArray")
-@_cdecl("bjs_ArrayRoundtrip_roundtripNestedIntArray")
-public func _bjs_ArrayRoundtrip_roundtripNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_roundtripNestedIntArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_roundtripNestedIntArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_roundtripNestedIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedIntArray(_: [[Int]].bridgeJSStackPop())
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedIntArray(_: [[Int]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_takeNestedPointArray")
-@_cdecl("bjs_ArrayRoundtrip_takeNestedPointArray")
-public func _bjs_ArrayRoundtrip_takeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_takeNestedPointArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_takeNestedPointArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_takeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedPointArray(_: [[Point]].bridgeJSStackPop())
+    Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).takeNestedPointArray(_: [[Benchmarks.Point]].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeNestedPointArray")
-@_cdecl("bjs_ArrayRoundtrip_makeNestedPointArray")
-public func _bjs_ArrayRoundtrip_makeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeNestedPointArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeNestedPointArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedPointArray()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeNestedPointArray()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_roundtripNestedPointArray")
-@_cdecl("bjs_ArrayRoundtrip_roundtripNestedPointArray")
-public func _bjs_ArrayRoundtrip_roundtripNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_roundtripNestedPointArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_roundtripNestedPointArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_roundtripNestedPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedPointArray(_: [[Point]].bridgeJSStackPop())
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripNestedPointArray(_: [[Benchmarks.Point]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_takeOptionalIntArray")
-@_cdecl("bjs_ArrayRoundtrip_takeOptionalIntArray")
-public func _bjs_ArrayRoundtrip_takeOptionalIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_takeOptionalIntArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_takeOptionalIntArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_takeOptionalIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalIntArray(_: [Optional<Int>].bridgeJSStackPop())
+    Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalIntArray(_: [Optional<Int>].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeOptionalIntArray")
-@_cdecl("bjs_ArrayRoundtrip_makeOptionalIntArray")
-public func _bjs_ArrayRoundtrip_makeOptionalIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeOptionalIntArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeOptionalIntArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeOptionalIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalIntArray()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalIntArray()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_roundtripOptionalIntArray")
-@_cdecl("bjs_ArrayRoundtrip_roundtripOptionalIntArray")
-public func _bjs_ArrayRoundtrip_roundtripOptionalIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalIntArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalIntArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalIntArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalIntArray(_: [Optional<Int>].bridgeJSStackPop())
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalIntArray(_: [Optional<Int>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_takeOptionalPointArray")
-@_cdecl("bjs_ArrayRoundtrip_takeOptionalPointArray")
-public func _bjs_ArrayRoundtrip_takeOptionalPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_takeOptionalPointArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_takeOptionalPointArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_takeOptionalPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalPointArray(_: [Optional<Point>].bridgeJSStackPop())
+    Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalPointArray(_: [Optional<Benchmarks.Point>].bridgeJSStackPop())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeOptionalPointArray")
-@_cdecl("bjs_ArrayRoundtrip_makeOptionalPointArray")
-public func _bjs_ArrayRoundtrip_makeOptionalPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeOptionalPointArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeOptionalPointArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeOptionalPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalPointArray()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalPointArray()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_roundtripOptionalPointArray")
-@_cdecl("bjs_ArrayRoundtrip_roundtripOptionalPointArray")
-public func _bjs_ArrayRoundtrip_roundtripOptionalPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalPointArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalPointArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalPointArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalPointArray(_: [Optional<Point>].bridgeJSStackPop())
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalPointArray(_: [Optional<Benchmarks.Point>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_takeOptionalArray")
-@_cdecl("bjs_ArrayRoundtrip_takeOptionalArray")
-public func _bjs_ArrayRoundtrip_takeOptionalArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_takeOptionalArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_takeOptionalArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_takeOptionalArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
+    Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).takeOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeOptionalArraySome")
-@_cdecl("bjs_ArrayRoundtrip_makeOptionalArraySome")
-public func _bjs_ArrayRoundtrip_makeOptionalArraySome(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeOptionalArraySome")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeOptionalArraySome")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeOptionalArraySome(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArraySome()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArraySome()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_makeOptionalArrayNone")
-@_cdecl("bjs_ArrayRoundtrip_makeOptionalArrayNone")
-public func _bjs_ArrayRoundtrip_makeOptionalArrayNone(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_makeOptionalArrayNone")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_makeOptionalArrayNone")
+public func _bjs_Benchmarks_ArrayRoundtrip_makeOptionalArrayNone(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArrayNone()
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).makeOptionalArrayNone()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_roundtripOptionalArray")
-@_cdecl("bjs_ArrayRoundtrip_roundtripOptionalArray")
-public func _bjs_ArrayRoundtrip_roundtripOptionalArray(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalArray")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalArray")
+public func _bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalArray(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
+    let ret = Benchmarks.ArrayRoundtrip.bridgeJSLiftParameter(_self).roundtripOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayRoundtrip_deinit")
-@_cdecl("bjs_ArrayRoundtrip_deinit")
-public func _bjs_ArrayRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_Benchmarks_ArrayRoundtrip_deinit")
+@_cdecl("bjs_Benchmarks_ArrayRoundtrip_deinit")
+public func _bjs_Benchmarks_ArrayRoundtrip_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ArrayRoundtrip>.fromOpaque(pointer).release()
+    Unmanaged<Benchmarks.ArrayRoundtrip>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ArrayRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension Benchmarks.ArrayRoundtrip: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ArrayRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_Benchmarks_ArrayRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ArrayRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_Benchmarks_ArrayRoundtrip_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "Benchmarks", name: "bjs_ArrayRoundtrip_wrap")
-fileprivate func _bjs_ArrayRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "Benchmarks", name: "bjs_Benchmarks_ArrayRoundtrip_wrap")
+fileprivate func _bjs_Benchmarks_ArrayRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ArrayRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_Benchmarks_ArrayRoundtrip_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ArrayRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ArrayRoundtrip_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_Benchmarks_ArrayRoundtrip_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_Benchmarks_ArrayRoundtrip_wrap_extern(pointer)
 }
 
 #if arch(wasm32)

--- a/Benchmarks/Sources/Generated/JavaScript/BridgeJS.json
+++ b/Benchmarks/Sources/Generated/JavaScript/BridgeJS.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_EnumRoundtrip_init",
+          "abiName" : "bjs_Benchmarks_EnumRoundtrip_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_EnumRoundtrip_take",
+            "abiName" : "bjs_Benchmarks_EnumRoundtrip_take",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -31,7 +31,7 @@
                 "name" : "value",
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "Benchmarks.APIResult"
                   }
                 }
               }
@@ -43,7 +43,7 @@
             }
           },
           {
-            "abiName" : "bjs_EnumRoundtrip_makeSuccess",
+            "abiName" : "bjs_Benchmarks_EnumRoundtrip_makeSuccess",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -55,12 +55,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "Benchmarks.APIResult"
               }
             }
           },
           {
-            "abiName" : "bjs_EnumRoundtrip_makeFailure",
+            "abiName" : "bjs_Benchmarks_EnumRoundtrip_makeFailure",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -72,12 +72,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "Benchmarks.APIResult"
               }
             }
           },
           {
-            "abiName" : "bjs_EnumRoundtrip_makeFlag",
+            "abiName" : "bjs_Benchmarks_EnumRoundtrip_makeFlag",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -89,12 +89,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "Benchmarks.APIResult"
               }
             }
           },
           {
-            "abiName" : "bjs_EnumRoundtrip_makeRate",
+            "abiName" : "bjs_Benchmarks_EnumRoundtrip_makeRate",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -106,12 +106,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "Benchmarks.APIResult"
               }
             }
           },
           {
-            "abiName" : "bjs_EnumRoundtrip_makePrecise",
+            "abiName" : "bjs_Benchmarks_EnumRoundtrip_makePrecise",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -123,12 +123,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "Benchmarks.APIResult"
               }
             }
           },
           {
-            "abiName" : "bjs_EnumRoundtrip_makeInfo",
+            "abiName" : "bjs_Benchmarks_EnumRoundtrip_makeInfo",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -140,12 +140,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "Benchmarks.APIResult"
               }
             }
           },
           {
-            "abiName" : "bjs_EnumRoundtrip_roundtrip",
+            "abiName" : "bjs_Benchmarks_EnumRoundtrip_roundtrip",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -158,14 +158,14 @@
                 "name" : "result",
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "Benchmarks.APIResult"
                   }
                 }
               }
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "Benchmarks.APIResult"
               }
             }
           }
@@ -174,11 +174,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "EnumRoundtrip"
+        "swiftCallName" : "Benchmarks.EnumRoundtrip"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_ComplexResultRoundtrip_init",
+          "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -190,7 +190,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_ComplexResultRoundtrip_take",
+            "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_take",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -203,7 +203,7 @@
                 "name" : "value",
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "ComplexResult"
+                    "_0" : "Benchmarks.ComplexResult"
                   }
                 }
               }
@@ -215,7 +215,7 @@
             }
           },
           {
-            "abiName" : "bjs_ComplexResultRoundtrip_makeSuccess",
+            "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_makeSuccess",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -227,12 +227,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "Benchmarks.ComplexResult"
               }
             }
           },
           {
-            "abiName" : "bjs_ComplexResultRoundtrip_makeError",
+            "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_makeError",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -244,12 +244,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "Benchmarks.ComplexResult"
               }
             }
           },
           {
-            "abiName" : "bjs_ComplexResultRoundtrip_makeLocation",
+            "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_makeLocation",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -261,12 +261,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "Benchmarks.ComplexResult"
               }
             }
           },
           {
-            "abiName" : "bjs_ComplexResultRoundtrip_makeStatus",
+            "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_makeStatus",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -278,12 +278,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "Benchmarks.ComplexResult"
               }
             }
           },
           {
-            "abiName" : "bjs_ComplexResultRoundtrip_makeCoordinates",
+            "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_makeCoordinates",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -295,12 +295,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "Benchmarks.ComplexResult"
               }
             }
           },
           {
-            "abiName" : "bjs_ComplexResultRoundtrip_makeComprehensive",
+            "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_makeComprehensive",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -312,12 +312,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "Benchmarks.ComplexResult"
               }
             }
           },
           {
-            "abiName" : "bjs_ComplexResultRoundtrip_makeInfo",
+            "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_makeInfo",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -329,12 +329,12 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "Benchmarks.ComplexResult"
               }
             }
           },
           {
-            "abiName" : "bjs_ComplexResultRoundtrip_roundtrip",
+            "abiName" : "bjs_Benchmarks_ComplexResultRoundtrip_roundtrip",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -347,14 +347,14 @@
                 "name" : "result",
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "ComplexResult"
+                    "_0" : "Benchmarks.ComplexResult"
                   }
                 }
               }
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "Benchmarks.ComplexResult"
               }
             }
           }
@@ -363,11 +363,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ComplexResultRoundtrip"
+        "swiftCallName" : "Benchmarks.ComplexResultRoundtrip"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_StringRoundtrip_init",
+          "abiName" : "bjs_Benchmarks_StringRoundtrip_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -379,7 +379,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_StringRoundtrip_take",
+            "abiName" : "bjs_Benchmarks_StringRoundtrip_take",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -404,7 +404,7 @@
             }
           },
           {
-            "abiName" : "bjs_StringRoundtrip_make",
+            "abiName" : "bjs_Benchmarks_StringRoundtrip_make",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -425,11 +425,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "StringRoundtrip"
+        "swiftCallName" : "Benchmarks.StringRoundtrip"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_OptionalReturnRoundtrip_init",
+          "abiName" : "bjs_Benchmarks_OptionalReturnRoundtrip_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -441,7 +441,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_OptionalReturnRoundtrip_makeIntSome",
+            "abiName" : "bjs_Benchmarks_OptionalReturnRoundtrip_makeIntSome",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -466,7 +466,7 @@
             }
           },
           {
-            "abiName" : "bjs_OptionalReturnRoundtrip_makeIntNone",
+            "abiName" : "bjs_Benchmarks_OptionalReturnRoundtrip_makeIntNone",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -491,7 +491,7 @@
             }
           },
           {
-            "abiName" : "bjs_OptionalReturnRoundtrip_makeBoolSome",
+            "abiName" : "bjs_Benchmarks_OptionalReturnRoundtrip_makeBoolSome",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -513,7 +513,7 @@
             }
           },
           {
-            "abiName" : "bjs_OptionalReturnRoundtrip_makeBoolNone",
+            "abiName" : "bjs_Benchmarks_OptionalReturnRoundtrip_makeBoolNone",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -535,7 +535,7 @@
             }
           },
           {
-            "abiName" : "bjs_OptionalReturnRoundtrip_makeDoubleSome",
+            "abiName" : "bjs_Benchmarks_OptionalReturnRoundtrip_makeDoubleSome",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -557,7 +557,7 @@
             }
           },
           {
-            "abiName" : "bjs_OptionalReturnRoundtrip_makeDoubleNone",
+            "abiName" : "bjs_Benchmarks_OptionalReturnRoundtrip_makeDoubleNone",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -579,7 +579,7 @@
             }
           },
           {
-            "abiName" : "bjs_OptionalReturnRoundtrip_makeStringSome",
+            "abiName" : "bjs_Benchmarks_OptionalReturnRoundtrip_makeStringSome",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -601,7 +601,7 @@
             }
           },
           {
-            "abiName" : "bjs_OptionalReturnRoundtrip_makeStringNone",
+            "abiName" : "bjs_Benchmarks_OptionalReturnRoundtrip_makeStringNone",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -627,11 +627,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "OptionalReturnRoundtrip"
+        "swiftCallName" : "Benchmarks.OptionalReturnRoundtrip"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_StructRoundtrip_init",
+          "abiName" : "bjs_Benchmarks_StructRoundtrip_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -643,7 +643,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_StructRoundtrip_takeSimple",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_takeSimple",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -656,7 +656,7 @@
                 "name" : "value",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "SimpleStruct"
+                    "_0" : "Benchmarks.SimpleStruct"
                   }
                 }
               }
@@ -668,7 +668,7 @@
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_makeSimple",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_makeSimple",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -680,12 +680,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "SimpleStruct"
+                "_0" : "Benchmarks.SimpleStruct"
               }
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_roundtripSimple",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_roundtripSimple",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -698,19 +698,19 @@
                 "name" : "value",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "SimpleStruct"
+                    "_0" : "Benchmarks.SimpleStruct"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "SimpleStruct"
+                "_0" : "Benchmarks.SimpleStruct"
               }
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_takeAddress",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_takeAddress",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -723,7 +723,7 @@
                 "name" : "value",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "Address"
+                    "_0" : "Benchmarks.Address"
                   }
                 }
               }
@@ -735,7 +735,7 @@
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_makeAddress",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_makeAddress",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -747,12 +747,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Address"
+                "_0" : "Benchmarks.Address"
               }
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_roundtripAddress",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_roundtripAddress",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -765,19 +765,19 @@
                 "name" : "value",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "Address"
+                    "_0" : "Benchmarks.Address"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Address"
+                "_0" : "Benchmarks.Address"
               }
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_takePerson",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_takePerson",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -790,7 +790,7 @@
                 "name" : "value",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "Person"
+                    "_0" : "Benchmarks.Person"
                   }
                 }
               }
@@ -802,7 +802,7 @@
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_makePerson",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_makePerson",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -814,12 +814,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Person"
+                "_0" : "Benchmarks.Person"
               }
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_roundtripPerson",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_roundtripPerson",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -832,19 +832,19 @@
                 "name" : "value",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "Person"
+                    "_0" : "Benchmarks.Person"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Person"
+                "_0" : "Benchmarks.Person"
               }
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_takeComplex",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_takeComplex",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -857,7 +857,7 @@
                 "name" : "value",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "ComplexStruct"
+                    "_0" : "Benchmarks.ComplexStruct"
                   }
                 }
               }
@@ -869,7 +869,7 @@
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_makeComplex",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_makeComplex",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -881,12 +881,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "ComplexStruct"
+                "_0" : "Benchmarks.ComplexStruct"
               }
             }
           },
           {
-            "abiName" : "bjs_StructRoundtrip_roundtripComplex",
+            "abiName" : "bjs_Benchmarks_StructRoundtrip_roundtripComplex",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -899,14 +899,14 @@
                 "name" : "value",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "ComplexStruct"
+                    "_0" : "Benchmarks.ComplexStruct"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "ComplexStruct"
+                "_0" : "Benchmarks.ComplexStruct"
               }
             }
           }
@@ -915,11 +915,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "StructRoundtrip"
+        "swiftCallName" : "Benchmarks.StructRoundtrip"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_SimpleClass_init",
+          "abiName" : "bjs_Benchmarks_SimpleClass_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1035,11 +1035,11 @@
             }
           }
         ],
-        "swiftCallName" : "SimpleClass"
+        "swiftCallName" : "Benchmarks.SimpleClass"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_AddressClass_init",
+          "abiName" : "bjs_Benchmarks_AddressClass_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1117,11 +1117,11 @@
             }
           }
         ],
-        "swiftCallName" : "AddressClass"
+        "swiftCallName" : "Benchmarks.AddressClass"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_ClassRoundtrip_init",
+          "abiName" : "bjs_Benchmarks_ClassRoundtrip_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1133,7 +1133,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_ClassRoundtrip_takeSimpleClass",
+            "abiName" : "bjs_Benchmarks_ClassRoundtrip_takeSimpleClass",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1146,7 +1146,7 @@
                 "name" : "value",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "SimpleClass"
+                    "_0" : "Benchmarks.SimpleClass"
                   }
                 }
               }
@@ -1158,7 +1158,7 @@
             }
           },
           {
-            "abiName" : "bjs_ClassRoundtrip_makeSimpleClass",
+            "abiName" : "bjs_Benchmarks_ClassRoundtrip_makeSimpleClass",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1170,12 +1170,12 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "SimpleClass"
+                "_0" : "Benchmarks.SimpleClass"
               }
             }
           },
           {
-            "abiName" : "bjs_ClassRoundtrip_roundtripSimpleClass",
+            "abiName" : "bjs_Benchmarks_ClassRoundtrip_roundtripSimpleClass",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1188,19 +1188,19 @@
                 "name" : "value",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "SimpleClass"
+                    "_0" : "Benchmarks.SimpleClass"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "SimpleClass"
+                "_0" : "Benchmarks.SimpleClass"
               }
             }
           },
           {
-            "abiName" : "bjs_ClassRoundtrip_takeAddressClass",
+            "abiName" : "bjs_Benchmarks_ClassRoundtrip_takeAddressClass",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1213,7 +1213,7 @@
                 "name" : "value",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "AddressClass"
+                    "_0" : "Benchmarks.AddressClass"
                   }
                 }
               }
@@ -1225,7 +1225,7 @@
             }
           },
           {
-            "abiName" : "bjs_ClassRoundtrip_makeAddressClass",
+            "abiName" : "bjs_Benchmarks_ClassRoundtrip_makeAddressClass",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1237,12 +1237,12 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "AddressClass"
+                "_0" : "Benchmarks.AddressClass"
               }
             }
           },
           {
-            "abiName" : "bjs_ClassRoundtrip_roundtripAddressClass",
+            "abiName" : "bjs_Benchmarks_ClassRoundtrip_roundtripAddressClass",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1255,14 +1255,14 @@
                 "name" : "value",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "AddressClass"
+                    "_0" : "Benchmarks.AddressClass"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "AddressClass"
+                "_0" : "Benchmarks.AddressClass"
               }
             }
           }
@@ -1271,11 +1271,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ClassRoundtrip"
+        "swiftCallName" : "Benchmarks.ClassRoundtrip"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_ClassArrayRoundtrip_init",
+          "abiName" : "bjs_Benchmarks_ClassArrayRoundtrip_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1287,7 +1287,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_ClassArrayRoundtrip_setupPool",
+            "abiName" : "bjs_Benchmarks_ClassArrayRoundtrip_setupPool",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1315,7 +1315,7 @@
             }
           },
           {
-            "abiName" : "bjs_ClassArrayRoundtrip_getPool",
+            "abiName" : "bjs_Benchmarks_ClassArrayRoundtrip_getPool",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1329,14 +1329,14 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "SimpleClass"
+                    "_0" : "Benchmarks.SimpleClass"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_ClassArrayRoundtrip_makeClassArray",
+            "abiName" : "bjs_Benchmarks_ClassArrayRoundtrip_makeClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1350,14 +1350,14 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "SimpleClass"
+                    "_0" : "Benchmarks.SimpleClass"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_ClassArrayRoundtrip_takeClassArray",
+            "abiName" : "bjs_Benchmarks_ClassArrayRoundtrip_takeClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1372,7 +1372,7 @@
                   "array" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "SimpleClass"
+                        "_0" : "Benchmarks.SimpleClass"
                       }
                     }
                   }
@@ -1386,7 +1386,7 @@
             }
           },
           {
-            "abiName" : "bjs_ClassArrayRoundtrip_roundtripClassArray",
+            "abiName" : "bjs_Benchmarks_ClassArrayRoundtrip_roundtripClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1401,7 +1401,7 @@
                   "array" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "SimpleClass"
+                        "_0" : "Benchmarks.SimpleClass"
                       }
                     }
                   }
@@ -1412,7 +1412,7 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "SimpleClass"
+                    "_0" : "Benchmarks.SimpleClass"
                   }
                 }
               }
@@ -1423,11 +1423,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ClassArrayRoundtrip"
+        "swiftCallName" : "Benchmarks.ClassArrayRoundtrip"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_IdentityCacheBenchmark_init",
+          "abiName" : "bjs_Benchmarks_IdentityCacheBenchmark_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1439,7 +1439,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_IdentityCacheBenchmark_setupPool",
+            "abiName" : "bjs_Benchmarks_IdentityCacheBenchmark_setupPool",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1467,7 +1467,7 @@
             }
           },
           {
-            "abiName" : "bjs_IdentityCacheBenchmark_getPoolRepeated",
+            "abiName" : "bjs_Benchmarks_IdentityCacheBenchmark_getPoolRepeated",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1481,7 +1481,7 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "SimpleClass"
+                    "_0" : "Benchmarks.SimpleClass"
                   }
                 }
               }
@@ -1492,11 +1492,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "IdentityCacheBenchmark"
+        "swiftCallName" : "Benchmarks.IdentityCacheBenchmark"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_SimpleClassIdentity_init",
+          "abiName" : "bjs_Benchmarks_SimpleClassIdentity_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1613,11 +1613,11 @@
             }
           }
         ],
-        "swiftCallName" : "SimpleClassIdentity"
+        "swiftCallName" : "Benchmarks.SimpleClassIdentity"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_ClassRoundtripIdentity_init",
+          "abiName" : "bjs_Benchmarks_ClassRoundtripIdentity_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1630,7 +1630,7 @@
         "identityMode" : true,
         "methods" : [
           {
-            "abiName" : "bjs_ClassRoundtripIdentity_roundtripSimpleClassIdentity",
+            "abiName" : "bjs_Benchmarks_ClassRoundtripIdentity_roundtripSimpleClassIdentity",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1643,19 +1643,19 @@
                 "name" : "obj",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "SimpleClassIdentity"
+                    "_0" : "Benchmarks.SimpleClassIdentity"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "SimpleClassIdentity"
+                "_0" : "Benchmarks.SimpleClassIdentity"
               }
             }
           },
           {
-            "abiName" : "bjs_ClassRoundtripIdentity_makeSimpleClassIdentity",
+            "abiName" : "bjs_Benchmarks_ClassRoundtripIdentity_makeSimpleClassIdentity",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1667,12 +1667,12 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "SimpleClassIdentity"
+                "_0" : "Benchmarks.SimpleClassIdentity"
               }
             }
           },
           {
-            "abiName" : "bjs_ClassRoundtripIdentity_takeSimpleClassIdentity",
+            "abiName" : "bjs_Benchmarks_ClassRoundtripIdentity_takeSimpleClassIdentity",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1685,7 +1685,7 @@
                 "name" : "obj",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "SimpleClassIdentity"
+                    "_0" : "Benchmarks.SimpleClassIdentity"
                   }
                 }
               }
@@ -1701,11 +1701,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ClassRoundtripIdentity"
+        "swiftCallName" : "Benchmarks.ClassRoundtripIdentity"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_IdentityCacheBenchmarkIdentity_init",
+          "abiName" : "bjs_Benchmarks_IdentityCacheBenchmarkIdentity_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1718,7 +1718,7 @@
         "identityMode" : true,
         "methods" : [
           {
-            "abiName" : "bjs_IdentityCacheBenchmarkIdentity_setupPool",
+            "abiName" : "bjs_Benchmarks_IdentityCacheBenchmarkIdentity_setupPool",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1746,7 +1746,7 @@
             }
           },
           {
-            "abiName" : "bjs_IdentityCacheBenchmarkIdentity_getPoolRepeated",
+            "abiName" : "bjs_Benchmarks_IdentityCacheBenchmarkIdentity_getPoolRepeated",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1760,7 +1760,7 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "SimpleClassIdentity"
+                    "_0" : "Benchmarks.SimpleClassIdentity"
                   }
                 }
               }
@@ -1771,11 +1771,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "IdentityCacheBenchmarkIdentity"
+        "swiftCallName" : "Benchmarks.IdentityCacheBenchmarkIdentity"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_ArrayRoundtrip_init",
+          "abiName" : "bjs_Benchmarks_ArrayRoundtrip_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1787,7 +1787,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_ArrayRoundtrip_takeIntArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_takeIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1819,7 +1819,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeIntArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1843,7 +1843,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_roundtripIntArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_roundtripIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1882,7 +1882,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeIntArrayLarge",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeIntArrayLarge",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1906,7 +1906,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_takeDoubleArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_takeDoubleArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1935,7 +1935,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeDoubleArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeDoubleArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1956,7 +1956,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_roundtripDoubleArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_roundtripDoubleArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1989,7 +1989,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_takeStringArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_takeStringArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2018,7 +2018,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeStringArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeStringArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2039,7 +2039,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_roundtripStringArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_roundtripStringArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2072,7 +2072,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_takePointArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_takePointArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2087,7 +2087,7 @@
                   "array" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "Benchmarks.Point"
                       }
                     }
                   }
@@ -2101,7 +2101,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makePointArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makePointArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2115,14 +2115,14 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "Benchmarks.Point"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_roundtripPointArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_roundtripPointArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2137,7 +2137,7 @@
                   "array" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "Benchmarks.Point"
                       }
                     }
                   }
@@ -2148,14 +2148,14 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "Benchmarks.Point"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makePointArrayLarge",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makePointArrayLarge",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2169,14 +2169,14 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "Benchmarks.Point"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_takeNestedIntArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_takeNestedIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2212,7 +2212,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeNestedIntArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeNestedIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2240,7 +2240,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_roundtripNestedIntArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_roundtripNestedIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2287,7 +2287,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_takeNestedPointArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_takeNestedPointArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2304,7 +2304,7 @@
                       "array" : {
                         "_0" : {
                           "swiftStruct" : {
-                            "_0" : "Point"
+                            "_0" : "Benchmarks.Point"
                           }
                         }
                       }
@@ -2320,7 +2320,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeNestedPointArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeNestedPointArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2336,7 +2336,7 @@
                   "array" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "Benchmarks.Point"
                       }
                     }
                   }
@@ -2345,7 +2345,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_roundtripNestedPointArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_roundtripNestedPointArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2362,7 +2362,7 @@
                       "array" : {
                         "_0" : {
                           "swiftStruct" : {
-                            "_0" : "Point"
+                            "_0" : "Benchmarks.Point"
                           }
                         }
                       }
@@ -2377,7 +2377,7 @@
                   "array" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "Benchmarks.Point"
                       }
                     }
                   }
@@ -2386,7 +2386,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_takeOptionalIntArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_takeOptionalIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2423,7 +2423,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeOptionalIntArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeOptionalIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2452,7 +2452,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_roundtripOptionalIntArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2501,7 +2501,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_takeOptionalPointArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_takeOptionalPointArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2518,7 +2518,7 @@
                       "nullable" : {
                         "_0" : {
                           "swiftStruct" : {
-                            "_0" : "Point"
+                            "_0" : "Benchmarks.Point"
                           }
                         },
                         "_1" : "null"
@@ -2535,7 +2535,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeOptionalPointArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeOptionalPointArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2551,7 +2551,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "Benchmarks.Point"
                       }
                     },
                     "_1" : "null"
@@ -2561,7 +2561,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_roundtripOptionalPointArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalPointArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2578,7 +2578,7 @@
                       "nullable" : {
                         "_0" : {
                           "swiftStruct" : {
-                            "_0" : "Point"
+                            "_0" : "Benchmarks.Point"
                           }
                         },
                         "_1" : "null"
@@ -2594,7 +2594,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "Benchmarks.Point"
                       }
                     },
                     "_1" : "null"
@@ -2604,7 +2604,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_takeOptionalArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_takeOptionalArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2641,7 +2641,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeOptionalArraySome",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeOptionalArraySome",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2670,7 +2670,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_makeOptionalArrayNone",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_makeOptionalArrayNone",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2699,7 +2699,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayRoundtrip_roundtripOptionalArray",
+            "abiName" : "bjs_Benchmarks_ArrayRoundtrip_roundtripOptionalArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2752,7 +2752,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ArrayRoundtrip"
+        "swiftCallName" : "Benchmarks.ArrayRoundtrip"
       }
     ],
     "enums" : [
@@ -2836,7 +2836,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "APIResult",
+        "swiftCallName" : "Benchmarks.APIResult",
         "tsFullPath" : "APIResult"
       },
       {
@@ -3045,14 +3045,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "ComplexResult",
+        "swiftCallName" : "Benchmarks.ComplexResult",
         "tsFullPath" : "ComplexResult"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_run",
+        "abiName" : "bjs_Benchmarks_run",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -3133,7 +3133,7 @@
             }
           }
         ],
-        "swiftCallName" : "SimpleStruct"
+        "swiftCallName" : "Benchmarks.SimpleStruct"
       },
       {
         "methods" : [
@@ -3175,7 +3175,7 @@
             }
           }
         ],
-        "swiftCallName" : "Address"
+        "swiftCallName" : "Benchmarks.Address"
       },
       {
         "methods" : [
@@ -3212,7 +3212,7 @@
             "name" : "address",
             "type" : {
               "swiftStruct" : {
-                "_0" : "Address"
+                "_0" : "Benchmarks.Address"
               }
             }
           },
@@ -3232,7 +3232,7 @@
             }
           }
         ],
-        "swiftCallName" : "Person"
+        "swiftCallName" : "Benchmarks.Person"
       },
       {
         "methods" : [
@@ -3304,7 +3304,7 @@
             }
           }
         ],
-        "swiftCallName" : "ComplexStruct"
+        "swiftCallName" : "Benchmarks.ComplexStruct"
       },
       {
         "methods" : [
@@ -3333,7 +3333,7 @@
             }
           }
         ],
-        "swiftCallName" : "Point"
+        "swiftCallName" : "Benchmarks.Point"
       }
     ]
   },

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/BridgeJS.swift
@@ -8,13 +8,13 @@
 
 @_spi(BridgeJS) import JavaScriptKit
 
-extension PlayBridgeJSOutput: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PlayBridgeJSOutput {
+extension PlayBridgeJS.PlayBridgeJSOutput: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PlayBridgeJS.PlayBridgeJSOutput {
         let swiftGlue = String.bridgeJSStackPop()
         let importSwiftMacroDecls = String.bridgeJSStackPop()
         let outputDts = String.bridgeJSStackPop()
         let outputJs = String.bridgeJSStackPop()
-        return PlayBridgeJSOutput(outputJs: outputJs, outputDts: outputDts, importSwiftMacroDecls: importSwiftMacroDecls, swiftGlue: swiftGlue)
+        return PlayBridgeJS.PlayBridgeJSOutput(outputJs: outputJs, outputDts: outputDts, importSwiftMacroDecls: importSwiftMacroDecls, swiftGlue: swiftGlue)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -25,50 +25,50 @@ extension PlayBridgeJSOutput: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_PlayBridgeJSOutput(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSOutput(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PlayBridgeJSOutput()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSOutput()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJSOutput")
-fileprivate func _bjs_struct_lower_PlayBridgeJSOutput_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJS_PlayBridgeJSOutput")
+fileprivate func _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSOutput_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PlayBridgeJSOutput_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSOutput_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_PlayBridgeJSOutput(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_PlayBridgeJSOutput_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSOutput(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSOutput_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PlayBridgeJSOutput")
-fileprivate func _bjs_struct_lift_PlayBridgeJSOutput_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PlayBridgeJS_PlayBridgeJSOutput")
+fileprivate func _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSOutput_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_PlayBridgeJSOutput_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSOutput_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_PlayBridgeJSOutput() -> Int32 {
-    return _bjs_struct_lift_PlayBridgeJSOutput_extern()
+@inline(never) fileprivate func _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSOutput() -> Int32 {
+    return _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSOutput_extern()
 }
 
-extension PlayBridgeJSDiagnostic: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PlayBridgeJSDiagnostic {
+extension PlayBridgeJS.PlayBridgeJSDiagnostic: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PlayBridgeJS.PlayBridgeJSDiagnostic {
         let endColumn = Int.bridgeJSStackPop()
         let endLine = Int.bridgeJSStackPop()
         let startColumn = Int.bridgeJSStackPop()
         let startLine = Int.bridgeJSStackPop()
         let message = String.bridgeJSStackPop()
         let file = String.bridgeJSStackPop()
-        return PlayBridgeJSDiagnostic(file: file, message: message, startLine: startLine, startColumn: startColumn, endLine: endLine, endColumn: endColumn)
+        return PlayBridgeJS.PlayBridgeJSDiagnostic(file: file, message: message, startLine: startLine, startColumn: startColumn, endLine: endLine, endColumn: endColumn)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -81,46 +81,46 @@ extension PlayBridgeJSDiagnostic: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_PlayBridgeJSDiagnostic(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSDiagnostic(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PlayBridgeJSDiagnostic()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSDiagnostic()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJSDiagnostic")
-fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJS_PlayBridgeJSDiagnostic")
+fileprivate func _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSDiagnostic_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSDiagnostic_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_PlayBridgeJSDiagnostic_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSDiagnostic(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSDiagnostic_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PlayBridgeJSDiagnostic")
-fileprivate func _bjs_struct_lift_PlayBridgeJSDiagnostic_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PlayBridgeJS_PlayBridgeJSDiagnostic")
+fileprivate func _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSDiagnostic_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_PlayBridgeJSDiagnostic_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSDiagnostic_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_PlayBridgeJSDiagnostic() -> Int32 {
-    return _bjs_struct_lift_PlayBridgeJSDiagnostic_extern()
+@inline(never) fileprivate func _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSDiagnostic() -> Int32 {
+    return _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSDiagnostic_extern()
 }
 
-extension PlayBridgeJSResult: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PlayBridgeJSResult {
-        let diagnostics = [PlayBridgeJSDiagnostic].bridgeJSStackPop()
-        let output = Optional<PlayBridgeJSOutput>.bridgeJSStackPop()
-        return PlayBridgeJSResult(output: output, diagnostics: diagnostics)
+extension PlayBridgeJS.PlayBridgeJSResult: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PlayBridgeJS.PlayBridgeJSResult {
+        let diagnostics = [PlayBridgeJS.PlayBridgeJSDiagnostic].bridgeJSStackPop()
+        let output = Optional<PlayBridgeJS.PlayBridgeJSOutput>.bridgeJSStackPop()
+        return PlayBridgeJS.PlayBridgeJSResult(output: output, diagnostics: diagnostics)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -129,58 +129,58 @@ extension PlayBridgeJSResult: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_PlayBridgeJSResult(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSResult(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PlayBridgeJSResult()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSResult()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJSResult")
-fileprivate func _bjs_struct_lower_PlayBridgeJSResult_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PlayBridgeJS_PlayBridgeJSResult")
+fileprivate func _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSResult_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PlayBridgeJSResult_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSResult_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_PlayBridgeJSResult(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_PlayBridgeJSResult_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSResult(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_PlayBridgeJS_PlayBridgeJSResult_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PlayBridgeJSResult")
-fileprivate func _bjs_struct_lift_PlayBridgeJSResult_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PlayBridgeJS_PlayBridgeJSResult")
+fileprivate func _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSResult_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_PlayBridgeJSResult_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSResult_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_PlayBridgeJSResult() -> Int32 {
-    return _bjs_struct_lift_PlayBridgeJSResult_extern()
+@inline(never) fileprivate func _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSResult() -> Int32 {
+    return _bjs_struct_lift_PlayBridgeJS_PlayBridgeJSResult_extern()
 }
 
-@_expose(wasm, "bjs_PlayBridgeJS_init")
-@_cdecl("bjs_PlayBridgeJS_init")
-public func _bjs_PlayBridgeJS_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_PlayBridgeJS_PlayBridgeJS_init")
+@_cdecl("bjs_PlayBridgeJS_PlayBridgeJS_init")
+public func _bjs_PlayBridgeJS_PlayBridgeJS_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PlayBridgeJS()
+    let ret = PlayBridgeJS.PlayBridgeJS()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PlayBridgeJS_updateDetailed")
-@_cdecl("bjs_PlayBridgeJS_updateDetailed")
-public func _bjs_PlayBridgeJS_updateDetailed(_ _self: UnsafeMutableRawPointer, _ swiftSourceBytes: Int32, _ swiftSourceLength: Int32, _ dtsSourceBytes: Int32, _ dtsSourceLength: Int32) -> Void {
+@_expose(wasm, "bjs_PlayBridgeJS_PlayBridgeJS_updateDetailed")
+@_cdecl("bjs_PlayBridgeJS_PlayBridgeJS_updateDetailed")
+public func _bjs_PlayBridgeJS_PlayBridgeJS_updateDetailed(_ _self: UnsafeMutableRawPointer, _ swiftSourceBytes: Int32, _ swiftSourceLength: Int32, _ dtsSourceBytes: Int32, _ dtsSourceLength: Int32) -> Void {
     #if arch(wasm32)
     do {
-        let ret = try PlayBridgeJS.bridgeJSLiftParameter(_self).updateDetailed(swiftSource: String.bridgeJSLiftParameter(swiftSourceBytes, swiftSourceLength), dtsSource: String.bridgeJSLiftParameter(dtsSourceBytes, dtsSourceLength))
+        let ret = try PlayBridgeJS.PlayBridgeJS.bridgeJSLiftParameter(_self).updateDetailed(swiftSource: String.bridgeJSLiftParameter(swiftSourceBytes, swiftSourceLength), dtsSource: String.bridgeJSLiftParameter(dtsSourceBytes, dtsSourceLength))
         return ret.bridgeJSLowerReturn()
     } catch let error {
         if let error = error.thrownValue.object {
@@ -200,35 +200,35 @@ public func _bjs_PlayBridgeJS_updateDetailed(_ _self: UnsafeMutableRawPointer, _
     #endif
 }
 
-@_expose(wasm, "bjs_PlayBridgeJS_deinit")
-@_cdecl("bjs_PlayBridgeJS_deinit")
-public func _bjs_PlayBridgeJS_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_PlayBridgeJS_PlayBridgeJS_deinit")
+@_cdecl("bjs_PlayBridgeJS_PlayBridgeJS_deinit")
+public func _bjs_PlayBridgeJS_PlayBridgeJS_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PlayBridgeJS>.fromOpaque(pointer).release()
+    Unmanaged<PlayBridgeJS.PlayBridgeJS>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PlayBridgeJS: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension PlayBridgeJS.PlayBridgeJS: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PlayBridgeJS_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_PlayBridgeJS_PlayBridgeJS_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PlayBridgeJS_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_PlayBridgeJS_PlayBridgeJS_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "PlayBridgeJS", name: "bjs_PlayBridgeJS_wrap")
-fileprivate func _bjs_PlayBridgeJS_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "PlayBridgeJS", name: "bjs_PlayBridgeJS_PlayBridgeJS_wrap")
+fileprivate func _bjs_PlayBridgeJS_PlayBridgeJS_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PlayBridgeJS_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_PlayBridgeJS_PlayBridgeJS_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PlayBridgeJS_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PlayBridgeJS_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_PlayBridgeJS_PlayBridgeJS_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_PlayBridgeJS_PlayBridgeJS_wrap_extern(pointer)
 }
 
 #if arch(wasm32)

--- a/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/JavaScript/BridgeJS.json
+++ b/Examples/PlayBridgeJS/Sources/PlayBridgeJS/Generated/JavaScript/BridgeJS.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_PlayBridgeJS_init",
+          "abiName" : "bjs_PlayBridgeJS_PlayBridgeJS_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_PlayBridgeJS_updateDetailed",
+            "abiName" : "bjs_PlayBridgeJS_PlayBridgeJS_updateDetailed",
             "documentation" : "Structured entry point used by the playground so JS doesn't need to parse diagnostics.",
             "effects" : {
               "isAsync" : false,
@@ -48,7 +48,7 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "PlayBridgeJSResult"
+                "_0" : "PlayBridgeJS.PlayBridgeJSResult"
               }
             }
           }
@@ -57,7 +57,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PlayBridgeJS"
+        "swiftCallName" : "PlayBridgeJS.PlayBridgeJS"
       }
     ],
     "enums" : [
@@ -118,7 +118,7 @@
             }
           }
         ],
-        "swiftCallName" : "PlayBridgeJSOutput"
+        "swiftCallName" : "PlayBridgeJS.PlayBridgeJSOutput"
       },
       {
         "methods" : [
@@ -199,7 +199,7 @@
             }
           }
         ],
-        "swiftCallName" : "PlayBridgeJSDiagnostic"
+        "swiftCallName" : "PlayBridgeJS.PlayBridgeJSDiagnostic"
       },
       {
         "methods" : [
@@ -215,7 +215,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "PlayBridgeJSOutput"
+                    "_0" : "PlayBridgeJS.PlayBridgeJSOutput"
                   }
                 },
                 "_1" : "null"
@@ -230,14 +230,14 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "PlayBridgeJSDiagnostic"
+                    "_0" : "PlayBridgeJS.PlayBridgeJSDiagnostic"
                   }
                 }
               }
             }
           }
         ],
-        "swiftCallName" : "PlayBridgeJSResult"
+        "swiftCallName" : "PlayBridgeJS.PlayBridgeJSResult"
       }
     ]
   },

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExportSwift.swift
@@ -789,7 +789,7 @@ public class ExportSwift {
                 try renderSingleExportedConstructor(
                     constructor: constructor,
                     callName: klass.swiftCallName,
-                    returnType: .swiftHeapObject(klass.name)
+                    returnType: .swiftHeapObject(klass.swiftCallName)
                 )
             )
         }
@@ -1614,7 +1614,11 @@ extension BridgeType {
         case .jsObject(let name?): return name
         case .swiftHeapObject(let name): return name
         case .unsafePointer(let ptr): return ptr.swiftType
-        case .swiftProtocol(let name): return "Any\(name)"
+        case .swiftProtocol(let name):
+            // The `Any<Proto>` wrapper struct is declared with the bare protocol name in
+            // the defining module's glue, so strip any module/namespace qualification.
+            let bareName = name.split(separator: ".").last.map(String.init) ?? name
+            return "Any\(bareName)"
         case .void: return "Void"
         case .nullable(let wrappedType, let kind):
             return kind == .null ? "Optional<\(wrappedType.swiftType)>" : "JSUndefinedOr<\(wrappedType.swiftType)>"

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/ExternalModuleIndex.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/ExternalModuleIndex.swift
@@ -31,6 +31,18 @@ public struct ExternalModuleIndex {
             guard let exported = skeleton.exported else { continue }
             var moduleEntries = entriesByModule[moduleName] ?? [:]
 
+            // Skeleton `swiftCallName`s are module-qualified (`Module.[Nesting.]Name`),
+            // but consumers reference dependency types without the module prefix (or with
+            // an explicit module qualifier handled separately), so index them by the
+            // module-stripped dot path while keeping the qualified name in the payload.
+            func lookupPath(for swiftCallName: String) -> String {
+                let prefix = "\(moduleName)."
+                if swiftCallName.hasPrefix(prefix) {
+                    return String(swiftCallName.dropFirst(prefix.count))
+                }
+                return swiftCallName
+            }
+
             func register(dotPath: String, bridgeType: BridgeType) {
                 let externalType = ExternalType(moduleName: moduleName, bridgeType: bridgeType)
                 if moduleEntries[dotPath] == nil {
@@ -40,10 +52,16 @@ public struct ExternalModuleIndex {
             }
 
             for klass in exported.classes {
-                register(dotPath: klass.swiftCallName, bridgeType: .swiftHeapObject(klass.swiftCallName))
+                register(
+                    dotPath: lookupPath(for: klass.swiftCallName),
+                    bridgeType: .swiftHeapObject(klass.swiftCallName)
+                )
             }
             for structDef in exported.structs {
-                register(dotPath: structDef.swiftCallName, bridgeType: .swiftStruct(structDef.swiftCallName))
+                register(
+                    dotPath: lookupPath(for: structDef.swiftCallName),
+                    bridgeType: .swiftStruct(structDef.swiftCallName)
+                )
             }
             for enumDef in exported.enums {
                 let bridgeType: BridgeType
@@ -58,14 +76,14 @@ public struct ExternalModuleIndex {
                 case .namespace:
                     bridgeType = .namespaceEnum(enumDef.swiftCallName)
                 }
-                register(dotPath: enumDef.swiftCallName, bridgeType: bridgeType)
+                register(dotPath: lookupPath(for: enumDef.swiftCallName), bridgeType: bridgeType)
             }
             for proto in exported.protocols {
-                register(dotPath: proto.name, bridgeType: .swiftProtocol(proto.name))
+                register(dotPath: proto.name, bridgeType: .swiftProtocol("\(moduleName).\(proto.name)"))
             }
             for alias in exported.aliases {
                 register(
-                    dotPath: alias.swiftCallName,
+                    dotPath: lookupPath(for: alias.swiftCallName),
                     bridgeType: .alias(name: alias.swiftCallName, underlying: alias.underlying)
                 )
             }

--- a/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSCore/SwiftToSkeleton.swift
@@ -393,12 +393,12 @@ public final class SwiftToSkeleton {
 
         if let typeDecl = typeDeclResolver.resolve(type) {
             if typeDecl.is(ProtocolDeclSyntax.self) {
-                let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: typeDecl, itemName: typeDecl.name.text)
+                let swiftCallName = exportedSwiftCallName(for: typeDecl, itemName: typeDecl.name.text)
                 return .swiftProtocol(swiftCallName)
             }
 
             if let enumDecl = typeDecl.as(EnumDeclSyntax.self) {
-                let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: enumDecl, itemName: enumDecl.name.text)
+                let swiftCallName = exportedSwiftCallName(for: enumDecl, itemName: enumDecl.name.text)
                 if let jsAttribute = enumDecl.attributes.firstJSAttribute,
                     let aliasTarget = extractAliasTarget(from: jsAttribute)
                 {
@@ -437,13 +437,14 @@ public final class SwiftToSkeleton {
             }
 
             if let structDecl = typeDecl.as(StructDeclSyntax.self) {
-                let swiftCallName = SwiftToSkeleton.computeSwiftCallName(
-                    for: structDecl,
-                    itemName: structDecl.name.text
-                )
                 if structDecl.attributes.hasAttribute(name: "JSClass") {
-                    return .jsObject(swiftCallName)
+                    // Imported JS object wrappers are not module-qualified; imports are
+                    // already namespaced per module via the import object.
+                    return .jsObject(
+                        SwiftToSkeleton.computeSwiftCallName(for: structDecl, itemName: structDecl.name.text)
+                    )
                 }
+                let swiftCallName = exportedSwiftCallName(for: structDecl, itemName: structDecl.name.text)
                 if let jsAttribute = structDecl.attributes.firstJSAttribute,
                     let aliasTarget = extractAliasTarget(from: jsAttribute)
                 {
@@ -455,17 +456,17 @@ public final class SwiftToSkeleton {
             guard typeDecl.is(ClassDeclSyntax.self) || typeDecl.is(ActorDeclSyntax.self) else {
                 return nil
             }
-            let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: typeDecl, itemName: typeDecl.name.text)
 
             // A type annotated with @JSClass is a JavaScript object wrapper (imported),
             // even if it is declared as a Swift class.
             if let classDecl = typeDecl.as(ClassDeclSyntax.self), classDecl.attributes.hasAttribute(name: "JSClass") {
-                return .jsObject(swiftCallName)
+                return .jsObject(SwiftToSkeleton.computeSwiftCallName(for: typeDecl, itemName: typeDecl.name.text))
             }
             if let actorDecl = typeDecl.as(ActorDeclSyntax.self), actorDecl.attributes.hasAttribute(name: "JSClass") {
-                return .jsObject(swiftCallName)
+                return .jsObject(SwiftToSkeleton.computeSwiftCallName(for: typeDecl, itemName: typeDecl.name.text))
             }
 
+            let swiftCallName = exportedSwiftCallName(for: typeDecl, itemName: typeDecl.name.text)
             if let classDecl = typeDecl.as(ClassDeclSyntax.self),
                 let jsAttribute = classDecl.attributes.firstJSAttribute,
                 let aliasTarget = extractAliasTarget(from: jsAttribute)
@@ -632,6 +633,17 @@ public final class SwiftToSkeleton {
         }
 
         return nil
+    }
+
+    /// Computes the module-qualified Swift call name for an exported `@JS` type
+    /// (e.g. "MyModule.Networking.API.HTTPServer").
+    ///
+    /// The result serves two purposes:
+    /// - It is a valid Swift expression usable at call sites in the generated glue code.
+    /// - Replacing `.` with `_` yields the type's ABI identity (`abiName`), which is
+    ///   unique across modules because it starts with the module name.
+    func exportedSwiftCallName(for node: some SyntaxProtocol, itemName: String) -> String {
+        "\(moduleName).\(SwiftToSkeleton.computeSwiftCallName(for: node, itemName: itemName))"
     }
 
     /// Computes the full Swift call name by walking up the AST hierarchy to find all parent enums
@@ -1297,7 +1309,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
 
             let isNamespaceEnum = exportedEnumByName[enumKey]?.cases.isEmpty ?? true
             let swiftCallName = exportedEnumByName[enumKey]?.swiftCallName ?? enumName
-            staticContext = isNamespaceEnum ? .namespaceEnum(swiftCallName) : .enumName(enumName)
+            staticContext = isNamespaceEnum ? .namespaceEnum(swiftCallName) : .enumName(swiftCallName)
         case .protocolBody(_, _):
             return nil
         case .structBody(_, let structKey):
@@ -1318,9 +1330,12 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         default:
             classNameForABI = nil
         }
+        // Prefix the namespace context with the module name so top-level function thunk
+        // names are unique across modules. Type-scoped contexts (className/staticContext)
+        // are already module-qualified through the type's abiName/swiftCallName.
         abiName = ABINameGenerator.generateABIName(
             baseName: name,
-            namespace: finalNamespace,
+            namespace: [parent.moduleName] + (finalNamespace ?? []),
             staticContext: isStatic ? staticContext : nil,
             className: classNameForABI
         )
@@ -1647,7 +1662,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             resolvedNamespace: namespaceResult.namespace,
             parentTypeNamespace: computeParentTypeNamespace(for: node)
         )
-        let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: node, itemName: name)
+        let swiftCallName = parent.exportedSwiftCallName(for: node, itemName: name)
         let explicitAccessControl = computeExplicitAtLeastInternalAccessControl(
             for: node,
             message: "Class visibility must be at least internal"
@@ -1742,7 +1757,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
         jsAttribute: AttributeSyntax,
         aliasTarget: TypeSyntax
     ) {
-        let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: node, itemName: node.name.text)
+        let swiftCallName = parent.exportedSwiftCallName(for: node, itemName: node.name.text)
         if extractNamespace(from: jsAttribute) != nil {
             errors.append(
                 DiagnosticError(
@@ -1805,7 +1820,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             parentTypeNamespace: computeParentTypeNamespace(for: node)
         )
         let emitStyle = extractEnumStyle(from: jsAttribute) ?? .const
-        let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: node, itemName: name)
+        let swiftCallName = parent.exportedSwiftCallName(for: node, itemName: name)
         let explicitAccessControl = computeExplicitAtLeastInternalAccessControl(
             for: node,
             message: "Enum visibility must be at least internal"
@@ -1987,7 +2002,7 @@ private final class ExportSwiftAPICollector: SyntaxAnyVisitor {
             resolvedNamespace: namespaceResult.namespace,
             parentTypeNamespace: computeParentTypeNamespace(for: node)
         )
-        let swiftCallName = SwiftToSkeleton.computeSwiftCallName(for: node, itemName: name)
+        let swiftCallName = parent.exportedSwiftCallName(for: node, itemName: name)
         let explicitAccessControl = computeExplicitAtLeastInternalAccessControl(
             for: node,
             message: "Struct visibility must be at least internal"

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/BridgeJSLink.swift
@@ -1220,13 +1220,63 @@ public struct BridgeJSLink {
         return printer.lines.joined(separator: "\n")
     }
 
+    /// Fails the link when two modules export the same public JS name at the same
+    /// namespace path. The internal ABI names are module-qualified and never collide,
+    /// but the public `exports` surface is flat, so same-named exports would silently
+    /// shadow each other.
+    private func validatePublicExportNameUniqueness() throws {
+        struct Entry {
+            let moduleName: String
+            let kind: String
+        }
+        var seen: [String: Entry] = [:]
+
+        func check(namespace: [String]?, name: String, kind: String, moduleName: String) throws {
+            let publicPath = ((namespace ?? []) + [name]).joined(separator: ".")
+            if let existing = seen[publicPath], existing.moduleName != moduleName {
+                throw BridgeJSLinkError(
+                    message:
+                        "Duplicate exported name '\(publicPath)': \(existing.kind) exported by module "
+                        + "'\(existing.moduleName)' conflicts with \(kind) exported by module '\(moduleName)'. "
+                        + "Rename one of them or place them in different namespaces "
+                        + "(e.g. @JS(namespace: \"...\"))."
+                )
+            }
+            if seen[publicPath] == nil {
+                seen[publicPath] = Entry(moduleName: moduleName, kind: kind)
+            }
+        }
+
+        for unified in skeletons {
+            guard let exported = unified.exported else { continue }
+            let moduleName = unified.moduleName
+            for klass in exported.classes {
+                try check(namespace: klass.namespace, name: klass.name, kind: "class", moduleName: moduleName)
+            }
+            for structDef in exported.structs {
+                try check(namespace: structDef.namespace, name: structDef.name, kind: "struct", moduleName: moduleName)
+            }
+            // Namespace enums are skipped: same-named namespaces from different modules
+            // intentionally merge into a single JS namespace object.
+            for enumDef in exported.enums where enumDef.enumType != .namespace {
+                try check(namespace: enumDef.namespace, name: enumDef.name, kind: "enum", moduleName: moduleName)
+            }
+            for function in exported.functions where function.staticContext == nil {
+                try check(namespace: function.namespace, name: function.name, kind: "function", moduleName: moduleName)
+            }
+        }
+    }
+
     public func link() throws -> (outputJs: String, outputDts: String) {
+        try validatePublicExportNameUniqueness()
         intrinsicRegistry.reset()
+        // Keyed by the module-qualified `swiftCallName`, which is what `BridgeType`
+        // payloads carry, so same-named classes from different modules don't collide.
         intrinsicRegistry.classNamespaces = skeletons.reduce(into: [:]) { result, unified in
             guard let skeleton = unified.exported else { return }
             for klass in skeleton.classes {
                 if let namespace = klass.namespace {
-                    result[klass.name] = namespace
+                    result[klass.swiftCallName] = namespace
                 }
             }
         }
@@ -1242,9 +1292,11 @@ public struct BridgeJSLink {
         for skeleton in skeletons.compactMap(\.exported) {
             for enumDef in skeleton.enums where enumDef.enumType == .associatedValue {
                 printer.write(
-                    "const \(enumDef.name)Helpers = __bjs_create\(enumDef.valuesName)Helpers();"
+                    "const \(enumDef.abiName)Helpers = __bjs_create\(enumDef.abiName)Helpers();"
                 )
-                printer.write("\(JSGlueVariableScope.reservedEnumHelpers).\(enumDef.name) = \(enumDef.name)Helpers;")
+                printer.write(
+                    "\(JSGlueVariableScope.reservedEnumHelpers).\(enumDef.abiName) = \(enumDef.abiName)Helpers;"
+                )
                 printer.nextLine()
             }
         }
@@ -3971,23 +4023,25 @@ extension BridgeType {
         case .jsValue:
             return "any"
         case .swiftHeapObject(let name):
-            return name
+            // Exported Swift type payloads are module-qualified; the public TS surface is
+            // flat, so drop the module prefix for display.
+            return Self.dropModulePrefix(name)
         case .unsafePointer:
             return "number"
         case .nullable(let wrappedType, let kind):
             return "\(wrappedType.tsType) | \(kind.absenceLiteral)"
         case .caseEnum(let name):
-            return "\(name)Tag"
+            return "\(Self.dropModulePrefix(name))Tag"
         case .rawValueEnum(let name, _):
-            return "\(name)Tag"
+            return "\(Self.dropModulePrefix(name))Tag"
         case .associatedValueEnum(let name):
-            return "\(name)Tag"
+            return "\(Self.dropModulePrefix(name))Tag"
         case .swiftStruct(let name):
-            return name
+            return Self.dropModulePrefix(name)
         case .namespaceEnum(let name):
-            return name
+            return Self.dropModulePrefix(name)
         case .swiftProtocol(let name):
-            return name
+            return Self.dropModulePrefix(name)
         case .closure(let signature, _):
             let paramTypes = signature.parameters.enumerated().map { index, param in
                 "arg\(index): \(param.tsType)"

--- a/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSLink/JSGlueGen.swift
@@ -151,7 +151,8 @@ struct IntrinsicJSFragment: Sendable {
         /// Whether the fragment has direct access to the SwiftHeapObject classes.
         /// If false, the fragment needs to use `_exports` to access the class.
         var hasDirectAccessToSwiftClass: Bool = true
-        /// Maps class names to their namespace path components for resolving `_exports` access.
+        /// Maps module-qualified class names (`Module.[Nesting.]Name`) to their JS
+        /// namespace path components for resolving `_exports` access.
         var classNamespaces: [String: [String]] = [:]
 
         func with<T>(_ keyPath: WritableKeyPath<PrintCodeContext, T>, _ value: T) -> PrintCodeContext {
@@ -164,20 +165,16 @@ struct IntrinsicJSFragment: Sendable {
             qualifiedName.split(separator: ".").last.map(String.init) ?? qualifiedName
         }
 
-        private func exportsAccess(forClass name: String) -> String {
-            if let namespace = classNamespaces[name], !namespace.isEmpty {
-                let path = namespace.map { ".\($0)" }.joined()
-                return "_exports\(path).\(name)"
-            }
-            return "_exports['\(name)']"
-        }
-
         func classReference(forQualifiedName qualifiedName: String) -> String {
-            if hasDirectAccessToSwiftClass {
-                return unqualifiedClassName(for: qualifiedName)
-            }
             let unqualified = unqualifiedClassName(for: qualifiedName)
-            return exportsAccess(forClass: unqualified)
+            if hasDirectAccessToSwiftClass {
+                return unqualified
+            }
+            if let namespace = classNamespaces[qualifiedName], !namespace.isEmpty {
+                let path = namespace.map { ".\($0)" }.joined()
+                return "_exports\(path).\(unqualified)"
+            }
+            return "_exports['\(unqualified)']"
         }
     }
 
@@ -894,11 +891,17 @@ struct IntrinsicJSFragment: Sendable {
         )
     }
 
+    /// Derives the `enumHelpers`/`structHelpers` registration key from a module-qualified
+    /// type payload (`Module.[Nesting.]Name`). Must match the defining type's `abiName`.
+    static func helperKey(_ fullName: String) -> String {
+        fullName.replacingOccurrences(of: ".", with: "_")
+    }
+
     private static func optionalLiftReturnAssociatedEnum(
         fullName: String,
         kind: JSOptionalKind
     ) -> IntrinsicJSFragment {
-        let base = fullName.components(separatedBy: ".").last ?? fullName
+        let base = helperKey(fullName)
         let absenceLiteral = kind.absenceLiteral
         return IntrinsicJSFragment(
             parameters: [],
@@ -1300,7 +1303,7 @@ struct IntrinsicJSFragment: Sendable {
             return try .optionalLowerParameter(wrappedType: wrappedType, kind: kind)
         case .rawValueEnum(_, .string): return .stringLowerParameter
         case .associatedValueEnum(let fullName):
-            let base = fullName.components(separatedBy: ".").last ?? fullName
+            let base = helperKey(fullName)
             return .associatedEnumLowerParameter(enumBase: base)
         case .swiftStruct(let fullName):
             let base = fullName.replacingOccurrences(of: ".", with: "_")
@@ -1319,7 +1322,10 @@ struct IntrinsicJSFragment: Sendable {
                 }
             )
         case .namespaceEnum(let string):
-            throw BridgeJSLinkError(message: "Namespace enums are not supported to be passed as parameters: \(string)")
+            throw BridgeJSLinkError(
+                message:
+                    "Namespace enums are not supported to be passed as parameters: \(BridgeType.dropModulePrefix(string))"
+            )
         case .array(let elementType):
             return try arrayLower(elementType: elementType)
         case .dictionary(let valueType):
@@ -1360,7 +1366,7 @@ struct IntrinsicJSFragment: Sendable {
             return .optionalLiftReturn(wrappedType: wrappedType, kind: kind)
         case .rawValueEnum(_, .string): return .stringLiftReturn
         case .associatedValueEnum(let fullName):
-            let base = fullName.components(separatedBy: ".").last ?? fullName
+            let base = helperKey(fullName)
             return .associatedEnumLiftReturn(enumBase: base)
         case .swiftStruct(let fullName):
             let base = fullName.replacingOccurrences(of: ".", with: "_")
@@ -1375,7 +1381,8 @@ struct IntrinsicJSFragment: Sendable {
             )
         case .namespaceEnum(let string):
             throw BridgeJSLinkError(
-                message: "Namespace enums are not supported to be returned from functions: \(string)"
+                message:
+                    "Namespace enums are not supported to be returned from functions: \(BridgeType.dropModulePrefix(string))"
             )
         case .array(let elementType):
             return try arrayLift(elementType: elementType)
@@ -1423,7 +1430,7 @@ struct IntrinsicJSFragment: Sendable {
             return try .optionalLiftParameter(wrappedType: wrappedType, kind: kind, context: context)
         case .rawValueEnum(_, .string): return .stringLiftParameter
         case .associatedValueEnum(let fullName):
-            let base = fullName.components(separatedBy: ".").last ?? fullName
+            let base = helperKey(fullName)
             return IntrinsicJSFragment(
                 parameters: ["caseId"],
                 printCode: { arguments, context in
@@ -1465,7 +1472,7 @@ struct IntrinsicJSFragment: Sendable {
         case .namespaceEnum(let string):
             throw BridgeJSLinkError(
                 message:
-                    "Namespace enums are not supported to be passed as parameters to imported JS functions: \(string)"
+                    "Namespace enums are not supported to be passed as parameters to imported JS functions: \(BridgeType.dropModulePrefix(string))"
             )
         case .array(let elementType):
             return try arrayLift(elementType: elementType)
@@ -1519,7 +1526,8 @@ struct IntrinsicJSFragment: Sendable {
             )
         case .namespaceEnum(let string):
             throw BridgeJSLinkError(
-                message: "Namespace enums are not supported to be returned from imported JS functions: \(string)"
+                message:
+                    "Namespace enums are not supported to be returned from imported JS functions: \(BridgeType.dropModulePrefix(string))"
             )
         case .array(let elementType):
             return try arrayLower(elementType: elementType)
@@ -1533,7 +1541,7 @@ struct IntrinsicJSFragment: Sendable {
     // MARK: - Enums Payload Fragments
 
     static func associatedValueLowerReturn(fullName: String) -> IntrinsicJSFragment {
-        let base = fullName.components(separatedBy: ".").last ?? fullName
+        let base = helperKey(fullName)
         return IntrinsicJSFragment(
             parameters: ["value"],
             printCode: { arguments, context in
@@ -1580,13 +1588,14 @@ struct IntrinsicJSFragment: Sendable {
     /// This is placed inside `createInstantiator` alongside struct helpers,
     /// so it has access to `_exports` for class references.
     static func associatedValueEnumHelperFactory(enumDefinition: ExportedEnum) -> IntrinsicJSFragment {
+        let factoryBase = enumDefinition.abiName
         return IntrinsicJSFragment(
             parameters: ["enumName"],
             printCode: { arguments, context in
                 let (scope, printer) = (context.scope, context.printer)
                 let enumName = arguments[0]
 
-                printer.write("const __bjs_create\(enumName)Helpers = () => ({")
+                printer.write("const __bjs_create\(factoryBase)Helpers = () => ({")
                 try printer.indent {
                     printer.write("lower: (value) => {")
                     try printer.indent {
@@ -2021,7 +2030,7 @@ struct IntrinsicJSFragment: Sendable {
                 }
             )
         case .associatedValueEnum(let fullName):
-            let base = fullName.components(separatedBy: ".").last ?? fullName
+            let base = helperKey(fullName)
             return IntrinsicJSFragment(
                 parameters: [],
                 printCode: { arguments, context in
@@ -2144,7 +2153,7 @@ struct IntrinsicJSFragment: Sendable {
             )
 
         case .associatedValueEnum(let fullName):
-            let base = fullName.components(separatedBy: ".").last ?? fullName
+            let base = helperKey(fullName)
             return IntrinsicJSFragment(
                 parameters: ["value"],
                 printCode: { arguments, context in

--- a/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
+++ b/Plugins/BridgeJS/Sources/BridgeJSSkeleton/BridgeJSSkeleton.swift
@@ -5,14 +5,18 @@
 public protocol NamespacedExportedType {
     var name: String { get }
     var namespace: [String]? { get }
+    /// The module-qualified Swift name of the type (e.g. `MyModule.Networking.HTTPServer`).
+    var swiftCallName: String { get }
 }
 
 extension NamespacedExportedType {
+    /// The ABI identity of the type, derived from the module-qualified Swift name so
+    /// that same-named types exported by different modules never collide.
+    ///
+    /// Invariant: for any `BridgeType` payload referencing an exported Swift type,
+    /// `payload.replacingOccurrences(of: ".", with: "_")` equals the defining type's `abiName`.
     public var abiName: String {
-        if let namespace = namespace, !namespace.isEmpty {
-            return (namespace + [name]).joined(separator: "_")
-        }
-        return name
+        swiftCallName.split(separator: ".", omittingEmptySubsequences: false).joined(separator: "_")
     }
 }
 
@@ -31,6 +35,12 @@ public struct ABINameGenerator {
         className: String? = nil
     ) -> String {
 
+        // Context names may be module-qualified Swift names (e.g. `MyModule.Direction`);
+        // sanitize dots so the ABI name stays a valid Swift/wasm identifier.
+        func sanitize(_ name: String) -> String {
+            name.split(separator: ".", omittingEmptySubsequences: false).joined(separator: "_")
+        }
+
         let namespacePart: String?
         if let namespace = namespace, !namespace.isEmpty {
             namespacePart = namespace.joined(separator: "_")
@@ -42,12 +52,12 @@ public struct ABINameGenerator {
         if let staticContext = staticContext {
             switch staticContext {
             case .className(let name), .enumName(let name), .structName(let name):
-                contextPart = name
-            case .namespaceEnum:
-                contextPart = namespacePart
+                contextPart = sanitize(name)
+            case .namespaceEnum(let name):
+                contextPart = sanitize(name)
             }
         } else if let className = className {
-            contextPart = className
+            contextPart = sanitize(className)
         } else {
             contextPart = namespacePart
         }
@@ -1626,6 +1636,17 @@ extension BridgeType {
         }
     }
 
+    /// Returns the public display name for a module-qualified exported Swift type payload.
+    ///
+    /// Exported Swift type payloads are minted as `Module.[Nesting.]Name` (see
+    /// `SwiftToSkeleton.exportedSwiftCallName`). The public JS/TS surface stays flat, so
+    /// display names must not include the leading module component.
+    public static func dropModulePrefix(_ qualifiedName: String) -> String {
+        let components = qualifiedName.split(separator: ".")
+        guard components.count >= 2 else { return qualifiedName }
+        return components.dropFirst().joined(separator: ".")
+    }
+
     public var unaliased: BridgeType {
         switch self {
         case .alias(_, let underlying): return underlying.unaliased
@@ -1712,7 +1733,13 @@ extension BridgeType {
 
     /// Simplified Swift ABI-style mangled name
     /// https://github.com/swiftlang/swift/blob/main/docs/ABI/Mangling.rst#types
+    ///
+    /// Type names may be module-qualified (e.g. `MyModule.Point`); dots are replaced
+    /// with underscores because mangled names are embedded in Swift identifiers.
     public var mangleTypeName: String {
+        func sanitize(_ name: String) -> String {
+            name.split(separator: ".", omittingEmptySubsequences: false).joined(separator: "_")
+        }
         switch self {
         case .integer(let t): return t.mangleTypeName
         case .float: return "Sf"
@@ -1721,12 +1748,13 @@ extension BridgeType {
         case .bool: return "Sb"
         case .void: return "y"
         case .jsObject(let name):
-            let typeName = name ?? "JSObject"
+            let typeName = sanitize(name ?? "JSObject")
             return "\(typeName.count)\(typeName)C"
         case .jsValue:
             return "7JSValueV"
         case .swiftHeapObject(let name):
-            return "\(name.count)\(name)C"
+            let typeName = sanitize(name)
+            return "\(typeName.count)\(typeName)C"
         case .unsafePointer(let ptr):
             func sanitize(_ s: String) -> String {
                 s.filter { $0.isNumber || $0.isLetter }
@@ -1751,11 +1779,14 @@ extension BridgeType {
             .rawValueEnum(let name, _),
             .associatedValueEnum(let name),
             .namespaceEnum(let name):
-            return "\(name.count)\(name)O"
+            let typeName = sanitize(name)
+            return "\(typeName.count)\(typeName)O"
         case .swiftProtocol(let name):
-            return "\(name.count)\(name)P"
+            let typeName = sanitize(name)
+            return "\(typeName.count)\(typeName)P"
         case .swiftStruct(let name):
-            return "\(name.count)\(name)V"
+            let typeName = sanitize(name)
+            return "\(typeName.count)\(typeName)V"
         case .closure(let signature, let useJSTypedClosure):
             let params =
                 signature.parameters.isEmpty
@@ -1770,9 +1801,10 @@ extension BridgeType {
             // Dictionary mangling: "SD" prefix followed by value type (key is always String)
             return "SD\(valueType.mangleTypeName)"
         case .alias(let name, _):
-            // `name` is the namespace-qualified swiftCallName (unique), so the underlying
+            // `name` is the module-qualified swiftCallName (unique), so the underlying
             // representation isn't mangled in - aliases bridge via their JS type's ABI.
-            return "Al\(name.count)\(name)"
+            let typeName = sanitize(name)
+            return "Al\(typeName.count)\(typeName)"
         }
     }
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/BridgeJSLinkTests.swift
@@ -126,6 +126,127 @@ import Testing
         try snapshot(bridgeJSLink: bridgeJSLink, name: "MixedModules")
     }
 
+    private func buildSkeleton(
+        moduleName: String,
+        source: String,
+        inputFilePath: String = "input.swift"
+    ) throws -> BridgeJSSkeleton {
+        let swiftAPI = SwiftToSkeleton(
+            progress: .silent,
+            moduleName: moduleName,
+            exposeToGlobal: false,
+            externalModuleIndex: .empty
+        )
+        swiftAPI.addSourceFile(Parser.parse(source: source), inputFilePath: inputFilePath)
+        return try swiftAPI.finalize()
+    }
+
+    @Test
+    func sameNamedTypesAcrossModulesLinkWithDistinctABINames() throws {
+        // Both modules export a `Point` struct and a `run` function with identical Swift
+        // names but different public JS names (one is namespaced). The module-qualified
+        // ABI names must keep the generated glue (struct hooks, helper keys, and
+        // function thunk names) distinct, while the public JS/TS surface stays flat.
+        let moduleA = try buildSkeleton(
+            moduleName: "ModuleA",
+            source: """
+                @JS public struct Point {
+                    public let x: Double
+                    public let y: Double
+                    @JS public init(x: Double, y: Double) {
+                        self.x = x
+                        self.y = y
+                    }
+                }
+                @JS public enum Validation {
+                    case valid
+                    case invalid(reason: String)
+                }
+                @JS public func run(point: Point, validation: Validation) -> Point {
+                    point
+                }
+                """
+        )
+        let moduleB = try buildSkeleton(
+            moduleName: "ModuleB",
+            source: """
+                @JS(namespace: "Inner") public struct Point {
+                    public let x: Double
+                    public let y: Double
+                    @JS public init(x: Double, y: Double) {
+                        self.x = x
+                        self.y = y
+                    }
+                }
+                @JS(namespace: "Inner") public func run() {
+                }
+                """
+        )
+        let bridgeJSLink = BridgeJSLink(skeletons: [moduleA, moduleB], sharedMemory: false)
+
+        let (outputJs, outputDts) = try bridgeJSLink.link()
+
+        // Struct hooks and helper keys are module-qualified and distinct.
+        #expect(outputJs.contains("swift_js_struct_lower_ModuleA_Point"))
+        #expect(outputJs.contains("swift_js_struct_lower_ModuleB_Point"))
+        #expect(outputJs.contains("structHelpers.ModuleA_Point"))
+        #expect(outputJs.contains("structHelpers.ModuleB_Point"))
+        // Associated-value enum helper keys are module-qualified.
+        #expect(outputJs.contains("enumHelpers.ModuleA_Validation"))
+        // Exported function thunk names are module-qualified and distinct.
+        #expect(outputJs.contains("instance.exports.bjs_ModuleA_run"))
+        #expect(outputJs.contains("instance.exports.bjs_ModuleB_Inner_run"))
+        // The public TS surface stays flat (no module prefixes).
+        #expect(!outputDts.contains("ModuleA"))
+        #expect(!outputDts.contains("ModuleB"))
+
+        try snapshot(bridgeJSLink: bridgeJSLink, name: "SameNamedTypesAcrossModules")
+    }
+
+    @Test
+    func duplicatePublicNamesAcrossModulesProduceDiagnostic() throws {
+        let source = """
+            @JS public struct Point {
+                public let x: Double
+                @JS public init(x: Double) {
+                    self.x = x
+                }
+            }
+            """
+        let moduleA = try buildSkeleton(moduleName: "ModuleA", source: source)
+        let moduleB = try buildSkeleton(moduleName: "ModuleB", source: source)
+        let bridgeJSLink = BridgeJSLink(skeletons: [moduleA, moduleB], sharedMemory: false)
+
+        do {
+            _ = try bridgeJSLink.link()
+            Issue.record("Expected duplicate public export name diagnostic, but linking succeeded")
+        } catch let error as BridgeJSLinkError {
+            #expect(error.message.contains("Duplicate exported name 'Point'"))
+            #expect(error.message.contains("ModuleA"))
+            #expect(error.message.contains("ModuleB"))
+        }
+    }
+
+    @Test
+    func duplicatePublicFunctionNamesAcrossModulesProduceDiagnostic() throws {
+        let moduleA = try buildSkeleton(
+            moduleName: "ModuleA",
+            source: "@JS public func run() {}"
+        )
+        let moduleB = try buildSkeleton(
+            moduleName: "ModuleB",
+            source: "@JS public func run() {}"
+        )
+        let bridgeJSLink = BridgeJSLink(skeletons: [moduleA, moduleB], sharedMemory: false)
+
+        do {
+            _ = try bridgeJSLink.link()
+            Issue.record("Expected duplicate public export name diagnostic, but linking succeeded")
+        } catch let error as BridgeJSLinkError {
+            #expect(error.message.contains("Duplicate exported name 'run'"))
+        }
+    }
+
     @Test
     func perClassIdentityModeFromAnnotation() throws {
         let url = Self.inputsDirectory.appendingPathComponent("IdentityModeClass.swift")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureAsyncDiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/ClosureAsyncDiagnosticsTests.swift
@@ -85,7 +85,7 @@ import Testing
                 """
         )
         let resolveTypes = try #require(app.exported?.asyncPromiseResolveReturnTypes)
-        #expect(resolveTypes.contains { $0.mangleTypeName == "5PointV" })
+        #expect(resolveTypes.contains { $0.mangleTypeName == "9App_PointV" })
     }
 
     @Test
@@ -99,7 +99,7 @@ import Testing
                 """
         )
         let resolveTypes = try #require(app.exported?.asyncPromiseResolveReturnTypes)
-        #expect(resolveTypes.contains { $0.mangleTypeName == "5PointV" })
+        #expect(resolveTypes.contains { $0.mangleTypeName == "9App_PointV" })
     }
 
     @Test
@@ -111,7 +111,7 @@ import Testing
                 """
         )
         let resolveTypes = try #require(app.exported?.asyncPromiseResolveReturnTypes)
-        #expect(resolveTypes.contains { $0.mangleTypeName == "5ShapeO" })
+        #expect(resolveTypes.contains { $0.mangleTypeName == "9App_ShapeO" })
     }
 
     @Test
@@ -125,7 +125,7 @@ import Testing
                 """
         )
         let resolveTypes = try #require(app.exported?.asyncPromiseResolveReturnTypes)
-        #expect(resolveTypes.contains { $0.mangleTypeName == "5ShapeO" })
+        #expect(resolveTypes.contains { $0.mangleTypeName == "9App_ShapeO" })
     }
 
     // MARK: - Utilities

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/CrossModuleResolutionTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/CrossModuleResolutionTests.swift
@@ -33,7 +33,7 @@ import Testing
         )
         #expect(app.usedExternalModules == ["Core"])
         let function = try #require(app.exported?.functions.first(where: { $0.name == "currentVelocity" }))
-        #expect(function.returnType == .swiftStruct("Vector3D"))
+        #expect(function.returnType == .swiftStruct("Core.Vector3D"))
     }
 
     @Test
@@ -56,7 +56,7 @@ import Testing
         )
         #expect(app.usedExternalModules == ["Core"])
         let function = try #require(app.exported?.functions.first(where: { $0.name == "makeEmitter" }))
-        #expect(function.returnType == .swiftHeapObject("Emitter"))
+        #expect(function.returnType == .swiftHeapObject("Core.Emitter"))
     }
 
     @Test
@@ -83,7 +83,7 @@ import Testing
         )
         #expect(app.usedExternalModules == ["Core"])
         let function = try #require(app.exported?.functions.first(where: { $0.name == "unitBox" }))
-        #expect(function.returnType == .swiftStruct("Geometry.BoundingBox"))
+        #expect(function.returnType == .swiftStruct("Core.Geometry.BoundingBox"))
     }
 
     @Test
@@ -104,7 +104,7 @@ import Testing
             dependencies: [(moduleName: "Core", skeleton: core)]
         )
         let function = try #require(app.exported?.functions.first(where: { $0.name == "fromCore" }))
-        #expect(function.returnType == .swiftStruct("Vector3D"))
+        #expect(function.returnType == .swiftStruct("Core.Vector3D"))
     }
 
     @Test
@@ -125,8 +125,8 @@ import Testing
             dependencies: [(moduleName: "Core", skeleton: core)]
         )
         let function = try #require(app.exported?.functions.first(where: { $0.name == "scatter" }))
-        #expect(function.returnType == .nullable(.swiftStruct("Point"), .null))
-        #expect(function.parameters.first?.type == .array(.nullable(.swiftStruct("Point"), .null)))
+        #expect(function.returnType == .nullable(.swiftStruct("Core.Point"), .null))
+        #expect(function.parameters.first?.type == .array(.nullable(.swiftStruct("Core.Point"), .null)))
     }
 
     // MARK: - Diagnostics
@@ -243,8 +243,8 @@ import Testing
             dependencies: [(moduleName: "Core", skeleton: core)]
         )
         let function = try #require(app.exported?.functions.first(where: { $0.name == "opposite" }))
-        #expect(function.returnType == .caseEnum("Direction"))
-        #expect(function.parameters.first?.type == .caseEnum("Direction"))
+        #expect(function.returnType == .caseEnum("Core.Direction"))
+        #expect(function.parameters.first?.type == .caseEnum("Core.Direction"))
     }
 
     @Test
@@ -261,7 +261,7 @@ import Testing
             dependencies: [(moduleName: "Core", skeleton: core)]
         )
         let function = try #require(app.exported?.functions.first(where: { $0.name == "describe" }))
-        #expect(function.parameters.first?.type == .rawValueEnum("HTTPMethod", .string))
+        #expect(function.parameters.first?.type == .rawValueEnum("Core.HTTPMethod", .string))
     }
 
     @Test
@@ -278,7 +278,7 @@ import Testing
             dependencies: [(moduleName: "Core", skeleton: core)]
         )
         let function = try #require(app.exported?.functions.first(where: { $0.name == "area" }))
-        #expect(function.parameters.first?.type == .associatedValueEnum("Shape"))
+        #expect(function.parameters.first?.type == .associatedValueEnum("Core.Shape"))
     }
 
     @Test
@@ -299,7 +299,7 @@ import Testing
             dependencies: [(moduleName: "Core", skeleton: core)]
         )
         let function = try #require(app.exported?.functions.first(where: { $0.name == "dummy" }))
-        #expect(function.returnType == .nullable(.namespaceEnum("Utils"), .null))
+        #expect(function.returnType == .nullable(.namespaceEnum("Core.Utils"), .null))
     }
 
     // MARK: - Structural positions
@@ -318,7 +318,7 @@ import Testing
             dependencies: [(moduleName: "Core", skeleton: core)]
         )
         let function = try #require(app.exported?.functions.first(where: { $0.name == "names" }))
-        #expect(function.parameters.first?.type == .dictionary(.swiftStruct("Vector3D")))
+        #expect(function.parameters.first?.type == .dictionary(.swiftStruct("Core.Vector3D")))
     }
 
     @Test
@@ -339,7 +339,7 @@ import Testing
         )
         let particle = try #require(app.exported?.structs.first(where: { $0.name == "Particle" }))
         let positionProperty = try #require(particle.properties.first(where: { $0.name == "position" }))
-        #expect(positionProperty.type == .swiftStruct("Vector3D"))
+        #expect(positionProperty.type == .swiftStruct("Core.Vector3D"))
         #expect(app.usedExternalModules == ["Core"])
     }
 
@@ -399,8 +399,8 @@ import Testing
             ]
         )
         let function = try #require(app.exported?.functions.first(where: { $0.name == "position" }))
-        #expect(function.returnType == .swiftStruct("Vector3D"))
-        #expect(function.parameters.first?.type == .swiftStruct("Particle"))
+        #expect(function.returnType == .swiftStruct("Core.Vector3D"))
+        #expect(function.parameters.first?.type == .swiftStruct("Domain.Particle"))
         #expect(app.usedExternalModules == ["Core", "Domain"])
     }
 

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/DiagnosticsTests.swift
@@ -188,7 +188,7 @@ import Testing
         #expect(skeleton.exported != nil)
         let structs = skeleton.exported?.structs ?? []
         #expect(structs.count == 1)
-        #expect(structs.first?.swiftCallName == "User.Stats")
+        #expect(structs.first?.swiftCallName == "TestModule.User.Stats")
     }
 
     @Test
@@ -211,7 +211,7 @@ import Testing
         #expect(skeleton.exported != nil)
         let classes = skeleton.exported?.classes ?? []
         #expect(classes.count == 1)
-        #expect(classes.first?.swiftCallName == "Container.Inner")
+        #expect(classes.first?.swiftCallName == "TestModule.Container.Inner")
     }
 
     @Test

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.json
@@ -2,23 +2,23 @@
   "exported" : {
     "aliases" : [
       {
-        "swiftCallName" : "Polygon",
+        "swiftCallName" : "TestModule.Polygon",
         "underlying" : {
           "swiftHeapObject" : {
-            "_0" : "PolygonReference"
+            "_0" : "TestModule.PolygonReference"
           }
         }
       },
       {
-        "swiftCallName" : "Tag",
+        "swiftCallName" : "TestModule.Tag",
         "underlying" : {
           "swiftHeapObject" : {
-            "_0" : "TagReference"
+            "_0" : "TestModule.TagReference"
           }
         }
       },
       {
-        "swiftCallName" : "Tagged",
+        "swiftCallName" : "TestModule.Tagged",
         "underlying" : {
           "string" : {
 
@@ -26,7 +26,7 @@
         }
       },
       {
-        "swiftCallName" : "Canvas",
+        "swiftCallName" : "TestModule.Canvas",
         "underlying" : {
           "jsObject" : {
             "_0" : "Surface"
@@ -34,15 +34,15 @@
         }
       },
       {
-        "swiftCallName" : "AliasedTag",
+        "swiftCallName" : "TestModule.AliasedTag",
         "underlying" : {
           "associatedValueEnum" : {
-            "_0" : "InnerTag"
+            "_0" : "TestModule.InnerTag"
           }
         }
       },
       {
-        "swiftCallName" : "UserId",
+        "swiftCallName" : "TestModule.UserId",
         "underlying" : {
           "integer" : {
             "_0" : {
@@ -56,7 +56,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_PolygonReference_init",
+          "abiName" : "bjs_TestModule_PolygonReference_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -68,10 +68,10 @@
               "name" : "underlying",
               "type" : {
                 "alias" : {
-                  "name" : "Polygon",
+                  "name" : "TestModule.Polygon",
                   "underlying" : {
                     "swiftHeapObject" : {
-                      "_0" : "PolygonReference"
+                      "_0" : "TestModule.PolygonReference"
                     }
                   }
                 }
@@ -81,7 +81,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_PolygonReference_snapshot",
+            "abiName" : "bjs_TestModule_PolygonReference_snapshot",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -93,17 +93,17 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "TestModule.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "TestModule.PolygonReference"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_PolygonReference_merge",
+            "abiName" : "bjs_TestModule_PolygonReference_merge",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -116,10 +116,10 @@
                 "name" : "other",
                 "type" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "TestModule.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "TestModule.PolygonReference"
                       }
                     }
                   }
@@ -128,17 +128,17 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "TestModule.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "TestModule.PolygonReference"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_PolygonReference_static_origin",
+            "abiName" : "bjs_TestModule_PolygonReference_static_origin",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -150,17 +150,17 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "TestModule.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "TestModule.PolygonReference"
                   }
                 }
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "PolygonReference"
+                "_0" : "TestModule_PolygonReference"
               }
             }
           }
@@ -169,11 +169,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PolygonReference"
+        "swiftCallName" : "TestModule.PolygonReference"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_TagReference_init",
+          "abiName" : "bjs_TestModule_TagReference_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -185,10 +185,10 @@
               "name" : "underlying",
               "type" : {
                 "alias" : {
-                  "name" : "Tag",
+                  "name" : "TestModule.Tag",
                   "underlying" : {
                     "swiftHeapObject" : {
-                      "_0" : "TagReference"
+                      "_0" : "TestModule.TagReference"
                     }
                   }
                 }
@@ -203,7 +203,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "TagReference"
+        "swiftCallName" : "TestModule.TagReference"
       }
     ],
     "enums" : [
@@ -239,14 +239,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "InnerTag",
+        "swiftCallName" : "TestModule.InnerTag",
         "tsFullPath" : "InnerTag"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_roundtripPolygon",
+        "abiName" : "bjs_TestModule_roundtripPolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -259,10 +259,10 @@
             "name" : "polygon",
             "type" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "TestModule.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "TestModule.PolygonReference"
                   }
                 }
               }
@@ -271,17 +271,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Polygon",
+            "name" : "TestModule.Polygon",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "PolygonReference"
+                "_0" : "TestModule.PolygonReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_optionalPolygon",
+        "abiName" : "bjs_TestModule_optionalPolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -296,10 +296,10 @@
               "nullable" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "TestModule.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "TestModule.PolygonReference"
                       }
                     }
                   }
@@ -313,10 +313,10 @@
           "nullable" : {
             "_0" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "TestModule.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "TestModule.PolygonReference"
                   }
                 }
               }
@@ -326,7 +326,7 @@
         }
       },
       {
-        "abiName" : "bjs_polygonArray",
+        "abiName" : "bjs_TestModule_polygonArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -341,10 +341,10 @@
               "array" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "TestModule.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "TestModule.PolygonReference"
                       }
                     }
                   }
@@ -357,10 +357,10 @@
           "array" : {
             "_0" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "TestModule.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "TestModule.PolygonReference"
                   }
                 }
               }
@@ -369,7 +369,7 @@
         }
       },
       {
-        "abiName" : "bjs_validatePolygon",
+        "abiName" : "bjs_TestModule_validatePolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -382,10 +382,10 @@
             "name" : "polygon",
             "type" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "TestModule.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "TestModule.PolygonReference"
                   }
                 }
               }
@@ -394,17 +394,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Polygon",
+            "name" : "TestModule.Polygon",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "PolygonReference"
+                "_0" : "TestModule.PolygonReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_makeTag",
+        "abiName" : "bjs_TestModule_makeTag",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -424,17 +424,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Tag",
+            "name" : "TestModule.Tag",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "TagReference"
+                "_0" : "TestModule.TagReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripTags",
+        "abiName" : "bjs_TestModule_roundtripTags",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -451,10 +451,10 @@
                   "nullable" : {
                     "_0" : {
                       "alias" : {
-                        "name" : "AliasedTag",
+                        "name" : "TestModule.AliasedTag",
                         "underlying" : {
                           "associatedValueEnum" : {
-                            "_0" : "InnerTag"
+                            "_0" : "TestModule.InnerTag"
                           }
                         }
                       }
@@ -472,10 +472,10 @@
               "nullable" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "AliasedTag",
+                    "name" : "TestModule.AliasedTag",
                     "underlying" : {
                       "associatedValueEnum" : {
-                        "_0" : "InnerTag"
+                        "_0" : "TestModule.InnerTag"
                       }
                     }
                   }
@@ -487,7 +487,7 @@
         }
       },
       {
-        "abiName" : "bjs_describeUser",
+        "abiName" : "bjs_TestModule_describeUser",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -500,14 +500,14 @@
             "name" : "owner",
             "type" : {
               "swiftProtocol" : {
-                "_0" : "HasOptionalUserId"
+                "_0" : "TestModule.HasOptionalUserId"
               }
             }
           }
         ],
         "returnType" : {
           "swiftProtocol" : {
-            "_0" : "HasOptionalUserId"
+            "_0" : "TestModule.HasOptionalUserId"
           }
         }
       }
@@ -526,7 +526,7 @@
               "nullable" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "UserId",
+                    "name" : "TestModule.UserId",
                     "underlying" : {
                       "integer" : {
                         "_0" : {
@@ -565,7 +565,7 @@
                 "name" : "tagged",
                 "type" : {
                   "alias" : {
-                    "name" : "Tagged",
+                    "name" : "TestModule.Tagged",
                     "underlying" : {
                       "string" : {
 
@@ -596,7 +596,7 @@
                   "nullable" : {
                     "_0" : {
                       "alias" : {
-                        "name" : "Tagged",
+                        "name" : "TestModule.Tagged",
                         "underlying" : {
                           "string" : {
 
@@ -628,7 +628,7 @@
                 "name" : "tagged",
                 "type" : {
                   "alias" : {
-                    "name" : "Tagged",
+                    "name" : "TestModule.Tagged",
                     "underlying" : {
                       "string" : {
 
@@ -640,7 +640,7 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Tagged",
+                "name" : "TestModule.Tagged",
                 "underlying" : {
                   "string" : {
 
@@ -664,7 +664,7 @@
               "nullable" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "Canvas",
+                    "name" : "TestModule.Canvas",
                     "underlying" : {
                       "jsObject" : {
                         "_0" : "Surface"

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Alias.swift
@@ -1,11 +1,11 @@
 struct AnyHasOptionalUserId: HasOptionalUserId, _BridgedSwiftProtocolWrapper {
     let jsObject: JSObject
 
-    var userId: Optional<UserId> {
+    var userId: Optional<TestModule.UserId> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_HasOptionalUserId_userId_get(jsObjectValue)
-            return Optional<UserId>.bridgeJSLiftReturnFromSideChannel()
+            return Optional<TestModule.UserId>.bridgeJSLiftReturnFromSideChannel()
         }
     }
 
@@ -26,15 +26,15 @@ fileprivate func bjs_HasOptionalUserId_userId_get_extern(_ jsObject: Int32) -> V
     return bjs_HasOptionalUserId_userId_get_extern(jsObject)
 }
 
-extension InnerTag: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> InnerTag {
+extension TestModule.InnerTag: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.InnerTag {
         switch caseId {
         case 0:
             return .payload(Int.bridgeJSStackPop())
         case 1:
             return .empty
         default:
-            fatalError("Unknown InnerTag case ID: \(caseId)")
+            fatalError("Unknown TestModule.InnerTag case ID: \(caseId)")
         }
     }
 
@@ -49,45 +49,45 @@ extension InnerTag: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-@_expose(wasm, "bjs_roundtripPolygon")
-@_cdecl("bjs_roundtripPolygon")
-public func _bjs_roundtripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_roundtripPolygon")
+@_cdecl("bjs_TestModule_roundtripPolygon")
+public func _bjs_TestModule_roundtripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundtripPolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+    let ret = roundtripPolygon(_: TestModule.Polygon.bridgeJSLiftParameter(polygon))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_optionalPolygon")
-@_cdecl("bjs_optionalPolygon")
-public func _bjs_optionalPolygon(_ polygonIsSome: Int32, _ polygonValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_optionalPolygon")
+@_cdecl("bjs_TestModule_optionalPolygon")
+public func _bjs_TestModule_optionalPolygon(_ polygonIsSome: Int32, _ polygonValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = optionalPolygon(_: Optional<Polygon>.bridgeJSLiftParameter(polygonIsSome, polygonValue))
+    let ret = optionalPolygon(_: Optional<TestModule.Polygon>.bridgeJSLiftParameter(polygonIsSome, polygonValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_polygonArray")
-@_cdecl("bjs_polygonArray")
-public func _bjs_polygonArray() -> Void {
+@_expose(wasm, "bjs_TestModule_polygonArray")
+@_cdecl("bjs_TestModule_polygonArray")
+public func _bjs_TestModule_polygonArray() -> Void {
     #if arch(wasm32)
-    let ret = polygonArray(_: [Polygon].bridgeJSStackPop())
+    let ret = polygonArray(_: [TestModule.Polygon].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_validatePolygon")
-@_cdecl("bjs_validatePolygon")
-public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_validatePolygon")
+@_cdecl("bjs_TestModule_validatePolygon")
+public func _bjs_TestModule_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     do {
-        let ret = try validatePolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+        let ret = try validatePolygon(_: TestModule.Polygon.bridgeJSLiftParameter(polygon))
         return ret.bridgeJSLowerReturn()
     } catch let error {
         if let error = error.thrownValue.object {
@@ -107,9 +107,9 @@ public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMu
     #endif
 }
 
-@_expose(wasm, "bjs_makeTag")
-@_cdecl("bjs_makeTag")
-public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_makeTag")
+@_cdecl("bjs_TestModule_makeTag")
+public func _bjs_TestModule_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = makeTag(_: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -118,20 +118,20 @@ public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutab
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripTags")
-@_cdecl("bjs_roundtripTags")
-public func _bjs_roundtripTags() -> Void {
+@_expose(wasm, "bjs_TestModule_roundtripTags")
+@_cdecl("bjs_TestModule_roundtripTags")
+public func _bjs_TestModule_roundtripTags() -> Void {
     #if arch(wasm32)
-    let ret = roundtripTags(_: [Optional<AliasedTag>].bridgeJSStackPop())
+    let ret = roundtripTags(_: [Optional<TestModule.AliasedTag>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_describeUser")
-@_cdecl("bjs_describeUser")
-public func _bjs_describeUser(_ owner: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_describeUser")
+@_cdecl("bjs_TestModule_describeUser")
+public func _bjs_TestModule_describeUser(_ owner: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = describeUser(_: AnyHasOptionalUserId.bridgeJSLiftParameter(owner)) as! _BridgedSwiftProtocolExportable
     return ret.bridgeJSLowerAsProtocolReturn()
@@ -140,134 +140,134 @@ public func _bjs_describeUser(_ owner: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_init")
-@_cdecl("bjs_PolygonReference_init")
-public func _bjs_PolygonReference_init(_ underlying: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PolygonReference_init")
+@_cdecl("bjs_TestModule_PolygonReference_init")
+public func _bjs_TestModule_PolygonReference_init(_ underlying: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference(underlying: Polygon.bridgeJSLiftParameter(underlying))
+    let ret = TestModule.PolygonReference(underlying: TestModule.Polygon.bridgeJSLiftParameter(underlying))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_snapshot")
-@_cdecl("bjs_PolygonReference_snapshot")
-public func _bjs_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PolygonReference_snapshot")
+@_cdecl("bjs_TestModule_PolygonReference_snapshot")
+public func _bjs_TestModule_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference.bridgeJSLiftParameter(_self).snapshot()
+    let ret = TestModule.PolygonReference.bridgeJSLiftParameter(_self).snapshot()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_merge")
-@_cdecl("bjs_PolygonReference_merge")
-public func _bjs_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ other: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PolygonReference_merge")
+@_cdecl("bjs_TestModule_PolygonReference_merge")
+public func _bjs_TestModule_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ other: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference.bridgeJSLiftParameter(_self).merge(_: Polygon.bridgeJSLiftParameter(other))
+    let ret = TestModule.PolygonReference.bridgeJSLiftParameter(_self).merge(_: TestModule.Polygon.bridgeJSLiftParameter(other))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_static_origin")
-@_cdecl("bjs_PolygonReference_static_origin")
-public func _bjs_PolygonReference_static_origin() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PolygonReference_static_origin")
+@_cdecl("bjs_TestModule_PolygonReference_static_origin")
+public func _bjs_TestModule_PolygonReference_static_origin() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference.origin()
+    let ret = TestModule.PolygonReference.origin()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_deinit")
-@_cdecl("bjs_PolygonReference_deinit")
-public func _bjs_PolygonReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PolygonReference_deinit")
+@_cdecl("bjs_TestModule_PolygonReference_deinit")
+public func _bjs_TestModule_PolygonReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PolygonReference>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.PolygonReference>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PolygonReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.PolygonReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_PolygonReference_wrap")
-fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_PolygonReference_wrap")
+fileprivate func _bjs_TestModule_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PolygonReference_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_PolygonReference_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_TagReference_init")
-@_cdecl("bjs_TagReference_init")
-public func _bjs_TagReference_init(_ underlying: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_TagReference_init")
+@_cdecl("bjs_TestModule_TagReference_init")
+public func _bjs_TestModule_TagReference_init(_ underlying: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = TagReference(underlying: Tag.bridgeJSLiftParameter(underlying))
+    let ret = TestModule.TagReference(underlying: TestModule.Tag.bridgeJSLiftParameter(underlying))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TagReference_deinit")
-@_cdecl("bjs_TagReference_deinit")
-public func _bjs_TagReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_TagReference_deinit")
+@_cdecl("bjs_TestModule_TagReference_deinit")
+public func _bjs_TestModule_TagReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<TagReference>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.TagReference>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension TagReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.TagReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_TagReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_TagReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_TagReference_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_TagReference_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_TagReference_wrap")
-fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_TagReference_wrap")
+fileprivate func _bjs_TestModule_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_TagReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_TagReference_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_TagReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_TagReference_wrap_extern(pointer)
 }
 
-extension Polygon: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension TestModule.Polygon: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension Tag: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension TestModule.Tag: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension Tagged: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension TestModule.Tagged: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension Canvas: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension TestModule.Canvas: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension AliasedTag: _BridgedSwiftAlias, _BridgedSwiftAssociatedValueEnum {}
+extension TestModule.AliasedTag: _BridgedSwiftAlias, _BridgedSwiftAssociatedValueEnum {}
 
-extension UserId: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension TestModule.UserId: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
 #if arch(wasm32)
 @_extern(wasm, module: "TestModule", name: "bjs_acceptTagged")
@@ -281,7 +281,7 @@ fileprivate func bjs_acceptTagged_extern(_ taggedBytes: Int32, _ taggedLength: I
     return bjs_acceptTagged_extern(taggedBytes, taggedLength)
 }
 
-func _$acceptTagged(_ tagged: Tagged) throws(JSException) -> Void {
+func _$acceptTagged(_ tagged: TestModule.Tagged) throws(JSException) -> Void {
     tagged.bridgeJSWithLoweredParameter { (taggedBytes, taggedLength) in
         bjs_acceptTagged(taggedBytes, taggedLength)
     }
@@ -302,7 +302,7 @@ fileprivate func bjs_acceptOptionalTagged_extern(_ taggedIsSome: Int32, _ tagged
     return bjs_acceptOptionalTagged_extern(taggedIsSome, taggedBytes, taggedLength)
 }
 
-func _$acceptOptionalTagged(_ tagged: Optional<Tagged>) throws(JSException) -> Void {
+func _$acceptOptionalTagged(_ tagged: Optional<TestModule.Tagged>) throws(JSException) -> Void {
     tagged.bridgeJSWithLoweredParameter { (taggedIsSome, taggedBytes, taggedLength) in
         bjs_acceptOptionalTagged(taggedIsSome, taggedBytes, taggedLength)
     }
@@ -323,7 +323,7 @@ fileprivate func bjs_roundtripTagged_extern(_ taggedBytes: Int32, _ taggedLength
     return bjs_roundtripTagged_extern(taggedBytes, taggedLength)
 }
 
-func _$roundtripTagged(_ tagged: Tagged) throws(JSException) -> Tagged {
+func _$roundtripTagged(_ tagged: TestModule.Tagged) throws(JSException) -> TestModule.Tagged {
     let ret0 = tagged.bridgeJSWithLoweredParameter { (taggedBytes, taggedLength) in
         let ret = bjs_roundtripTagged(taggedBytes, taggedLength)
         return ret
@@ -332,7 +332,7 @@ func _$roundtripTagged(_ tagged: Tagged) throws(JSException) -> Tagged {
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Tagged.bridgeJSLiftReturn(ret)
+    return TestModule.Tagged.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)
@@ -347,12 +347,12 @@ fileprivate func bjs_produceOptionalCanvas_extern() -> Void {
     return bjs_produceOptionalCanvas_extern()
 }
 
-func _$produceOptionalCanvas() throws(JSException) -> Optional<Canvas> {
+func _$produceOptionalCanvas() throws(JSException) -> Optional<TestModule.Canvas> {
     bjs_produceOptionalCanvas()
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<Canvas>.bridgeJSLiftReturn()
+    return Optional<TestModule.Canvas>.bridgeJSLiftReturn()
 }
 
 #if arch(wasm32)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.json
@@ -2,10 +2,10 @@
   "exported" : {
     "aliases" : [
       {
-        "swiftCallName" : "Polygon",
+        "swiftCallName" : "TestModule.Polygon",
         "underlying" : {
           "swiftHeapObject" : {
-            "_0" : "PolygonReference"
+            "_0" : "TestModule.PolygonReference"
           }
         }
       }
@@ -13,7 +13,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_PolygonReference_init",
+          "abiName" : "bjs_TestModule_PolygonReference_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -41,7 +41,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PolygonReference"
+        "swiftCallName" : "TestModule.PolygonReference"
       }
     ],
     "enums" : [
@@ -50,7 +50,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_makePolygonFactory",
+        "abiName" : "bjs_TestModule_makePolygonFactory",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -65,17 +65,17 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuley_Al7Polygon",
+              "mangleName" : "10TestModuley_Al18TestModule_Polygon",
               "moduleName" : "TestModule",
               "parameters" : [
 
               ],
               "returnType" : {
                 "alias" : {
-                  "name" : "Polygon",
+                  "name" : "TestModule.Polygon",
                   "underlying" : {
                     "swiftHeapObject" : {
-                      "_0" : "PolygonReference"
+                      "_0" : "TestModule.PolygonReference"
                     }
                   }
                 }
@@ -87,7 +87,7 @@
         }
       },
       {
-        "abiName" : "bjs_makePolygonInspector",
+        "abiName" : "bjs_TestModule_makePolygonInspector",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -102,15 +102,15 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuleAl7Polygon_Si",
+              "mangleName" : "10TestModuleAl18TestModule_Polygon_Si",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "TestModule.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "TestModule.PolygonReference"
                       }
                     }
                   }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AliasInClosure.swift
@@ -1,35 +1,35 @@
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si")
-fileprivate func invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleAl18TestModule_Polygon_Si")
+fileprivate func invoke_js_callback_TestModule_10TestModuleAl18TestModule_Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModuleAl18TestModule_Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleAl18TestModule_Polygon_Si(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModuleAl18TestModule_Polygon_Si_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleAl7Polygon_Si")
-fileprivate func make_swift_closure_TestModule_10TestModuleAl7Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si")
+fileprivate func make_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuleAl7Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleAl7Polygon_Si_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuleAl7Polygon_Si {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Polygon) -> Int {
+private enum _BJS_Closure_10TestModuleAl18TestModule_Polygon_Si {
+    static func bridgeJSLift(_ callbackId: Int32) -> (TestModule.Polygon) -> Int {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0Pointer = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si(callbackValue, param0Pointer)
+            let ret = invoke_js_callback_TestModule_10TestModuleAl18TestModule_Polygon_Si(callbackValue, param0Pointer)
             return Int.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -38,10 +38,10 @@ private enum _BJS_Closure_10TestModuleAl7Polygon_Si {
     }
 }
 
-extension JSTypedClosure where Signature == (Polygon) -> Int {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Polygon) -> Int) {
+extension JSTypedClosure where Signature == (TestModule.Polygon) -> Int {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (TestModule.Polygon) -> Int) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleAl7Polygon_Si,
+            makeClosure: make_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si,
             body: body,
             fileID: fileID,
             line: line
@@ -49,12 +49,12 @@ extension JSTypedClosure where Signature == (Polygon) -> Int {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si")
-public func _invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si")
+public func _invoke_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Polygon) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Polygon.bridgeJSLiftParameter(param0))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(TestModule.Polygon) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(TestModule.Polygon.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -62,37 +62,37 @@ public func _invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si(_ boxPtr:
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuley_Al7Polygon")
-fileprivate func invoke_js_callback_TestModule_10TestModuley_Al7Polygon_extern(_ callback: Int32) -> UnsafeMutableRawPointer
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuley_Al18TestModule_Polygon")
+fileprivate func invoke_js_callback_TestModule_10TestModuley_Al18TestModule_Polygon_extern(_ callback: Int32) -> UnsafeMutableRawPointer
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuley_Al7Polygon_extern(_ callback: Int32) -> UnsafeMutableRawPointer {
+fileprivate func invoke_js_callback_TestModule_10TestModuley_Al18TestModule_Polygon_extern(_ callback: Int32) -> UnsafeMutableRawPointer {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuley_Al7Polygon(_ callback: Int32) -> UnsafeMutableRawPointer {
-    return invoke_js_callback_TestModule_10TestModuley_Al7Polygon_extern(callback)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuley_Al18TestModule_Polygon(_ callback: Int32) -> UnsafeMutableRawPointer {
+    return invoke_js_callback_TestModule_10TestModuley_Al18TestModule_Polygon_extern(callback)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuley_Al7Polygon")
-fileprivate func make_swift_closure_TestModule_10TestModuley_Al7Polygon_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon")
+fileprivate func make_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuley_Al7Polygon_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuley_Al7Polygon(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuley_Al7Polygon_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuley_Al7Polygon {
-    static func bridgeJSLift(_ callbackId: Int32) -> () -> Polygon {
+private enum _BJS_Closure_10TestModuley_Al18TestModule_Polygon {
+    static func bridgeJSLift(_ callbackId: Int32) -> () -> TestModule.Polygon {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModuley_Al7Polygon(callbackValue)
-            return Polygon.bridgeJSLiftReturn(ret)
+            let ret = invoke_js_callback_TestModule_10TestModuley_Al18TestModule_Polygon(callbackValue)
+            return TestModule.Polygon.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -100,10 +100,10 @@ private enum _BJS_Closure_10TestModuley_Al7Polygon {
     }
 }
 
-extension JSTypedClosure where Signature == () -> Polygon {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping () -> Polygon) {
+extension JSTypedClosure where Signature == () -> TestModule.Polygon {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping () -> TestModule.Polygon) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuley_Al7Polygon,
+            makeClosure: make_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon,
             body: body,
             fileID: fileID,
             line: line
@@ -111,11 +111,11 @@ extension JSTypedClosure where Signature == () -> Polygon {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuley_Al7Polygon")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuley_Al7Polygon")
-public func _invoke_swift_closure_TestModule_10TestModuley_Al7Polygon(_ boxPtr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon")
+public func _invoke_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon(_ boxPtr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> Polygon>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> TestModule.Polygon>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure()
     return result.bridgeJSLowerReturn()
     #else
@@ -123,9 +123,9 @@ public func _invoke_swift_closure_TestModule_10TestModuley_Al7Polygon(_ boxPtr: 
     #endif
 }
 
-@_expose(wasm, "bjs_makePolygonFactory")
-@_cdecl("bjs_makePolygonFactory")
-public func _bjs_makePolygonFactory() -> Int32 {
+@_expose(wasm, "bjs_TestModule_makePolygonFactory")
+@_cdecl("bjs_TestModule_makePolygonFactory")
+public func _bjs_TestModule_makePolygonFactory() -> Int32 {
     #if arch(wasm32)
     let ret = makePolygonFactory()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -134,9 +134,9 @@ public func _bjs_makePolygonFactory() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_makePolygonInspector")
-@_cdecl("bjs_makePolygonInspector")
-public func _bjs_makePolygonInspector() -> Int32 {
+@_expose(wasm, "bjs_TestModule_makePolygonInspector")
+@_cdecl("bjs_TestModule_makePolygonInspector")
+public func _bjs_TestModule_makePolygonInspector() -> Int32 {
     #if arch(wasm32)
     let ret = makePolygonInspector()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -145,46 +145,46 @@ public func _bjs_makePolygonInspector() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_init")
-@_cdecl("bjs_PolygonReference_init")
-public func _bjs_PolygonReference_init(_ sides: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PolygonReference_init")
+@_cdecl("bjs_TestModule_PolygonReference_init")
+public func _bjs_TestModule_PolygonReference_init(_ sides: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference(sides: Int.bridgeJSLiftParameter(sides))
+    let ret = TestModule.PolygonReference(sides: Int.bridgeJSLiftParameter(sides))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_deinit")
-@_cdecl("bjs_PolygonReference_deinit")
-public func _bjs_PolygonReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PolygonReference_deinit")
+@_cdecl("bjs_TestModule_PolygonReference_deinit")
+public func _bjs_TestModule_PolygonReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PolygonReference>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.PolygonReference>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PolygonReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.PolygonReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_PolygonReference_wrap")
-fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_PolygonReference_wrap")
+fileprivate func _bjs_TestModule_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PolygonReference_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_PolygonReference_wrap_extern(pointer)
 }
 
-extension Polygon: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension TestModule.Polygon: _BridgedSwiftAlias, _BridgedSwiftStackType {}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.json
@@ -12,11 +12,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Item"
+        "swiftCallName" : "TestModule.Item"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_MultiArrayContainer_init",
+          "abiName" : "bjs_TestModule_MultiArrayContainer_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -91,7 +91,7 @@
             }
           }
         ],
-        "swiftCallName" : "MultiArrayContainer"
+        "swiftCallName" : "TestModule.MultiArrayContainer"
       }
     ],
     "enums" : [
@@ -130,7 +130,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Direction",
+        "swiftCallName" : "TestModule.Direction",
         "tsFullPath" : "Direction"
       },
       {
@@ -166,14 +166,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Status",
+        "swiftCallName" : "TestModule.Status",
         "tsFullPath" : "Status"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_processIntArray",
+        "abiName" : "bjs_TestModule_processIntArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -212,7 +212,7 @@
         }
       },
       {
-        "abiName" : "bjs_processStringArray",
+        "abiName" : "bjs_TestModule_processStringArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -245,7 +245,7 @@
         }
       },
       {
-        "abiName" : "bjs_processDoubleArray",
+        "abiName" : "bjs_TestModule_processDoubleArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -278,7 +278,7 @@
         }
       },
       {
-        "abiName" : "bjs_processBoolArray",
+        "abiName" : "bjs_TestModule_processBoolArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -311,7 +311,7 @@
         }
       },
       {
-        "abiName" : "bjs_processPointArray",
+        "abiName" : "bjs_TestModule_processPointArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -326,7 +326,7 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "TestModule.Point"
                   }
                 }
               }
@@ -337,14 +337,14 @@
           "array" : {
             "_0" : {
               "swiftStruct" : {
-                "_0" : "Point"
+                "_0" : "TestModule.Point"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_processDirectionArray",
+        "abiName" : "bjs_TestModule_processDirectionArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -359,7 +359,7 @@
               "array" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "TestModule.Direction"
                   }
                 }
               }
@@ -370,14 +370,14 @@
           "array" : {
             "_0" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "TestModule.Direction"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_processStatusArray",
+        "abiName" : "bjs_TestModule_processStatusArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -392,7 +392,7 @@
               "array" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Status",
+                    "_0" : "TestModule.Status",
                     "_1" : "Int"
                   }
                 }
@@ -404,7 +404,7 @@
           "array" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "Status",
+                "_0" : "TestModule.Status",
                 "_1" : "Int"
               }
             }
@@ -412,7 +412,7 @@
         }
       },
       {
-        "abiName" : "bjs_sumIntArray",
+        "abiName" : "bjs_TestModule_sumIntArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -447,7 +447,7 @@
         }
       },
       {
-        "abiName" : "bjs_findFirstPoint",
+        "abiName" : "bjs_TestModule_findFirstPoint",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -462,7 +462,7 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "TestModule.Point"
                   }
                 }
               }
@@ -480,12 +480,12 @@
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "Point"
+            "_0" : "TestModule.Point"
           }
         }
       },
       {
-        "abiName" : "bjs_processUnsafeRawPointerArray",
+        "abiName" : "bjs_TestModule_processUnsafeRawPointerArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -522,7 +522,7 @@
         }
       },
       {
-        "abiName" : "bjs_processUnsafeMutableRawPointerArray",
+        "abiName" : "bjs_TestModule_processUnsafeMutableRawPointerArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -559,7 +559,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOpaquePointerArray",
+        "abiName" : "bjs_TestModule_processOpaquePointerArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -596,7 +596,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOptionalIntArray",
+        "abiName" : "bjs_TestModule_processOptionalIntArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -645,7 +645,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOptionalStringArray",
+        "abiName" : "bjs_TestModule_processOptionalStringArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -688,7 +688,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOptionalArray",
+        "abiName" : "bjs_TestModule_processOptionalArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -737,7 +737,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOptionalPointArray",
+        "abiName" : "bjs_TestModule_processOptionalPointArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -754,7 +754,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "TestModule.Point"
                       }
                     },
                     "_1" : "null"
@@ -770,7 +770,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "TestModule.Point"
                   }
                 },
                 "_1" : "null"
@@ -780,7 +780,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOptionalDirectionArray",
+        "abiName" : "bjs_TestModule_processOptionalDirectionArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -797,7 +797,7 @@
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "TestModule.Direction"
                       }
                     },
                     "_1" : "null"
@@ -813,7 +813,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "TestModule.Direction"
                   }
                 },
                 "_1" : "null"
@@ -823,7 +823,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOptionalStatusArray",
+        "abiName" : "bjs_TestModule_processOptionalStatusArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -840,7 +840,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "Status",
+                        "_0" : "TestModule.Status",
                         "_1" : "Int"
                       }
                     },
@@ -857,7 +857,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Status",
+                    "_0" : "TestModule.Status",
                     "_1" : "Int"
                   }
                 },
@@ -868,7 +868,7 @@
         }
       },
       {
-        "abiName" : "bjs_processNestedIntArray",
+        "abiName" : "bjs_TestModule_processNestedIntArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -915,7 +915,7 @@
         }
       },
       {
-        "abiName" : "bjs_processNestedStringArray",
+        "abiName" : "bjs_TestModule_processNestedStringArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -956,7 +956,7 @@
         }
       },
       {
-        "abiName" : "bjs_processNestedPointArray",
+        "abiName" : "bjs_TestModule_processNestedPointArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -973,7 +973,7 @@
                   "array" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "TestModule.Point"
                       }
                     }
                   }
@@ -988,7 +988,7 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "TestModule.Point"
                   }
                 }
               }
@@ -997,7 +997,7 @@
         }
       },
       {
-        "abiName" : "bjs_processItemArray",
+        "abiName" : "bjs_TestModule_processItemArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1012,7 +1012,7 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Item"
+                    "_0" : "TestModule.Item"
                   }
                 }
               }
@@ -1023,14 +1023,14 @@
           "array" : {
             "_0" : {
               "swiftHeapObject" : {
-                "_0" : "Item"
+                "_0" : "TestModule.Item"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_processNestedItemArray",
+        "abiName" : "bjs_TestModule_processNestedItemArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1047,7 +1047,7 @@
                   "array" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Item"
+                        "_0" : "TestModule.Item"
                       }
                     }
                   }
@@ -1062,7 +1062,7 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Item"
+                    "_0" : "TestModule.Item"
                   }
                 }
               }
@@ -1071,7 +1071,7 @@
         }
       },
       {
-        "abiName" : "bjs_processJSObjectArray",
+        "abiName" : "bjs_TestModule_processJSObjectArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1104,7 +1104,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOptionalJSObjectArray",
+        "abiName" : "bjs_TestModule_processOptionalJSObjectArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1147,7 +1147,7 @@
         }
       },
       {
-        "abiName" : "bjs_processNestedJSObjectArray",
+        "abiName" : "bjs_TestModule_processNestedJSObjectArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1188,7 +1188,7 @@
         }
       },
       {
-        "abiName" : "bjs_multiArrayParams",
+        "abiName" : "bjs_TestModule_multiArrayParams",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1236,7 +1236,7 @@
         }
       },
       {
-        "abiName" : "bjs_multiOptionalArrayParams",
+        "abiName" : "bjs_TestModule_multiOptionalArrayParams",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1325,7 +1325,7 @@
             }
           }
         ],
-        "swiftCallName" : "Point"
+        "swiftCallName" : "TestModule.Point"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ArrayTypes.swift
@@ -1,12 +1,12 @@
-extension Direction: _BridgedSwiftCaseEnum {
+extension TestModule.Direction: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Direction {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Direction {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Direction {
-        return Direction(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Direction {
+        return TestModule.Direction(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -41,14 +41,14 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Status: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Status: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+extension TestModule.Point: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Point {
         let y = Double.bridgeJSStackPop()
         let x = Double.bridgeJSStackPop()
-        return Point(x: x, y: y)
+        return TestModule.Point(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -57,44 +57,44 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Point()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Point")
+fileprivate func _bjs_struct_lower_TestModule_Point_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Point_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Point_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Point(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Point_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Point")
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Point")
+fileprivate func _bjs_struct_lift_TestModule_Point_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Point_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Point() -> Int32 {
-    return _bjs_struct_lift_Point_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Point() -> Int32 {
+    return _bjs_struct_lift_TestModule_Point_extern()
 }
 
-@_expose(wasm, "bjs_processIntArray")
-@_cdecl("bjs_processIntArray")
-public func _bjs_processIntArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processIntArray")
+@_cdecl("bjs_TestModule_processIntArray")
+public func _bjs_TestModule_processIntArray() -> Void {
     #if arch(wasm32)
     let ret = processIntArray(_: [Int].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -103,9 +103,9 @@ public func _bjs_processIntArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processStringArray")
-@_cdecl("bjs_processStringArray")
-public func _bjs_processStringArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processStringArray")
+@_cdecl("bjs_TestModule_processStringArray")
+public func _bjs_TestModule_processStringArray() -> Void {
     #if arch(wasm32)
     let ret = processStringArray(_: [String].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -114,9 +114,9 @@ public func _bjs_processStringArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processDoubleArray")
-@_cdecl("bjs_processDoubleArray")
-public func _bjs_processDoubleArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processDoubleArray")
+@_cdecl("bjs_TestModule_processDoubleArray")
+public func _bjs_TestModule_processDoubleArray() -> Void {
     #if arch(wasm32)
     let ret = processDoubleArray(_: [Double].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -125,9 +125,9 @@ public func _bjs_processDoubleArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processBoolArray")
-@_cdecl("bjs_processBoolArray")
-public func _bjs_processBoolArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processBoolArray")
+@_cdecl("bjs_TestModule_processBoolArray")
+public func _bjs_TestModule_processBoolArray() -> Void {
     #if arch(wasm32)
     let ret = processBoolArray(_: [Bool].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -136,42 +136,42 @@ public func _bjs_processBoolArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processPointArray")
-@_cdecl("bjs_processPointArray")
-public func _bjs_processPointArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processPointArray")
+@_cdecl("bjs_TestModule_processPointArray")
+public func _bjs_TestModule_processPointArray() -> Void {
     #if arch(wasm32)
-    let ret = processPointArray(_: [Point].bridgeJSStackPop())
+    let ret = processPointArray(_: [TestModule.Point].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processDirectionArray")
-@_cdecl("bjs_processDirectionArray")
-public func _bjs_processDirectionArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processDirectionArray")
+@_cdecl("bjs_TestModule_processDirectionArray")
+public func _bjs_TestModule_processDirectionArray() -> Void {
     #if arch(wasm32)
-    let ret = processDirectionArray(_: [Direction].bridgeJSStackPop())
+    let ret = processDirectionArray(_: [TestModule.Direction].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processStatusArray")
-@_cdecl("bjs_processStatusArray")
-public func _bjs_processStatusArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processStatusArray")
+@_cdecl("bjs_TestModule_processStatusArray")
+public func _bjs_TestModule_processStatusArray() -> Void {
     #if arch(wasm32)
-    let ret = processStatusArray(_: [Status].bridgeJSStackPop())
+    let ret = processStatusArray(_: [TestModule.Status].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_sumIntArray")
-@_cdecl("bjs_sumIntArray")
-public func _bjs_sumIntArray() -> Int32 {
+@_expose(wasm, "bjs_TestModule_sumIntArray")
+@_cdecl("bjs_TestModule_sumIntArray")
+public func _bjs_TestModule_sumIntArray() -> Int32 {
     #if arch(wasm32)
     let ret = sumIntArray(_: [Int].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
@@ -180,20 +180,20 @@ public func _bjs_sumIntArray() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_findFirstPoint")
-@_cdecl("bjs_findFirstPoint")
-public func _bjs_findFirstPoint(_ matchingBytes: Int32, _ matchingLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_findFirstPoint")
+@_cdecl("bjs_TestModule_findFirstPoint")
+public func _bjs_TestModule_findFirstPoint(_ matchingBytes: Int32, _ matchingLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = findFirstPoint(_: [Point].bridgeJSStackPop(), matching: String.bridgeJSLiftParameter(matchingBytes, matchingLength))
+    let ret = findFirstPoint(_: [TestModule.Point].bridgeJSStackPop(), matching: String.bridgeJSLiftParameter(matchingBytes, matchingLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processUnsafeRawPointerArray")
-@_cdecl("bjs_processUnsafeRawPointerArray")
-public func _bjs_processUnsafeRawPointerArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processUnsafeRawPointerArray")
+@_cdecl("bjs_TestModule_processUnsafeRawPointerArray")
+public func _bjs_TestModule_processUnsafeRawPointerArray() -> Void {
     #if arch(wasm32)
     let ret = processUnsafeRawPointerArray(_: [UnsafeRawPointer].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -202,9 +202,9 @@ public func _bjs_processUnsafeRawPointerArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processUnsafeMutableRawPointerArray")
-@_cdecl("bjs_processUnsafeMutableRawPointerArray")
-public func _bjs_processUnsafeMutableRawPointerArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processUnsafeMutableRawPointerArray")
+@_cdecl("bjs_TestModule_processUnsafeMutableRawPointerArray")
+public func _bjs_TestModule_processUnsafeMutableRawPointerArray() -> Void {
     #if arch(wasm32)
     let ret = processUnsafeMutableRawPointerArray(_: [UnsafeMutableRawPointer].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -213,9 +213,9 @@ public func _bjs_processUnsafeMutableRawPointerArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processOpaquePointerArray")
-@_cdecl("bjs_processOpaquePointerArray")
-public func _bjs_processOpaquePointerArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processOpaquePointerArray")
+@_cdecl("bjs_TestModule_processOpaquePointerArray")
+public func _bjs_TestModule_processOpaquePointerArray() -> Void {
     #if arch(wasm32)
     let ret = processOpaquePointerArray(_: [OpaquePointer].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -224,9 +224,9 @@ public func _bjs_processOpaquePointerArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processOptionalIntArray")
-@_cdecl("bjs_processOptionalIntArray")
-public func _bjs_processOptionalIntArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processOptionalIntArray")
+@_cdecl("bjs_TestModule_processOptionalIntArray")
+public func _bjs_TestModule_processOptionalIntArray() -> Void {
     #if arch(wasm32)
     let ret = processOptionalIntArray(_: [Optional<Int>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -235,9 +235,9 @@ public func _bjs_processOptionalIntArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processOptionalStringArray")
-@_cdecl("bjs_processOptionalStringArray")
-public func _bjs_processOptionalStringArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processOptionalStringArray")
+@_cdecl("bjs_TestModule_processOptionalStringArray")
+public func _bjs_TestModule_processOptionalStringArray() -> Void {
     #if arch(wasm32)
     let ret = processOptionalStringArray(_: [Optional<String>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -246,9 +246,9 @@ public func _bjs_processOptionalStringArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processOptionalArray")
-@_cdecl("bjs_processOptionalArray")
-public func _bjs_processOptionalArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processOptionalArray")
+@_cdecl("bjs_TestModule_processOptionalArray")
+public func _bjs_TestModule_processOptionalArray() -> Void {
     #if arch(wasm32)
     let ret = processOptionalArray(_: Optional<[Int]>.bridgeJSLiftParameter())
     ret.bridgeJSStackPush()
@@ -257,42 +257,42 @@ public func _bjs_processOptionalArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processOptionalPointArray")
-@_cdecl("bjs_processOptionalPointArray")
-public func _bjs_processOptionalPointArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processOptionalPointArray")
+@_cdecl("bjs_TestModule_processOptionalPointArray")
+public func _bjs_TestModule_processOptionalPointArray() -> Void {
     #if arch(wasm32)
-    let ret = processOptionalPointArray(_: [Optional<Point>].bridgeJSStackPop())
+    let ret = processOptionalPointArray(_: [Optional<TestModule.Point>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processOptionalDirectionArray")
-@_cdecl("bjs_processOptionalDirectionArray")
-public func _bjs_processOptionalDirectionArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processOptionalDirectionArray")
+@_cdecl("bjs_TestModule_processOptionalDirectionArray")
+public func _bjs_TestModule_processOptionalDirectionArray() -> Void {
     #if arch(wasm32)
-    let ret = processOptionalDirectionArray(_: [Optional<Direction>].bridgeJSStackPop())
+    let ret = processOptionalDirectionArray(_: [Optional<TestModule.Direction>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processOptionalStatusArray")
-@_cdecl("bjs_processOptionalStatusArray")
-public func _bjs_processOptionalStatusArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processOptionalStatusArray")
+@_cdecl("bjs_TestModule_processOptionalStatusArray")
+public func _bjs_TestModule_processOptionalStatusArray() -> Void {
     #if arch(wasm32)
-    let ret = processOptionalStatusArray(_: [Optional<Status>].bridgeJSStackPop())
+    let ret = processOptionalStatusArray(_: [Optional<TestModule.Status>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processNestedIntArray")
-@_cdecl("bjs_processNestedIntArray")
-public func _bjs_processNestedIntArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processNestedIntArray")
+@_cdecl("bjs_TestModule_processNestedIntArray")
+public func _bjs_TestModule_processNestedIntArray() -> Void {
     #if arch(wasm32)
     let ret = processNestedIntArray(_: [[Int]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -301,9 +301,9 @@ public func _bjs_processNestedIntArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processNestedStringArray")
-@_cdecl("bjs_processNestedStringArray")
-public func _bjs_processNestedStringArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processNestedStringArray")
+@_cdecl("bjs_TestModule_processNestedStringArray")
+public func _bjs_TestModule_processNestedStringArray() -> Void {
     #if arch(wasm32)
     let ret = processNestedStringArray(_: [[String]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -312,42 +312,42 @@ public func _bjs_processNestedStringArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processNestedPointArray")
-@_cdecl("bjs_processNestedPointArray")
-public func _bjs_processNestedPointArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processNestedPointArray")
+@_cdecl("bjs_TestModule_processNestedPointArray")
+public func _bjs_TestModule_processNestedPointArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedPointArray(_: [[Point]].bridgeJSStackPop())
+    let ret = processNestedPointArray(_: [[TestModule.Point]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processItemArray")
-@_cdecl("bjs_processItemArray")
-public func _bjs_processItemArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processItemArray")
+@_cdecl("bjs_TestModule_processItemArray")
+public func _bjs_TestModule_processItemArray() -> Void {
     #if arch(wasm32)
-    let ret = processItemArray(_: [Item].bridgeJSStackPop())
+    let ret = processItemArray(_: [TestModule.Item].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processNestedItemArray")
-@_cdecl("bjs_processNestedItemArray")
-public func _bjs_processNestedItemArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processNestedItemArray")
+@_cdecl("bjs_TestModule_processNestedItemArray")
+public func _bjs_TestModule_processNestedItemArray() -> Void {
     #if arch(wasm32)
-    let ret = processNestedItemArray(_: [[Item]].bridgeJSStackPop())
+    let ret = processNestedItemArray(_: [[TestModule.Item]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processJSObjectArray")
-@_cdecl("bjs_processJSObjectArray")
-public func _bjs_processJSObjectArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processJSObjectArray")
+@_cdecl("bjs_TestModule_processJSObjectArray")
+public func _bjs_TestModule_processJSObjectArray() -> Void {
     #if arch(wasm32)
     let ret = processJSObjectArray(_: [JSObject].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -356,9 +356,9 @@ public func _bjs_processJSObjectArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processOptionalJSObjectArray")
-@_cdecl("bjs_processOptionalJSObjectArray")
-public func _bjs_processOptionalJSObjectArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processOptionalJSObjectArray")
+@_cdecl("bjs_TestModule_processOptionalJSObjectArray")
+public func _bjs_TestModule_processOptionalJSObjectArray() -> Void {
     #if arch(wasm32)
     let ret = processOptionalJSObjectArray(_: [Optional<JSObject>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -367,9 +367,9 @@ public func _bjs_processOptionalJSObjectArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processNestedJSObjectArray")
-@_cdecl("bjs_processNestedJSObjectArray")
-public func _bjs_processNestedJSObjectArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processNestedJSObjectArray")
+@_cdecl("bjs_TestModule_processNestedJSObjectArray")
+public func _bjs_TestModule_processNestedJSObjectArray() -> Void {
     #if arch(wasm32)
     let ret = processNestedJSObjectArray(_: [[JSObject]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -378,9 +378,9 @@ public func _bjs_processNestedJSObjectArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_multiArrayParams")
-@_cdecl("bjs_multiArrayParams")
-public func _bjs_multiArrayParams() -> Int32 {
+@_expose(wasm, "bjs_TestModule_multiArrayParams")
+@_cdecl("bjs_TestModule_multiArrayParams")
+public func _bjs_TestModule_multiArrayParams() -> Int32 {
     #if arch(wasm32)
     let _tmp_strs = [String].bridgeJSStackPop()
     let _tmp_nums = [Int].bridgeJSStackPop()
@@ -391,9 +391,9 @@ public func _bjs_multiArrayParams() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_multiOptionalArrayParams")
-@_cdecl("bjs_multiOptionalArrayParams")
-public func _bjs_multiOptionalArrayParams() -> Int32 {
+@_expose(wasm, "bjs_TestModule_multiOptionalArrayParams")
+@_cdecl("bjs_TestModule_multiOptionalArrayParams")
+public func _bjs_TestModule_multiOptionalArrayParams() -> Int32 {
     #if arch(wasm32)
     let _tmp_b = Optional<[String]>.bridgeJSLiftParameter()
     let _tmp_a = Optional<[Int]>.bridgeJSLiftParameter()
@@ -404,101 +404,101 @@ public func _bjs_multiOptionalArrayParams() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_Item_deinit")
-@_cdecl("bjs_Item_deinit")
-public func _bjs_Item_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Item_deinit")
+@_cdecl("bjs_TestModule_Item_deinit")
+public func _bjs_TestModule_Item_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Item>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Item>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Item: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Item: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Item_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Item_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Item_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Item_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Item_wrap")
-fileprivate func _bjs_Item_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Item_wrap")
+fileprivate func _bjs_TestModule_Item_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Item_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Item_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Item_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Item_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Item_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Item_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_MultiArrayContainer_init")
-@_cdecl("bjs_MultiArrayContainer_init")
-public func _bjs_MultiArrayContainer_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_MultiArrayContainer_init")
+@_cdecl("bjs_TestModule_MultiArrayContainer_init")
+public func _bjs_TestModule_MultiArrayContainer_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let _tmp_strs = [String].bridgeJSStackPop()
     let _tmp_nums = [Int].bridgeJSStackPop()
-    let ret = MultiArrayContainer(nums: _tmp_nums, strs: _tmp_strs)
+    let ret = TestModule.MultiArrayContainer(nums: _tmp_nums, strs: _tmp_strs)
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MultiArrayContainer_numbers_get")
-@_cdecl("bjs_MultiArrayContainer_numbers_get")
-public func _bjs_MultiArrayContainer_numbers_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_MultiArrayContainer_numbers_get")
+@_cdecl("bjs_TestModule_MultiArrayContainer_numbers_get")
+public func _bjs_TestModule_MultiArrayContainer_numbers_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = MultiArrayContainer.bridgeJSLiftParameter(_self).numbers
+    let ret = TestModule.MultiArrayContainer.bridgeJSLiftParameter(_self).numbers
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MultiArrayContainer_strings_get")
-@_cdecl("bjs_MultiArrayContainer_strings_get")
-public func _bjs_MultiArrayContainer_strings_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_MultiArrayContainer_strings_get")
+@_cdecl("bjs_TestModule_MultiArrayContainer_strings_get")
+public func _bjs_TestModule_MultiArrayContainer_strings_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = MultiArrayContainer.bridgeJSLiftParameter(_self).strings
+    let ret = TestModule.MultiArrayContainer.bridgeJSLiftParameter(_self).strings
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MultiArrayContainer_deinit")
-@_cdecl("bjs_MultiArrayContainer_deinit")
-public func _bjs_MultiArrayContainer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_MultiArrayContainer_deinit")
+@_cdecl("bjs_TestModule_MultiArrayContainer_deinit")
+public func _bjs_TestModule_MultiArrayContainer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<MultiArrayContainer>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.MultiArrayContainer>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension MultiArrayContainer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.MultiArrayContainer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_MultiArrayContainer_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_MultiArrayContainer_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_MultiArrayContainer_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_MultiArrayContainer_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_MultiArrayContainer_wrap")
-fileprivate func _bjs_MultiArrayContainer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_MultiArrayContainer_wrap")
+fileprivate func _bjs_TestModule_MultiArrayContainer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_MultiArrayContainer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_MultiArrayContainer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_MultiArrayContainer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_MultiArrayContainer_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_MultiArrayContainer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_MultiArrayContainer_wrap_extern(pointer)
 }
 
 #if arch(wasm32)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.json
@@ -30,7 +30,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "AsyncDirection",
+        "swiftCallName" : "TestModule.AsyncDirection",
         "tsFullPath" : "AsyncDirection"
       },
       {
@@ -57,14 +57,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "AsyncTheme",
+        "swiftCallName" : "TestModule.AsyncTheme",
         "tsFullPath" : "AsyncTheme"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_asyncReturnVoid",
+        "abiName" : "bjs_TestModule_asyncReturnVoid",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -81,7 +81,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripInt",
+        "abiName" : "bjs_TestModule_asyncRoundTripInt",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -112,7 +112,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripString",
+        "abiName" : "bjs_TestModule_asyncRoundTripString",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -137,7 +137,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripBool",
+        "abiName" : "bjs_TestModule_asyncRoundTripBool",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -162,7 +162,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripFloat",
+        "abiName" : "bjs_TestModule_asyncRoundTripFloat",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -187,7 +187,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripDouble",
+        "abiName" : "bjs_TestModule_asyncRoundTripDouble",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -212,7 +212,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripJSObject",
+        "abiName" : "bjs_TestModule_asyncRoundTripJSObject",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -237,7 +237,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripStruct",
+        "abiName" : "bjs_TestModule_asyncRoundTripStruct",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -250,19 +250,19 @@
             "name" : "v",
             "type" : {
               "swiftStruct" : {
-                "_0" : "AsyncPoint"
+                "_0" : "TestModule.AsyncPoint"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "AsyncPoint"
+            "_0" : "TestModule.AsyncPoint"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripStructThrows",
+        "abiName" : "bjs_TestModule_asyncRoundTripStructThrows",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -275,19 +275,19 @@
             "name" : "v",
             "type" : {
               "swiftStruct" : {
-                "_0" : "AsyncPoint"
+                "_0" : "TestModule.AsyncPoint"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "AsyncPoint"
+            "_0" : "TestModule.AsyncPoint"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncThrowsZeroArg",
+        "abiName" : "bjs_TestModule_asyncThrowsZeroArg",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -304,7 +304,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncCombineStructs",
+        "abiName" : "bjs_TestModule_asyncCombineStructs",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -317,7 +317,7 @@
             "name" : "a",
             "type" : {
               "swiftStruct" : {
-                "_0" : "AsyncPoint"
+                "_0" : "TestModule.AsyncPoint"
               }
             }
           },
@@ -326,19 +326,19 @@
             "name" : "b",
             "type" : {
               "swiftStruct" : {
-                "_0" : "AsyncPoint"
+                "_0" : "TestModule.AsyncPoint"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "AsyncPoint"
+            "_0" : "TestModule.AsyncPoint"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripEnum",
+        "abiName" : "bjs_TestModule_asyncRoundTripEnum",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -351,19 +351,19 @@
             "name" : "v",
             "type" : {
               "caseEnum" : {
-                "_0" : "AsyncDirection"
+                "_0" : "TestModule.AsyncDirection"
               }
             }
           }
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "AsyncDirection"
+            "_0" : "TestModule.AsyncDirection"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripRawEnum",
+        "abiName" : "bjs_TestModule_asyncRoundTripRawEnum",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -376,7 +376,7 @@
             "name" : "v",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "AsyncTheme",
+                "_0" : "TestModule.AsyncTheme",
                 "_1" : "String"
               }
             }
@@ -384,13 +384,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "AsyncTheme",
+            "_0" : "TestModule.AsyncTheme",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripOptionalEnum",
+        "abiName" : "bjs_TestModule_asyncRoundTripOptionalEnum",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -405,7 +405,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "AsyncDirection"
+                    "_0" : "TestModule.AsyncDirection"
                   }
                 },
                 "_1" : "null"
@@ -417,7 +417,7 @@
           "nullable" : {
             "_0" : {
               "caseEnum" : {
-                "_0" : "AsyncDirection"
+                "_0" : "TestModule.AsyncDirection"
               }
             },
             "_1" : "null"
@@ -425,7 +425,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripOptionalRawEnum",
+        "abiName" : "bjs_TestModule_asyncRoundTripOptionalRawEnum",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -440,7 +440,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "AsyncTheme",
+                    "_0" : "TestModule.AsyncTheme",
                     "_1" : "String"
                   }
                 },
@@ -453,7 +453,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "AsyncTheme",
+                "_0" : "TestModule.AsyncTheme",
                 "_1" : "String"
               }
             },
@@ -462,7 +462,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripOptionalStruct",
+        "abiName" : "bjs_TestModule_asyncRoundTripOptionalStruct",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -477,7 +477,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "AsyncPoint"
+                    "_0" : "TestModule.AsyncPoint"
                   }
                 },
                 "_1" : "null"
@@ -489,7 +489,7 @@
           "nullable" : {
             "_0" : {
               "swiftStruct" : {
-                "_0" : "AsyncPoint"
+                "_0" : "TestModule.AsyncPoint"
               }
             },
             "_1" : "null"
@@ -497,7 +497,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripStructArray",
+        "abiName" : "bjs_TestModule_asyncRoundTripStructArray",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -512,7 +512,7 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "AsyncPoint"
+                    "_0" : "TestModule.AsyncPoint"
                   }
                 }
               }
@@ -523,14 +523,14 @@
           "array" : {
             "_0" : {
               "swiftStruct" : {
-                "_0" : "AsyncPoint"
+                "_0" : "TestModule.AsyncPoint"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripEnumArray",
+        "abiName" : "bjs_TestModule_asyncRoundTripEnumArray",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -545,7 +545,7 @@
               "array" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "AsyncDirection"
+                    "_0" : "TestModule.AsyncDirection"
                   }
                 }
               }
@@ -556,14 +556,14 @@
           "array" : {
             "_0" : {
               "caseEnum" : {
-                "_0" : "AsyncDirection"
+                "_0" : "TestModule.AsyncDirection"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripStructDictionary",
+        "abiName" : "bjs_TestModule_asyncRoundTripStructDictionary",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -578,7 +578,7 @@
               "dictionary" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "AsyncPoint"
+                    "_0" : "TestModule.AsyncPoint"
                   }
                 }
               }
@@ -589,14 +589,14 @@
           "dictionary" : {
             "_0" : {
               "swiftStruct" : {
-                "_0" : "AsyncPoint"
+                "_0" : "TestModule.AsyncPoint"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripEnumDictionary",
+        "abiName" : "bjs_TestModule_asyncRoundTripEnumDictionary",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -611,7 +611,7 @@
               "dictionary" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "AsyncDirection"
+                    "_0" : "TestModule.AsyncDirection"
                   }
                 }
               }
@@ -622,7 +622,7 @@
           "dictionary" : {
             "_0" : {
               "caseEnum" : {
-                "_0" : "AsyncDirection"
+                "_0" : "TestModule.AsyncDirection"
               }
             }
           }
@@ -666,7 +666,7 @@
             }
           }
         ],
-        "swiftCallName" : "AsyncPoint"
+        "swiftCallName" : "TestModule.AsyncPoint"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Async.swift
@@ -1,12 +1,12 @@
-extension AsyncDirection: _BridgedSwiftCaseEnum {
+extension TestModule.AsyncDirection: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> AsyncDirection {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.AsyncDirection {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> AsyncDirection {
-        return AsyncDirection(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.AsyncDirection {
+        return TestModule.AsyncDirection(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -33,14 +33,14 @@ extension AsyncDirection: _BridgedSwiftCaseEnum {
     }
 }
 
-extension AsyncTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.AsyncTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension AsyncPoint: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> AsyncPoint {
+extension TestModule.AsyncPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.AsyncPoint {
         let y = Int.bridgeJSStackPop()
         let x = Int.bridgeJSStackPop()
-        return AsyncPoint(x: x, y: y)
+        return TestModule.AsyncPoint(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -49,44 +49,44 @@ extension AsyncPoint: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_AsyncPoint(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_AsyncPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_AsyncPoint()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_AsyncPoint()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_AsyncPoint")
-fileprivate func _bjs_struct_lower_AsyncPoint_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_AsyncPoint")
+fileprivate func _bjs_struct_lower_TestModule_AsyncPoint_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_AsyncPoint_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_AsyncPoint_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_AsyncPoint(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_AsyncPoint_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_AsyncPoint(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_AsyncPoint_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_AsyncPoint")
-fileprivate func _bjs_struct_lift_AsyncPoint_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_AsyncPoint")
+fileprivate func _bjs_struct_lift_TestModule_AsyncPoint_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_AsyncPoint_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_AsyncPoint_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_AsyncPoint() -> Int32 {
-    return _bjs_struct_lift_AsyncPoint_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_AsyncPoint() -> Int32 {
+    return _bjs_struct_lift_TestModule_AsyncPoint_extern()
 }
 
-@_expose(wasm, "bjs_asyncReturnVoid")
-@_cdecl("bjs_asyncReturnVoid")
-public func _bjs_asyncReturnVoid() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncReturnVoid")
+@_cdecl("bjs_TestModule_asyncReturnVoid")
+public func _bjs_TestModule_asyncReturnVoid() -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_y, reject: Promise_reject) {
         await asyncReturnVoid()
@@ -96,9 +96,9 @@ public func _bjs_asyncReturnVoid() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripInt")
-@_cdecl("bjs_asyncRoundTripInt")
-public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripInt")
+@_cdecl("bjs_TestModule_asyncRoundTripInt")
+public func _bjs_TestModule_asyncRoundTripInt(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_Si, reject: Promise_reject) {
         return await asyncRoundTripInt(_: Int.bridgeJSLiftParameter(v))
@@ -108,9 +108,9 @@ public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripString")
-@_cdecl("bjs_asyncRoundTripString")
-public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripString")
+@_cdecl("bjs_TestModule_asyncRoundTripString")
+public func _bjs_TestModule_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
         return await asyncRoundTripString(_: String.bridgeJSLiftParameter(vBytes, vLength))
@@ -120,9 +120,9 @@ public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int3
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripBool")
-@_cdecl("bjs_asyncRoundTripBool")
-public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripBool")
+@_cdecl("bjs_TestModule_asyncRoundTripBool")
+public func _bjs_TestModule_asyncRoundTripBool(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_Sb, reject: Promise_reject) {
         return await asyncRoundTripBool(_: Bool.bridgeJSLiftParameter(v))
@@ -132,9 +132,9 @@ public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripFloat")
-@_cdecl("bjs_asyncRoundTripFloat")
-public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripFloat")
+@_cdecl("bjs_TestModule_asyncRoundTripFloat")
+public func _bjs_TestModule_asyncRoundTripFloat(_ v: Float32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_Sf, reject: Promise_reject) {
         return await asyncRoundTripFloat(_: Float.bridgeJSLiftParameter(v))
@@ -144,9 +144,9 @@ public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripDouble")
-@_cdecl("bjs_asyncRoundTripDouble")
-public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripDouble")
+@_cdecl("bjs_TestModule_asyncRoundTripDouble")
+public func _bjs_TestModule_asyncRoundTripDouble(_ v: Float64) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_Sd, reject: Promise_reject) {
         return await asyncRoundTripDouble(_: Double.bridgeJSLiftParameter(v))
@@ -156,9 +156,9 @@ public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripJSObject")
-@_cdecl("bjs_asyncRoundTripJSObject")
-public func _bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripJSObject")
+@_cdecl("bjs_TestModule_asyncRoundTripJSObject")
+public func _bjs_TestModule_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_8JSObjectC, reject: Promise_reject) {
         return await asyncRoundTripJSObject(_: JSObject.bridgeJSLiftParameter(v))
@@ -168,12 +168,12 @@ public func _bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripStruct")
-@_cdecl("bjs_asyncRoundTripStruct")
-public func _bjs_asyncRoundTripStruct() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripStruct")
+@_cdecl("bjs_TestModule_asyncRoundTripStruct")
+public func _bjs_TestModule_asyncRoundTripStruct() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = AsyncPoint.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_10AsyncPointV, reject: Promise_reject) {
+    let _tmp_v = TestModule.AsyncPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_21TestModule_AsyncPointV, reject: Promise_reject) {
         return await asyncRoundTripStruct(_: _tmp_v)
     }
     #else
@@ -181,12 +181,12 @@ public func _bjs_asyncRoundTripStruct() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripStructThrows")
-@_cdecl("bjs_asyncRoundTripStructThrows")
-public func _bjs_asyncRoundTripStructThrows() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripStructThrows")
+@_cdecl("bjs_TestModule_asyncRoundTripStructThrows")
+public func _bjs_TestModule_asyncRoundTripStructThrows() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = AsyncPoint.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_10AsyncPointV, reject: Promise_reject) { () async throws(JSException) -> AsyncPoint in
+    let _tmp_v = TestModule.AsyncPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_21TestModule_AsyncPointV, reject: Promise_reject) { () async throws(JSException) -> TestModule.AsyncPoint in
         return try await asyncRoundTripStructThrows(_: _tmp_v)
     }
     #else
@@ -194,9 +194,9 @@ public func _bjs_asyncRoundTripStructThrows() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncThrowsZeroArg")
-@_cdecl("bjs_asyncThrowsZeroArg")
-public func _bjs_asyncThrowsZeroArg() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncThrowsZeroArg")
+@_cdecl("bjs_TestModule_asyncThrowsZeroArg")
+public func _bjs_TestModule_asyncThrowsZeroArg() -> Int32 {
     #if arch(wasm32)
     let __bjs_capture = 0
     return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { [__bjs_capture] () async throws(JSException) -> String in
@@ -208,13 +208,13 @@ public func _bjs_asyncThrowsZeroArg() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncCombineStructs")
-@_cdecl("bjs_asyncCombineStructs")
-public func _bjs_asyncCombineStructs() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncCombineStructs")
+@_cdecl("bjs_TestModule_asyncCombineStructs")
+public func _bjs_TestModule_asyncCombineStructs() -> Int32 {
     #if arch(wasm32)
-    let _tmp_b = AsyncPoint.bridgeJSLiftParameter()
-    let _tmp_a = AsyncPoint.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_10AsyncPointV, reject: Promise_reject) {
+    let _tmp_b = TestModule.AsyncPoint.bridgeJSLiftParameter()
+    let _tmp_a = TestModule.AsyncPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_21TestModule_AsyncPointV, reject: Promise_reject) {
         return await asyncCombineStructs(_: _tmp_a, _: _tmp_b)
     }
     #else
@@ -222,60 +222,60 @@ public func _bjs_asyncCombineStructs() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripEnum")
-@_cdecl("bjs_asyncRoundTripEnum")
-public func _bjs_asyncRoundTripEnum(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripEnum")
+@_cdecl("bjs_TestModule_asyncRoundTripEnum")
+public func _bjs_TestModule_asyncRoundTripEnum(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_14AsyncDirectionO, reject: Promise_reject) {
-        return await asyncRoundTripEnum(_: AsyncDirection.bridgeJSLiftParameter(v))
+    return _bjs_makePromise(resolve: Promise_resolve_25TestModule_AsyncDirectionO, reject: Promise_reject) {
+        return await asyncRoundTripEnum(_: TestModule.AsyncDirection.bridgeJSLiftParameter(v))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripRawEnum")
-@_cdecl("bjs_asyncRoundTripRawEnum")
-public func _bjs_asyncRoundTripRawEnum(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripRawEnum")
+@_cdecl("bjs_TestModule_asyncRoundTripRawEnum")
+public func _bjs_TestModule_asyncRoundTripRawEnum(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_10AsyncThemeO, reject: Promise_reject) {
-        return await asyncRoundTripRawEnum(_: AsyncTheme.bridgeJSLiftParameter(vBytes, vLength))
+    return _bjs_makePromise(resolve: Promise_resolve_21TestModule_AsyncThemeO, reject: Promise_reject) {
+        return await asyncRoundTripRawEnum(_: TestModule.AsyncTheme.bridgeJSLiftParameter(vBytes, vLength))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripOptionalEnum")
-@_cdecl("bjs_asyncRoundTripOptionalEnum")
-public func _bjs_asyncRoundTripOptionalEnum(_ vIsSome: Int32, _ vValue: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripOptionalEnum")
+@_cdecl("bjs_TestModule_asyncRoundTripOptionalEnum")
+public func _bjs_TestModule_asyncRoundTripOptionalEnum(_ vIsSome: Int32, _ vValue: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq14AsyncDirectionO, reject: Promise_reject) {
-        return await asyncRoundTripOptionalEnum(_: Optional<AsyncDirection>.bridgeJSLiftParameter(vIsSome, vValue))
+    return _bjs_makePromise(resolve: Promise_resolve_Sq25TestModule_AsyncDirectionO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalEnum(_: Optional<TestModule.AsyncDirection>.bridgeJSLiftParameter(vIsSome, vValue))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripOptionalRawEnum")
-@_cdecl("bjs_asyncRoundTripOptionalRawEnum")
-public func _bjs_asyncRoundTripOptionalRawEnum(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripOptionalRawEnum")
+@_cdecl("bjs_TestModule_asyncRoundTripOptionalRawEnum")
+public func _bjs_TestModule_asyncRoundTripOptionalRawEnum(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq10AsyncThemeO, reject: Promise_reject) {
-        return await asyncRoundTripOptionalRawEnum(_: Optional<AsyncTheme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
+    return _bjs_makePromise(resolve: Promise_resolve_Sq21TestModule_AsyncThemeO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalRawEnum(_: Optional<TestModule.AsyncTheme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripOptionalStruct")
-@_cdecl("bjs_asyncRoundTripOptionalStruct")
-public func _bjs_asyncRoundTripOptionalStruct() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripOptionalStruct")
+@_cdecl("bjs_TestModule_asyncRoundTripOptionalStruct")
+public func _bjs_TestModule_asyncRoundTripOptionalStruct() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = Optional<AsyncPoint>.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_Sq10AsyncPointV, reject: Promise_reject) {
+    let _tmp_v = Optional<TestModule.AsyncPoint>.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_Sq21TestModule_AsyncPointV, reject: Promise_reject) {
         return await asyncRoundTripOptionalStruct(_: _tmp_v)
     }
     #else
@@ -283,12 +283,12 @@ public func _bjs_asyncRoundTripOptionalStruct() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripStructArray")
-@_cdecl("bjs_asyncRoundTripStructArray")
-public func _bjs_asyncRoundTripStructArray() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripStructArray")
+@_cdecl("bjs_TestModule_asyncRoundTripStructArray")
+public func _bjs_TestModule_asyncRoundTripStructArray() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = [AsyncPoint].bridgeJSStackPop()
-    return _bjs_makePromise(resolve: Promise_resolve_Sa10AsyncPointV, reject: Promise_reject) {
+    let _tmp_v = [TestModule.AsyncPoint].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa21TestModule_AsyncPointV, reject: Promise_reject) {
         return await asyncRoundTripStructArray(_: _tmp_v)
     }
     #else
@@ -296,12 +296,12 @@ public func _bjs_asyncRoundTripStructArray() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripEnumArray")
-@_cdecl("bjs_asyncRoundTripEnumArray")
-public func _bjs_asyncRoundTripEnumArray() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripEnumArray")
+@_cdecl("bjs_TestModule_asyncRoundTripEnumArray")
+public func _bjs_TestModule_asyncRoundTripEnumArray() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = [AsyncDirection].bridgeJSStackPop()
-    return _bjs_makePromise(resolve: Promise_resolve_Sa14AsyncDirectionO, reject: Promise_reject) {
+    let _tmp_v = [TestModule.AsyncDirection].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa25TestModule_AsyncDirectionO, reject: Promise_reject) {
         return await asyncRoundTripEnumArray(_: _tmp_v)
     }
     #else
@@ -309,12 +309,12 @@ public func _bjs_asyncRoundTripEnumArray() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripStructDictionary")
-@_cdecl("bjs_asyncRoundTripStructDictionary")
-public func _bjs_asyncRoundTripStructDictionary() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripStructDictionary")
+@_cdecl("bjs_TestModule_asyncRoundTripStructDictionary")
+public func _bjs_TestModule_asyncRoundTripStructDictionary() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = [String: AsyncPoint].bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_SD10AsyncPointV, reject: Promise_reject) {
+    let _tmp_v = [String: TestModule.AsyncPoint].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD21TestModule_AsyncPointV, reject: Promise_reject) {
         return await asyncRoundTripStructDictionary(_: _tmp_v)
     }
     #else
@@ -322,12 +322,12 @@ public func _bjs_asyncRoundTripStructDictionary() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripEnumDictionary")
-@_cdecl("bjs_asyncRoundTripEnumDictionary")
-public func _bjs_asyncRoundTripEnumDictionary() -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripEnumDictionary")
+@_cdecl("bjs_TestModule_asyncRoundTripEnumDictionary")
+public func _bjs_TestModule_asyncRoundTripEnumDictionary() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = [String: AsyncDirection].bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_SD14AsyncDirectionO, reject: Promise_reject) {
+    let _tmp_v = [String: TestModule.AsyncDirection].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD25TestModule_AsyncDirectionO, reject: Promise_reject) {
         return await asyncRoundTripEnumDictionary(_: _tmp_v)
     }
     #else
@@ -503,214 +503,214 @@ func _$Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_10AsyncPointV(_ promise: JSObject, _ value: AsyncPoint) throws(JSException)
+@JSFunction func Promise_resolve_21TestModule_AsyncPointV(_ promise: JSObject, _ value: TestModule.AsyncPoint) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_10AsyncPointV")
-fileprivate func promise_resolve_TestModule_10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_21TestModule_AsyncPointV")
+fileprivate func promise_resolve_TestModule_21TestModule_AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_21TestModule_AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_10AsyncPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_TestModule_10AsyncPointV_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_TestModule_21TestModule_AsyncPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_21TestModule_AsyncPointV_extern(promise, value)
 }
 
-func _$Promise_resolve_10AsyncPointV(_ promise: JSObject, _ value: AsyncPoint) throws(JSException) -> Void {
+func _$Promise_resolve_21TestModule_AsyncPointV(_ promise: JSObject, _ value: TestModule.AsyncPoint) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_10AsyncPointV(promiseValue, valueObjectId)
+    promise_resolve_TestModule_21TestModule_AsyncPointV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_14AsyncDirectionO(_ promise: JSObject, _ value: AsyncDirection) throws(JSException)
+@JSFunction func Promise_resolve_25TestModule_AsyncDirectionO(_ promise: JSObject, _ value: TestModule.AsyncDirection) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_14AsyncDirectionO")
-fileprivate func promise_resolve_TestModule_14AsyncDirectionO_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_25TestModule_AsyncDirectionO")
+fileprivate func promise_resolve_TestModule_25TestModule_AsyncDirectionO_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_14AsyncDirectionO_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_25TestModule_AsyncDirectionO_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_14AsyncDirectionO(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_TestModule_14AsyncDirectionO_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_TestModule_25TestModule_AsyncDirectionO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_25TestModule_AsyncDirectionO_extern(promise, value)
 }
 
-func _$Promise_resolve_14AsyncDirectionO(_ promise: JSObject, _ value: AsyncDirection) throws(JSException) -> Void {
+func _$Promise_resolve_25TestModule_AsyncDirectionO(_ promise: JSObject, _ value: TestModule.AsyncDirection) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_14AsyncDirectionO(promiseValue, valueValue)
+    promise_resolve_TestModule_25TestModule_AsyncDirectionO(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_10AsyncThemeO(_ promise: JSObject, _ value: AsyncTheme) throws(JSException)
+@JSFunction func Promise_resolve_21TestModule_AsyncThemeO(_ promise: JSObject, _ value: TestModule.AsyncTheme) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_10AsyncThemeO")
-fileprivate func promise_resolve_TestModule_10AsyncThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_21TestModule_AsyncThemeO")
+fileprivate func promise_resolve_TestModule_21TestModule_AsyncThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_10AsyncThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_21TestModule_AsyncThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_10AsyncThemeO(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    return promise_resolve_TestModule_10AsyncThemeO_extern(promise, valueBytes, valueLength)
+@inline(never) fileprivate func promise_resolve_TestModule_21TestModule_AsyncThemeO(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_TestModule_21TestModule_AsyncThemeO_extern(promise, valueBytes, valueLength)
 }
 
-func _$Promise_resolve_10AsyncThemeO(_ promise: JSObject, _ value: AsyncTheme) throws(JSException) -> Void {
+func _$Promise_resolve_21TestModule_AsyncThemeO(_ promise: JSObject, _ value: TestModule.AsyncTheme) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
-        promise_resolve_TestModule_10AsyncThemeO(promiseValue, valueBytes, valueLength)
+        promise_resolve_TestModule_21TestModule_AsyncThemeO(promiseValue, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sq14AsyncDirectionO(_ promise: JSObject, _ value: Optional<AsyncDirection>) throws(JSException)
+@JSFunction func Promise_resolve_Sq25TestModule_AsyncDirectionO(_ promise: JSObject, _ value: Optional<TestModule.AsyncDirection>) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq14AsyncDirectionO")
-fileprivate func promise_resolve_TestModule_Sq14AsyncDirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq25TestModule_AsyncDirectionO")
+fileprivate func promise_resolve_TestModule_Sq25TestModule_AsyncDirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_Sq14AsyncDirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_Sq25TestModule_AsyncDirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_Sq14AsyncDirectionO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    return promise_resolve_TestModule_Sq14AsyncDirectionO_extern(promise, valueIsSome, valueValue)
+@inline(never) fileprivate func promise_resolve_TestModule_Sq25TestModule_AsyncDirectionO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    return promise_resolve_TestModule_Sq25TestModule_AsyncDirectionO_extern(promise, valueIsSome, valueValue)
 }
 
-func _$Promise_resolve_Sq14AsyncDirectionO(_ promise: JSObject, _ value: Optional<AsyncDirection>) throws(JSException) -> Void {
+func _$Promise_resolve_Sq25TestModule_AsyncDirectionO(_ promise: JSObject, _ value: Optional<TestModule.AsyncDirection>) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_Sq14AsyncDirectionO(promiseValue, valueIsSome, valueValue)
+    promise_resolve_TestModule_Sq25TestModule_AsyncDirectionO(promiseValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sq10AsyncThemeO(_ promise: JSObject, _ value: Optional<AsyncTheme>) throws(JSException)
+@JSFunction func Promise_resolve_Sq21TestModule_AsyncThemeO(_ promise: JSObject, _ value: Optional<TestModule.AsyncTheme>) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq10AsyncThemeO")
-fileprivate func promise_resolve_TestModule_Sq10AsyncThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq21TestModule_AsyncThemeO")
+fileprivate func promise_resolve_TestModule_Sq21TestModule_AsyncThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_Sq10AsyncThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_Sq21TestModule_AsyncThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_Sq10AsyncThemeO(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    return promise_resolve_TestModule_Sq10AsyncThemeO_extern(promise, valueIsSome, valueBytes, valueLength)
+@inline(never) fileprivate func promise_resolve_TestModule_Sq21TestModule_AsyncThemeO(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_TestModule_Sq21TestModule_AsyncThemeO_extern(promise, valueIsSome, valueBytes, valueLength)
 }
 
-func _$Promise_resolve_Sq10AsyncThemeO(_ promise: JSObject, _ value: Optional<AsyncTheme>) throws(JSException) -> Void {
+func _$Promise_resolve_Sq21TestModule_AsyncThemeO(_ promise: JSObject, _ value: Optional<TestModule.AsyncTheme>) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
-        promise_resolve_TestModule_Sq10AsyncThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
+        promise_resolve_TestModule_Sq21TestModule_AsyncThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sq10AsyncPointV(_ promise: JSObject, _ value: Optional<AsyncPoint>) throws(JSException)
+@JSFunction func Promise_resolve_Sq21TestModule_AsyncPointV(_ promise: JSObject, _ value: Optional<TestModule.AsyncPoint>) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq10AsyncPointV")
-fileprivate func promise_resolve_TestModule_Sq10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq21TestModule_AsyncPointV")
+fileprivate func promise_resolve_TestModule_Sq21TestModule_AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_Sq10AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_Sq21TestModule_AsyncPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_Sq10AsyncPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_TestModule_Sq10AsyncPointV_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_TestModule_Sq21TestModule_AsyncPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_Sq21TestModule_AsyncPointV_extern(promise, value)
 }
 
-func _$Promise_resolve_Sq10AsyncPointV(_ promise: JSObject, _ value: Optional<AsyncPoint>) throws(JSException) -> Void {
+func _$Promise_resolve_Sq21TestModule_AsyncPointV(_ promise: JSObject, _ value: Optional<TestModule.AsyncPoint>) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueIsSome = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_Sq10AsyncPointV(promiseValue, valueIsSome)
+    promise_resolve_TestModule_Sq21TestModule_AsyncPointV(promiseValue, valueIsSome)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sa10AsyncPointV(_ promise: JSObject, _ value: [AsyncPoint]) throws(JSException)
+@JSFunction func Promise_resolve_Sa21TestModule_AsyncPointV(_ promise: JSObject, _ value: [TestModule.AsyncPoint]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sa10AsyncPointV")
-fileprivate func promise_resolve_TestModule_Sa10AsyncPointV_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sa21TestModule_AsyncPointV")
+fileprivate func promise_resolve_TestModule_Sa21TestModule_AsyncPointV_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_Sa10AsyncPointV_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_Sa21TestModule_AsyncPointV_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_Sa10AsyncPointV(_ promise: Int32) -> Void {
-    return promise_resolve_TestModule_Sa10AsyncPointV_extern(promise)
+@inline(never) fileprivate func promise_resolve_TestModule_Sa21TestModule_AsyncPointV(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_Sa21TestModule_AsyncPointV_extern(promise)
 }
 
-func _$Promise_resolve_Sa10AsyncPointV(_ promise: JSObject, _ value: [AsyncPoint]) throws(JSException) -> Void {
+func _$Promise_resolve_Sa21TestModule_AsyncPointV(_ promise: JSObject, _ value: [TestModule.AsyncPoint]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_Sa10AsyncPointV(promiseValue)
+    promise_resolve_TestModule_Sa21TestModule_AsyncPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sa14AsyncDirectionO(_ promise: JSObject, _ value: [AsyncDirection]) throws(JSException)
+@JSFunction func Promise_resolve_Sa25TestModule_AsyncDirectionO(_ promise: JSObject, _ value: [TestModule.AsyncDirection]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sa14AsyncDirectionO")
-fileprivate func promise_resolve_TestModule_Sa14AsyncDirectionO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sa25TestModule_AsyncDirectionO")
+fileprivate func promise_resolve_TestModule_Sa25TestModule_AsyncDirectionO_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_Sa14AsyncDirectionO_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_Sa25TestModule_AsyncDirectionO_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_Sa14AsyncDirectionO(_ promise: Int32) -> Void {
-    return promise_resolve_TestModule_Sa14AsyncDirectionO_extern(promise)
+@inline(never) fileprivate func promise_resolve_TestModule_Sa25TestModule_AsyncDirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_Sa25TestModule_AsyncDirectionO_extern(promise)
 }
 
-func _$Promise_resolve_Sa14AsyncDirectionO(_ promise: JSObject, _ value: [AsyncDirection]) throws(JSException) -> Void {
+func _$Promise_resolve_Sa25TestModule_AsyncDirectionO(_ promise: JSObject, _ value: [TestModule.AsyncDirection]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_Sa14AsyncDirectionO(promiseValue)
+    promise_resolve_TestModule_Sa25TestModule_AsyncDirectionO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_SD10AsyncPointV(_ promise: JSObject, _ value: [String: AsyncPoint]) throws(JSException)
+@JSFunction func Promise_resolve_SD21TestModule_AsyncPointV(_ promise: JSObject, _ value: [String: TestModule.AsyncPoint]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_SD10AsyncPointV")
-fileprivate func promise_resolve_TestModule_SD10AsyncPointV_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_SD21TestModule_AsyncPointV")
+fileprivate func promise_resolve_TestModule_SD21TestModule_AsyncPointV_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_SD10AsyncPointV_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_SD21TestModule_AsyncPointV_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_SD10AsyncPointV(_ promise: Int32) -> Void {
-    return promise_resolve_TestModule_SD10AsyncPointV_extern(promise)
+@inline(never) fileprivate func promise_resolve_TestModule_SD21TestModule_AsyncPointV(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_SD21TestModule_AsyncPointV_extern(promise)
 }
 
-func _$Promise_resolve_SD10AsyncPointV(_ promise: JSObject, _ value: [String: AsyncPoint]) throws(JSException) -> Void {
+func _$Promise_resolve_SD21TestModule_AsyncPointV(_ promise: JSObject, _ value: [String: TestModule.AsyncPoint]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_SD10AsyncPointV(promiseValue)
+    promise_resolve_TestModule_SD21TestModule_AsyncPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_SD14AsyncDirectionO(_ promise: JSObject, _ value: [String: AsyncDirection]) throws(JSException)
+@JSFunction func Promise_resolve_SD25TestModule_AsyncDirectionO(_ promise: JSObject, _ value: [String: TestModule.AsyncDirection]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_SD14AsyncDirectionO")
-fileprivate func promise_resolve_TestModule_SD14AsyncDirectionO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_SD25TestModule_AsyncDirectionO")
+fileprivate func promise_resolve_TestModule_SD25TestModule_AsyncDirectionO_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_SD14AsyncDirectionO_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_SD25TestModule_AsyncDirectionO_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_SD14AsyncDirectionO(_ promise: Int32) -> Void {
-    return promise_resolve_TestModule_SD14AsyncDirectionO_extern(promise)
+@inline(never) fileprivate func promise_resolve_TestModule_SD25TestModule_AsyncDirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_TestModule_SD25TestModule_AsyncDirectionO_extern(promise)
 }
 
-func _$Promise_resolve_SD14AsyncDirectionO(_ promise: JSObject, _ value: [String: AsyncDirection]) throws(JSException) -> Void {
+func _$Promise_resolve_SD25TestModule_AsyncDirectionO(_ promise: JSObject, _ value: [String: TestModule.AsyncDirection]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_SD14AsyncDirectionO(promiseValue)
+    promise_resolve_TestModule_SD25TestModule_AsyncDirectionO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncAssociatedValueEnum.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncAssociatedValueEnum.json
@@ -51,14 +51,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "AsyncPayloadResult",
+        "swiftCallName" : "TestModule.AsyncPayloadResult",
         "tsFullPath" : "AsyncPayloadResult"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_asyncRoundTripAssociatedValueEnum",
+        "abiName" : "bjs_TestModule_asyncRoundTripAssociatedValueEnum",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -71,19 +71,19 @@
             "name" : "value",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "AsyncPayloadResult"
+                "_0" : "TestModule.AsyncPayloadResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "AsyncPayloadResult"
+            "_0" : "TestModule.AsyncPayloadResult"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripOptionalAssociatedValueEnum",
+        "abiName" : "bjs_TestModule_asyncRoundTripOptionalAssociatedValueEnum",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -98,7 +98,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "AsyncPayloadResult"
+                    "_0" : "TestModule.AsyncPayloadResult"
                   }
                 },
                 "_1" : "null"
@@ -110,7 +110,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "AsyncPayloadResult"
+                "_0" : "TestModule.AsyncPayloadResult"
               }
             },
             "_1" : "null"

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncAssociatedValueEnum.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/AsyncAssociatedValueEnum.swift
@@ -1,5 +1,5 @@
-extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AsyncPayloadResult {
+extension TestModule.AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.AsyncPayloadResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -8,7 +8,7 @@ extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
         case 2:
             return .idle
         default:
-            fatalError("Unknown AsyncPayloadResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.AsyncPayloadResult case ID: \(caseId)")
         }
     }
 
@@ -26,12 +26,12 @@ extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-@_expose(wasm, "bjs_asyncRoundTripAssociatedValueEnum")
-@_cdecl("bjs_asyncRoundTripAssociatedValueEnum")
-public func _bjs_asyncRoundTripAssociatedValueEnum(_ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripAssociatedValueEnum")
+@_cdecl("bjs_TestModule_asyncRoundTripAssociatedValueEnum")
+public func _bjs_TestModule_asyncRoundTripAssociatedValueEnum(_ value: Int32) -> Int32 {
     #if arch(wasm32)
-    let _tmp_value = AsyncPayloadResult.bridgeJSLiftParameter(value)
-    return _bjs_makePromise(resolve: Promise_resolve_18AsyncPayloadResultO, reject: Promise_reject) {
+    let _tmp_value = TestModule.AsyncPayloadResult.bridgeJSLiftParameter(value)
+    return _bjs_makePromise(resolve: Promise_resolve_29TestModule_AsyncPayloadResultO, reject: Promise_reject) {
         return await asyncRoundTripAssociatedValueEnum(_: _tmp_value)
     }
     #else
@@ -39,12 +39,12 @@ public func _bjs_asyncRoundTripAssociatedValueEnum(_ value: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripOptionalAssociatedValueEnum")
-@_cdecl("bjs_asyncRoundTripOptionalAssociatedValueEnum")
-public func _bjs_asyncRoundTripOptionalAssociatedValueEnum(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_asyncRoundTripOptionalAssociatedValueEnum")
+@_cdecl("bjs_TestModule_asyncRoundTripOptionalAssociatedValueEnum")
+public func _bjs_TestModule_asyncRoundTripOptionalAssociatedValueEnum(_ valueIsSome: Int32, _ valueCaseId: Int32) -> Int32 {
     #if arch(wasm32)
-    let _tmp_value = Optional<AsyncPayloadResult>.bridgeJSLiftParameter(valueIsSome, valueCaseId)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq18AsyncPayloadResultO, reject: Promise_reject) {
+    let _tmp_value = Optional<TestModule.AsyncPayloadResult>.bridgeJSLiftParameter(valueIsSome, valueCaseId)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq29TestModule_AsyncPayloadResultO, reject: Promise_reject) {
         return await asyncRoundTripOptionalAssociatedValueEnum(_: _tmp_value)
     }
     #else
@@ -73,44 +73,44 @@ func _$Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException)
+@JSFunction func Promise_resolve_29TestModule_AsyncPayloadResultO(_ promise: JSObject, _ value: TestModule.AsyncPayloadResult) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_18AsyncPayloadResultO")
-fileprivate func promise_resolve_TestModule_18AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_29TestModule_AsyncPayloadResultO")
+fileprivate func promise_resolve_TestModule_29TestModule_AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_18AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_29TestModule_AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_18AsyncPayloadResultO(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_TestModule_18AsyncPayloadResultO_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_TestModule_29TestModule_AsyncPayloadResultO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_29TestModule_AsyncPayloadResultO_extern(promise, value)
 }
 
-func _$Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException) -> Void {
+func _$Promise_resolve_29TestModule_AsyncPayloadResultO(_ promise: JSObject, _ value: TestModule.AsyncPayloadResult) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueCaseId = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_18AsyncPayloadResultO(promiseValue, valueCaseId)
+    promise_resolve_TestModule_29TestModule_AsyncPayloadResultO(promiseValue, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException)
+@JSFunction func Promise_resolve_Sq29TestModule_AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<TestModule.AsyncPayloadResult>) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq18AsyncPayloadResultO")
-fileprivate func promise_resolve_TestModule_Sq18AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_Sq29TestModule_AsyncPayloadResultO")
+fileprivate func promise_resolve_TestModule_Sq29TestModule_AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_Sq18AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_Sq29TestModule_AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_Sq18AsyncPayloadResultO(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
-    return promise_resolve_TestModule_Sq18AsyncPayloadResultO_extern(promise, valueIsSome, valueCaseId)
+@inline(never) fileprivate func promise_resolve_TestModule_Sq29TestModule_AsyncPayloadResultO(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
+    return promise_resolve_TestModule_Sq29TestModule_AsyncPayloadResultO_extern(promise, valueIsSome, valueCaseId)
 }
 
-func _$Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException) -> Void {
+func _$Promise_resolve_Sq29TestModule_AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<TestModule.AsyncPayloadResult>) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_Sq18AsyncPayloadResultO(promiseValue, valueIsSome, valueCaseId)
+    promise_resolve_TestModule_Sq29TestModule_AsyncPayloadResultO(promiseValue, valueIsSome, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ClassWithNestedTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ClassWithNestedTypes.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Account_init",
+          "abiName" : "bjs_TestModule_Account_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -26,7 +26,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Account_describe",
+            "abiName" : "bjs_TestModule_Account_describe",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -61,7 +61,7 @@
             "name" : "role",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Account.Role",
+                "_0" : "TestModule.Account.Role",
                 "_1" : "String"
               }
             }
@@ -72,18 +72,18 @@
             "name" : "defaultRole",
             "staticContext" : {
               "className" : {
-                "_0" : "Account"
+                "_0" : "TestModule_Account"
               }
             },
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Account.Role",
+                "_0" : "TestModule.Account.Role",
                 "_1" : "String"
               }
             }
           }
         ],
-        "swiftCallName" : "Account"
+        "swiftCallName" : "TestModule.Account"
       }
     ],
     "enums" : [
@@ -114,7 +114,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Account.Role",
+        "swiftCallName" : "TestModule.Account.Role",
         "tsFullPath" : "Account.Role"
       }
     ],
@@ -128,7 +128,7 @@
     "structs" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Account_Credentials_init",
+          "abiName" : "bjs_TestModule_Account_Credentials_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -148,7 +148,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Account_Credentials_static_empty",
+            "abiName" : "bjs_TestModule_Account_Credentials_static_empty",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -160,12 +160,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Account.Credentials"
+                "_0" : "TestModule.Account.Credentials"
               }
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "Account_Credentials"
+                "_0" : "TestModule_Account_Credentials"
               }
             }
           }
@@ -194,7 +194,7 @@
             "name" : "maxLength",
             "staticContext" : {
               "structName" : {
-                "_0" : "Account_Credentials"
+                "_0" : "TestModule_Account_Credentials"
               }
             },
             "type" : {
@@ -207,7 +207,7 @@
             }
           }
         ],
-        "swiftCallName" : "Account.Credentials"
+        "swiftCallName" : "TestModule.Account.Credentials"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ClassWithNestedTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ClassWithNestedTypes.swift
@@ -1,10 +1,10 @@
-extension Account.Role: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Account.Role: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Account.Credentials: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Account.Credentials {
+extension TestModule.Account.Credentials: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Account.Credentials {
         let token = String.bridgeJSStackPop()
-        return Account.Credentials(token: token)
+        return TestModule.Account.Credentials(token: token)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -12,166 +12,166 @@ extension Account.Credentials: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Account_Credentials(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Account_Credentials(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Account_Credentials()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Account_Credentials()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Account_Credentials")
-fileprivate func _bjs_struct_lower_Account_Credentials_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Account_Credentials")
+fileprivate func _bjs_struct_lower_TestModule_Account_Credentials_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Account_Credentials_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Account_Credentials_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Account_Credentials(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Account_Credentials_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Account_Credentials(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Account_Credentials_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Account_Credentials")
-fileprivate func _bjs_struct_lift_Account_Credentials_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Account_Credentials")
+fileprivate func _bjs_struct_lift_TestModule_Account_Credentials_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Account_Credentials_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Account_Credentials_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Account_Credentials() -> Int32 {
-    return _bjs_struct_lift_Account_Credentials_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Account_Credentials() -> Int32 {
+    return _bjs_struct_lift_TestModule_Account_Credentials_extern()
 }
 
-@_expose(wasm, "bjs_Account_Credentials_init")
-@_cdecl("bjs_Account_Credentials_init")
-public func _bjs_Account_Credentials_init(_ tokenBytes: Int32, _ tokenLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Account_Credentials_init")
+@_cdecl("bjs_TestModule_Account_Credentials_init")
+public func _bjs_TestModule_Account_Credentials_init(_ tokenBytes: Int32, _ tokenLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Account.Credentials(token: String.bridgeJSLiftParameter(tokenBytes, tokenLength))
+    let ret = TestModule.Account.Credentials(token: String.bridgeJSLiftParameter(tokenBytes, tokenLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Account_Credentials_static_maxLength_get")
-@_cdecl("bjs_Account_Credentials_static_maxLength_get")
-public func _bjs_Account_Credentials_static_maxLength_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_Account_Credentials_static_maxLength_get")
+@_cdecl("bjs_TestModule_Account_Credentials_static_maxLength_get")
+public func _bjs_TestModule_Account_Credentials_static_maxLength_get() -> Int32 {
     #if arch(wasm32)
-    let ret = Account.Credentials.maxLength
+    let ret = TestModule.Account.Credentials.maxLength
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Account_Credentials_static_empty")
-@_cdecl("bjs_Account_Credentials_static_empty")
-public func _bjs_Account_Credentials_static_empty() -> Void {
+@_expose(wasm, "bjs_TestModule_Account_Credentials_static_empty")
+@_cdecl("bjs_TestModule_Account_Credentials_static_empty")
+public func _bjs_TestModule_Account_Credentials_static_empty() -> Void {
     #if arch(wasm32)
-    let ret = Account.Credentials.empty()
+    let ret = TestModule.Account.Credentials.empty()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Account_init")
-@_cdecl("bjs_Account_init")
-public func _bjs_Account_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Account_init")
+@_cdecl("bjs_TestModule_Account_init")
+public func _bjs_TestModule_Account_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Account(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Account(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Account_describe")
-@_cdecl("bjs_Account_describe")
-public func _bjs_Account_describe(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Account_describe")
+@_cdecl("bjs_TestModule_Account_describe")
+public func _bjs_TestModule_Account_describe(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Account.bridgeJSLiftParameter(_self).describe()
+    let ret = TestModule.Account.bridgeJSLiftParameter(_self).describe()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Account_name_get")
-@_cdecl("bjs_Account_name_get")
-public func _bjs_Account_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Account_name_get")
+@_cdecl("bjs_TestModule_Account_name_get")
+public func _bjs_TestModule_Account_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Account.bridgeJSLiftParameter(_self).name
+    let ret = TestModule.Account.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Account_name_set")
-@_cdecl("bjs_Account_name_set")
-public func _bjs_Account_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Account_name_set")
+@_cdecl("bjs_TestModule_Account_name_set")
+public func _bjs_TestModule_Account_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    Account.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.Account.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Account_role_get")
-@_cdecl("bjs_Account_role_get")
-public func _bjs_Account_role_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Account_role_get")
+@_cdecl("bjs_TestModule_Account_role_get")
+public func _bjs_TestModule_Account_role_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Account.bridgeJSLiftParameter(_self).role
+    let ret = TestModule.Account.bridgeJSLiftParameter(_self).role
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Account_static_defaultRole_get")
-@_cdecl("bjs_Account_static_defaultRole_get")
-public func _bjs_Account_static_defaultRole_get() -> Void {
+@_expose(wasm, "bjs_TestModule_Account_static_defaultRole_get")
+@_cdecl("bjs_TestModule_Account_static_defaultRole_get")
+public func _bjs_TestModule_Account_static_defaultRole_get() -> Void {
     #if arch(wasm32)
-    let ret = Account.defaultRole
+    let ret = TestModule.Account.defaultRole
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Account_deinit")
-@_cdecl("bjs_Account_deinit")
-public func _bjs_Account_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Account_deinit")
+@_cdecl("bjs_TestModule_Account_deinit")
+public func _bjs_TestModule_Account_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Account>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Account>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Account: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Account: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Account_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Account_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Account_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Account_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Account_wrap")
-fileprivate func _bjs_Account_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Account_wrap")
+fileprivate func _bjs_TestModule_Account_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Account_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Account_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Account_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Account_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Account_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Account_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileExtension.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileExtension.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Greeter_init",
+          "abiName" : "bjs_TestModule_Greeter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -26,7 +26,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Greeter_greet",
+            "abiName" : "bjs_TestModule_Greeter_greet",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -43,7 +43,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_greetFormally",
+            "abiName" : "bjs_TestModule_Greeter_greetFormally",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -64,7 +64,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Greeter"
+        "swiftCallName" : "TestModule.Greeter"
       }
     ],
     "enums" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileExtension.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileExtension.swift
@@ -1,63 +1,63 @@
-@_expose(wasm, "bjs_Greeter_init")
-@_cdecl("bjs_Greeter_init")
-public func _bjs_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Greeter_init")
+@_cdecl("bjs_TestModule_Greeter_init")
+public func _bjs_TestModule_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greet")
-@_cdecl("bjs_Greeter_greet")
-public func _bjs_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_greet")
+@_cdecl("bjs_TestModule_Greeter_greet")
+public func _bjs_TestModule_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greet()
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greetFormally")
-@_cdecl("bjs_Greeter_greetFormally")
-public func _bjs_Greeter_greetFormally(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_greetFormally")
+@_cdecl("bjs_TestModule_Greeter_greetFormally")
+public func _bjs_TestModule_Greeter_greetFormally(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greetFormally()
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).greetFormally()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_deinit")
-@_cdecl("bjs_Greeter_deinit")
-public func _bjs_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_deinit")
+@_cdecl("bjs_TestModule_Greeter_deinit")
+public func _bjs_TestModule_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Greeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Greeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Greeter_wrap")
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Greeter_wrap")
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Greeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Greeter_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.ReverseOrder.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.ReverseOrder.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_FunctionA_init",
+          "abiName" : "bjs_TestModule_FunctionA_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_FunctionA_processB",
+            "abiName" : "bjs_TestModule_FunctionA_processB",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -31,7 +31,7 @@
                 "name" : "b",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "FunctionB"
+                    "_0" : "TestModule.FunctionB"
                   }
                 }
               }
@@ -43,7 +43,7 @@
             }
           },
           {
-            "abiName" : "bjs_FunctionA_createB",
+            "abiName" : "bjs_TestModule_FunctionA_createB",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -63,7 +63,7 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "FunctionB"
+                "_0" : "TestModule.FunctionB"
               }
             }
           }
@@ -72,11 +72,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "FunctionA"
+        "swiftCallName" : "TestModule.FunctionA"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_FunctionB_init",
+          "abiName" : "bjs_TestModule_FunctionB_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -110,7 +110,7 @@
             }
           }
         ],
-        "swiftCallName" : "FunctionB"
+        "swiftCallName" : "TestModule.FunctionB"
       }
     ],
     "enums" : [
@@ -119,7 +119,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_standaloneFunction",
+        "abiName" : "bjs_TestModule_standaloneFunction",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -132,14 +132,14 @@
             "name" : "b",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "FunctionB"
+                "_0" : "TestModule.FunctionB"
               }
             }
           }
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "FunctionB"
+            "_0" : "TestModule.FunctionB"
           }
         }
       }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.ReverseOrder.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.ReverseOrder.swift
@@ -1,137 +1,137 @@
-@_expose(wasm, "bjs_standaloneFunction")
-@_cdecl("bjs_standaloneFunction")
-public func _bjs_standaloneFunction(_ b: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_standaloneFunction")
+@_cdecl("bjs_TestModule_standaloneFunction")
+public func _bjs_TestModule_standaloneFunction(_ b: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = standaloneFunction(b: FunctionB.bridgeJSLiftParameter(b))
+    let ret = standaloneFunction(b: TestModule.FunctionB.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionA_init")
-@_cdecl("bjs_FunctionA_init")
-public func _bjs_FunctionA_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_FunctionA_init")
+@_cdecl("bjs_TestModule_FunctionA_init")
+public func _bjs_TestModule_FunctionA_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = FunctionA()
+    let ret = TestModule.FunctionA()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionA_processB")
-@_cdecl("bjs_FunctionA_processB")
-public func _bjs_FunctionA_processB(_ _self: UnsafeMutableRawPointer, _ b: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionA_processB")
+@_cdecl("bjs_TestModule_FunctionA_processB")
+public func _bjs_TestModule_FunctionA_processB(_ _self: UnsafeMutableRawPointer, _ b: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = FunctionA.bridgeJSLiftParameter(_self).processB(b: FunctionB.bridgeJSLiftParameter(b))
+    let ret = TestModule.FunctionA.bridgeJSLiftParameter(_self).processB(b: TestModule.FunctionB.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionA_createB")
-@_cdecl("bjs_FunctionA_createB")
-public func _bjs_FunctionA_createB(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_FunctionA_createB")
+@_cdecl("bjs_TestModule_FunctionA_createB")
+public func _bjs_TestModule_FunctionA_createB(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = FunctionA.bridgeJSLiftParameter(_self).createB(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    let ret = TestModule.FunctionA.bridgeJSLiftParameter(_self).createB(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionA_deinit")
-@_cdecl("bjs_FunctionA_deinit")
-public func _bjs_FunctionA_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionA_deinit")
+@_cdecl("bjs_TestModule_FunctionA_deinit")
+public func _bjs_TestModule_FunctionA_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<FunctionA>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.FunctionA>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension FunctionA: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.FunctionA: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_FunctionA_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_FunctionA_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_FunctionA_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_FunctionA_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_FunctionA_wrap")
-fileprivate func _bjs_FunctionA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_FunctionA_wrap")
+fileprivate func _bjs_TestModule_FunctionA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_FunctionA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_FunctionA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_FunctionA_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_FunctionA_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_FunctionA_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_FunctionA_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_FunctionB_init")
-@_cdecl("bjs_FunctionB_init")
-public func _bjs_FunctionB_init(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_FunctionB_init")
+@_cdecl("bjs_TestModule_FunctionB_init")
+public func _bjs_TestModule_FunctionB_init(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = FunctionB(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    let ret = TestModule.FunctionB(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionB_value_get")
-@_cdecl("bjs_FunctionB_value_get")
-public func _bjs_FunctionB_value_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionB_value_get")
+@_cdecl("bjs_TestModule_FunctionB_value_get")
+public func _bjs_TestModule_FunctionB_value_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = FunctionB.bridgeJSLiftParameter(_self).value
+    let ret = TestModule.FunctionB.bridgeJSLiftParameter(_self).value
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionB_value_set")
-@_cdecl("bjs_FunctionB_value_set")
-public func _bjs_FunctionB_value_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionB_value_set")
+@_cdecl("bjs_TestModule_FunctionB_value_set")
+public func _bjs_TestModule_FunctionB_value_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    FunctionB.bridgeJSLiftParameter(_self).value = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.FunctionB.bridgeJSLiftParameter(_self).value = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionB_deinit")
-@_cdecl("bjs_FunctionB_deinit")
-public func _bjs_FunctionB_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionB_deinit")
+@_cdecl("bjs_TestModule_FunctionB_deinit")
+public func _bjs_TestModule_FunctionB_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<FunctionB>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.FunctionB>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension FunctionB: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.FunctionB: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_FunctionB_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_FunctionB_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_FunctionB_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_FunctionB_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_FunctionB_wrap")
-fileprivate func _bjs_FunctionB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_FunctionB_wrap")
+fileprivate func _bjs_TestModule_FunctionB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_FunctionB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_FunctionB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_FunctionB_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_FunctionB_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_FunctionB_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_FunctionB_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_FunctionB_init",
+          "abiName" : "bjs_TestModule_FunctionB_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -40,11 +40,11 @@
             }
           }
         ],
-        "swiftCallName" : "FunctionB"
+        "swiftCallName" : "TestModule.FunctionB"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_FunctionA_init",
+          "abiName" : "bjs_TestModule_FunctionA_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -56,7 +56,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_FunctionA_processB",
+            "abiName" : "bjs_TestModule_FunctionA_processB",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -69,7 +69,7 @@
                 "name" : "b",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "FunctionB"
+                    "_0" : "TestModule.FunctionB"
                   }
                 }
               }
@@ -81,7 +81,7 @@
             }
           },
           {
-            "abiName" : "bjs_FunctionA_createB",
+            "abiName" : "bjs_TestModule_FunctionA_createB",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -101,7 +101,7 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "FunctionB"
+                "_0" : "TestModule.FunctionB"
               }
             }
           }
@@ -110,7 +110,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "FunctionA"
+        "swiftCallName" : "TestModule.FunctionA"
       }
     ],
     "enums" : [
@@ -119,7 +119,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_standaloneFunction",
+        "abiName" : "bjs_TestModule_standaloneFunction",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -132,14 +132,14 @@
             "name" : "b",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "FunctionB"
+                "_0" : "TestModule.FunctionB"
               }
             }
           }
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "FunctionB"
+            "_0" : "TestModule.FunctionB"
           }
         }
       }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileFunctionTypes.swift
@@ -1,137 +1,137 @@
-@_expose(wasm, "bjs_standaloneFunction")
-@_cdecl("bjs_standaloneFunction")
-public func _bjs_standaloneFunction(_ b: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_standaloneFunction")
+@_cdecl("bjs_TestModule_standaloneFunction")
+public func _bjs_TestModule_standaloneFunction(_ b: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = standaloneFunction(b: FunctionB.bridgeJSLiftParameter(b))
+    let ret = standaloneFunction(b: TestModule.FunctionB.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionB_init")
-@_cdecl("bjs_FunctionB_init")
-public func _bjs_FunctionB_init(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_FunctionB_init")
+@_cdecl("bjs_TestModule_FunctionB_init")
+public func _bjs_TestModule_FunctionB_init(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = FunctionB(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    let ret = TestModule.FunctionB(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionB_value_get")
-@_cdecl("bjs_FunctionB_value_get")
-public func _bjs_FunctionB_value_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionB_value_get")
+@_cdecl("bjs_TestModule_FunctionB_value_get")
+public func _bjs_TestModule_FunctionB_value_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = FunctionB.bridgeJSLiftParameter(_self).value
+    let ret = TestModule.FunctionB.bridgeJSLiftParameter(_self).value
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionB_value_set")
-@_cdecl("bjs_FunctionB_value_set")
-public func _bjs_FunctionB_value_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionB_value_set")
+@_cdecl("bjs_TestModule_FunctionB_value_set")
+public func _bjs_TestModule_FunctionB_value_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    FunctionB.bridgeJSLiftParameter(_self).value = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.FunctionB.bridgeJSLiftParameter(_self).value = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionB_deinit")
-@_cdecl("bjs_FunctionB_deinit")
-public func _bjs_FunctionB_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionB_deinit")
+@_cdecl("bjs_TestModule_FunctionB_deinit")
+public func _bjs_TestModule_FunctionB_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<FunctionB>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.FunctionB>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension FunctionB: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.FunctionB: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_FunctionB_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_FunctionB_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_FunctionB_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_FunctionB_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_FunctionB_wrap")
-fileprivate func _bjs_FunctionB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_FunctionB_wrap")
+fileprivate func _bjs_TestModule_FunctionB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_FunctionB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_FunctionB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_FunctionB_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_FunctionB_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_FunctionB_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_FunctionB_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_FunctionA_init")
-@_cdecl("bjs_FunctionA_init")
-public func _bjs_FunctionA_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_FunctionA_init")
+@_cdecl("bjs_TestModule_FunctionA_init")
+public func _bjs_TestModule_FunctionA_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = FunctionA()
+    let ret = TestModule.FunctionA()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionA_processB")
-@_cdecl("bjs_FunctionA_processB")
-public func _bjs_FunctionA_processB(_ _self: UnsafeMutableRawPointer, _ b: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionA_processB")
+@_cdecl("bjs_TestModule_FunctionA_processB")
+public func _bjs_TestModule_FunctionA_processB(_ _self: UnsafeMutableRawPointer, _ b: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = FunctionA.bridgeJSLiftParameter(_self).processB(b: FunctionB.bridgeJSLiftParameter(b))
+    let ret = TestModule.FunctionA.bridgeJSLiftParameter(_self).processB(b: TestModule.FunctionB.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionA_createB")
-@_cdecl("bjs_FunctionA_createB")
-public func _bjs_FunctionA_createB(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_FunctionA_createB")
+@_cdecl("bjs_TestModule_FunctionA_createB")
+public func _bjs_TestModule_FunctionA_createB(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = FunctionA.bridgeJSLiftParameter(_self).createB(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    let ret = TestModule.FunctionA.bridgeJSLiftParameter(_self).createB(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_FunctionA_deinit")
-@_cdecl("bjs_FunctionA_deinit")
-public func _bjs_FunctionA_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_FunctionA_deinit")
+@_cdecl("bjs_TestModule_FunctionA_deinit")
+public func _bjs_TestModule_FunctionA_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<FunctionA>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.FunctionA>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension FunctionA: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.FunctionA: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_FunctionA_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_FunctionA_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_FunctionA_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_FunctionA_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_FunctionA_wrap")
-fileprivate func _bjs_FunctionA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_FunctionA_wrap")
+fileprivate func _bjs_TestModule_FunctionA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_FunctionA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_FunctionA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_FunctionA_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_FunctionA_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_FunctionA_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_FunctionA_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.ReverseOrder.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.ReverseOrder.json
@@ -18,7 +18,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "ClassB"
+                    "_0" : "TestModule.ClassB"
                   }
                 },
                 "_1" : "null"
@@ -26,11 +26,11 @@
             }
           }
         ],
-        "swiftCallName" : "ClassA"
+        "swiftCallName" : "TestModule.ClassA"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_ClassB_init",
+          "abiName" : "bjs_TestModule_ClassB_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -47,7 +47,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ClassB"
+        "swiftCallName" : "TestModule.ClassB"
       }
     ],
     "enums" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.ReverseOrder.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.ReverseOrder.swift
@@ -1,93 +1,93 @@
-@_expose(wasm, "bjs_ClassA_linkedB_get")
-@_cdecl("bjs_ClassA_linkedB_get")
-public func _bjs_ClassA_linkedB_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ClassA_linkedB_get")
+@_cdecl("bjs_TestModule_ClassA_linkedB_get")
+public func _bjs_TestModule_ClassA_linkedB_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ClassA.bridgeJSLiftParameter(_self).linkedB
+    let ret = TestModule.ClassA.bridgeJSLiftParameter(_self).linkedB
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassA_linkedB_set")
-@_cdecl("bjs_ClassA_linkedB_set")
-public func _bjs_ClassA_linkedB_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ClassA_linkedB_set")
+@_cdecl("bjs_TestModule_ClassA_linkedB_set")
+public func _bjs_TestModule_ClassA_linkedB_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ClassA.bridgeJSLiftParameter(_self).linkedB = Optional<ClassB>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    TestModule.ClassA.bridgeJSLiftParameter(_self).linkedB = Optional<TestModule.ClassB>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassA_deinit")
-@_cdecl("bjs_ClassA_deinit")
-public func _bjs_ClassA_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ClassA_deinit")
+@_cdecl("bjs_TestModule_ClassA_deinit")
+public func _bjs_TestModule_ClassA_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ClassA>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.ClassA>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ClassA: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.ClassA: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ClassA_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_ClassA_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ClassA_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_ClassA_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_ClassA_wrap")
-fileprivate func _bjs_ClassA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_ClassA_wrap")
+fileprivate func _bjs_TestModule_ClassA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ClassA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_ClassA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ClassA_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ClassA_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_ClassA_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_ClassA_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ClassB_init")
-@_cdecl("bjs_ClassB_init")
-public func _bjs_ClassB_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_ClassB_init")
+@_cdecl("bjs_TestModule_ClassB_init")
+public func _bjs_TestModule_ClassB_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassB()
+    let ret = TestModule.ClassB()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassB_deinit")
-@_cdecl("bjs_ClassB_deinit")
-public func _bjs_ClassB_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ClassB_deinit")
+@_cdecl("bjs_TestModule_ClassB_deinit")
+public func _bjs_TestModule_ClassB_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ClassB>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.ClassB>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ClassB: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.ClassB: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ClassB_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_ClassB_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ClassB_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_ClassB_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_ClassB_wrap")
-fileprivate func _bjs_ClassB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_ClassB_wrap")
+fileprivate func _bjs_TestModule_ClassB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ClassB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_ClassB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ClassB_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ClassB_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_ClassB_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_ClassB_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_ClassB_init",
+          "abiName" : "bjs_TestModule_ClassB_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -23,7 +23,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ClassB"
+        "swiftCallName" : "TestModule.ClassB"
       },
       {
         "methods" : [
@@ -39,7 +39,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "ClassB"
+                    "_0" : "TestModule.ClassB"
                   }
                 },
                 "_1" : "null"
@@ -47,7 +47,7 @@
             }
           }
         ],
-        "swiftCallName" : "ClassA"
+        "swiftCallName" : "TestModule.ClassA"
       }
     ],
     "enums" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/CrossFileTypeResolution.swift
@@ -1,93 +1,93 @@
-@_expose(wasm, "bjs_ClassB_init")
-@_cdecl("bjs_ClassB_init")
-public func _bjs_ClassB_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_ClassB_init")
+@_cdecl("bjs_TestModule_ClassB_init")
+public func _bjs_TestModule_ClassB_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ClassB()
+    let ret = TestModule.ClassB()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassB_deinit")
-@_cdecl("bjs_ClassB_deinit")
-public func _bjs_ClassB_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ClassB_deinit")
+@_cdecl("bjs_TestModule_ClassB_deinit")
+public func _bjs_TestModule_ClassB_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ClassB>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.ClassB>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ClassB: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.ClassB: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ClassB_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_ClassB_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ClassB_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_ClassB_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_ClassB_wrap")
-fileprivate func _bjs_ClassB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_ClassB_wrap")
+fileprivate func _bjs_TestModule_ClassB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ClassB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_ClassB_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ClassB_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ClassB_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_ClassB_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_ClassB_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ClassA_linkedB_get")
-@_cdecl("bjs_ClassA_linkedB_get")
-public func _bjs_ClassA_linkedB_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ClassA_linkedB_get")
+@_cdecl("bjs_TestModule_ClassA_linkedB_get")
+public func _bjs_TestModule_ClassA_linkedB_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ClassA.bridgeJSLiftParameter(_self).linkedB
+    let ret = TestModule.ClassA.bridgeJSLiftParameter(_self).linkedB
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassA_linkedB_set")
-@_cdecl("bjs_ClassA_linkedB_set")
-public func _bjs_ClassA_linkedB_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ClassA_linkedB_set")
+@_cdecl("bjs_TestModule_ClassA_linkedB_set")
+public func _bjs_TestModule_ClassA_linkedB_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    ClassA.bridgeJSLiftParameter(_self).linkedB = Optional<ClassB>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    TestModule.ClassA.bridgeJSLiftParameter(_self).linkedB = Optional<TestModule.ClassB>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClassA_deinit")
-@_cdecl("bjs_ClassA_deinit")
-public func _bjs_ClassA_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ClassA_deinit")
+@_cdecl("bjs_TestModule_ClassA_deinit")
+public func _bjs_TestModule_ClassA_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ClassA>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.ClassA>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ClassA: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.ClassA: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ClassA_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_ClassA_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ClassA_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_ClassA_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_ClassA_wrap")
-fileprivate func _bjs_ClassA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_ClassA_wrap")
+fileprivate func _bjs_TestModule_ClassA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ClassA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_ClassA_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ClassA_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ClassA_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_ClassA_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_ClassA_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_DefaultGreeter_init",
+          "abiName" : "bjs_TestModule_DefaultGreeter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -40,11 +40,11 @@
             }
           }
         ],
-        "swiftCallName" : "DefaultGreeter"
+        "swiftCallName" : "TestModule.DefaultGreeter"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_EmptyGreeter_init",
+          "abiName" : "bjs_TestModule_EmptyGreeter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -61,11 +61,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "EmptyGreeter"
+        "swiftCallName" : "TestModule.EmptyGreeter"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_ConstructorDefaults_init",
+          "abiName" : "bjs_TestModule_ConstructorDefaults_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -120,7 +120,7 @@
             {
               "defaultValue" : {
                 "enumCase" : {
-                  "_0" : "Status",
+                  "_0" : "TestModule.Status",
                   "_1" : "active"
                 }
               },
@@ -128,7 +128,7 @@
               "name" : "status",
               "type" : {
                 "caseEnum" : {
-                  "_0" : "Status"
+                  "_0" : "TestModule.Status"
                 }
               }
             },
@@ -197,7 +197,7 @@
             "name" : "status",
             "type" : {
               "caseEnum" : {
-                "_0" : "Status"
+                "_0" : "TestModule.Status"
               }
             }
           },
@@ -217,7 +217,7 @@
             }
           }
         ],
-        "swiftCallName" : "ConstructorDefaults"
+        "swiftCallName" : "TestModule.ConstructorDefaults"
       }
     ],
     "enums" : [
@@ -251,14 +251,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Status",
+        "swiftCallName" : "TestModule.Status",
         "tsFullPath" : "Status"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_testStringDefault",
+        "abiName" : "bjs_TestModule_testStringDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -288,7 +288,7 @@
         }
       },
       {
-        "abiName" : "bjs_testNegativeIntDefault",
+        "abiName" : "bjs_TestModule_testNegativeIntDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -324,7 +324,7 @@
         }
       },
       {
-        "abiName" : "bjs_testBoolDefault",
+        "abiName" : "bjs_TestModule_testBoolDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -354,7 +354,7 @@
         }
       },
       {
-        "abiName" : "bjs_testNegativeFloatDefault",
+        "abiName" : "bjs_TestModule_testNegativeFloatDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -384,7 +384,7 @@
         }
       },
       {
-        "abiName" : "bjs_testDoubleDefault",
+        "abiName" : "bjs_TestModule_testDoubleDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -414,7 +414,7 @@
         }
       },
       {
-        "abiName" : "bjs_testOptionalDefault",
+        "abiName" : "bjs_TestModule_testOptionalDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -454,7 +454,7 @@
         }
       },
       {
-        "abiName" : "bjs_testOptionalStringDefault",
+        "abiName" : "bjs_TestModule_testOptionalStringDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -494,7 +494,7 @@
         }
       },
       {
-        "abiName" : "bjs_testMultipleDefaults",
+        "abiName" : "bjs_TestModule_testMultipleDefaults",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -555,7 +555,7 @@
         }
       },
       {
-        "abiName" : "bjs_testEnumDefault",
+        "abiName" : "bjs_TestModule_testEnumDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -566,7 +566,7 @@
           {
             "defaultValue" : {
               "enumCase" : {
-                "_0" : "Status",
+                "_0" : "TestModule.Status",
                 "_1" : "active"
               }
             },
@@ -574,19 +574,19 @@
             "name" : "status",
             "type" : {
               "caseEnum" : {
-                "_0" : "Status"
+                "_0" : "TestModule.Status"
               }
             }
           }
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "Status"
+            "_0" : "TestModule.Status"
           }
         }
       },
       {
-        "abiName" : "bjs_testComplexInit",
+        "abiName" : "bjs_TestModule_testComplexInit",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -611,19 +611,19 @@
             "name" : "greeter",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "DefaultGreeter"
+                "_0" : "TestModule.DefaultGreeter"
               }
             }
           }
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "DefaultGreeter"
+            "_0" : "TestModule.DefaultGreeter"
           }
         }
       },
       {
-        "abiName" : "bjs_testEmptyInit",
+        "abiName" : "bjs_TestModule_testEmptyInit",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -641,19 +641,19 @@
             "name" : "greeter",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "EmptyGreeter"
+                "_0" : "TestModule.EmptyGreeter"
               }
             }
           }
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "EmptyGreeter"
+            "_0" : "TestModule.EmptyGreeter"
           }
         }
       },
       {
-        "abiName" : "bjs_testOptionalStructDefault",
+        "abiName" : "bjs_TestModule_testOptionalStructDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -673,7 +673,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Config"
+                    "_0" : "TestModule.Config"
                   }
                 },
                 "_1" : "null"
@@ -685,7 +685,7 @@
           "nullable" : {
             "_0" : {
               "swiftStruct" : {
-                "_0" : "Config"
+                "_0" : "TestModule.Config"
               }
             },
             "_1" : "null"
@@ -693,7 +693,7 @@
         }
       },
       {
-        "abiName" : "bjs_testOptionalStructWithValueDefault",
+        "abiName" : "bjs_TestModule_testOptionalStructWithValueDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -739,7 +739,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Config"
+                    "_0" : "TestModule.Config"
                   }
                 },
                 "_1" : "null"
@@ -751,7 +751,7 @@
           "nullable" : {
             "_0" : {
               "swiftStruct" : {
-                "_0" : "Config"
+                "_0" : "TestModule.Config"
               }
             },
             "_1" : "null"
@@ -759,7 +759,7 @@
         }
       },
       {
-        "abiName" : "bjs_testIntArrayDefault",
+        "abiName" : "bjs_TestModule_testIntArrayDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -819,7 +819,7 @@
         }
       },
       {
-        "abiName" : "bjs_testStringArrayDefault",
+        "abiName" : "bjs_TestModule_testStringArrayDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -873,7 +873,7 @@
         }
       },
       {
-        "abiName" : "bjs_testDoubleArrayDefault",
+        "abiName" : "bjs_TestModule_testDoubleArrayDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -927,7 +927,7 @@
         }
       },
       {
-        "abiName" : "bjs_testBoolArrayDefault",
+        "abiName" : "bjs_TestModule_testBoolArrayDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -981,7 +981,7 @@
         }
       },
       {
-        "abiName" : "bjs_testEmptyArrayDefault",
+        "abiName" : "bjs_TestModule_testEmptyArrayDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1027,7 +1027,7 @@
         }
       },
       {
-        "abiName" : "bjs_testMixedWithArrayDefault",
+        "abiName" : "bjs_TestModule_testMixedWithArrayDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1152,11 +1152,11 @@
             }
           }
         ],
-        "swiftCallName" : "Config"
+        "swiftCallName" : "TestModule.Config"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_MathOperations_init",
+          "abiName" : "bjs_TestModule_MathOperations_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1181,7 +1181,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_MathOperations_add",
+            "abiName" : "bjs_TestModule_MathOperations_add",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1220,7 +1220,7 @@
             }
           },
           {
-            "abiName" : "bjs_MathOperations_multiply",
+            "abiName" : "bjs_TestModule_MathOperations_multiply",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1254,7 +1254,7 @@
             }
           },
           {
-            "abiName" : "bjs_MathOperations_static_subtract",
+            "abiName" : "bjs_TestModule_MathOperations_static_subtract",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -1293,7 +1293,7 @@
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "MathOperations"
+                "_0" : "TestModule_MathOperations"
               }
             }
           }
@@ -1311,7 +1311,7 @@
             }
           }
         ],
-        "swiftCallName" : "MathOperations"
+        "swiftCallName" : "TestModule.MathOperations"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DefaultParameters.swift
@@ -1,12 +1,12 @@
-extension Status: _BridgedSwiftCaseEnum {
+extension TestModule.Status: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Status {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Status {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Status {
-        return Status(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Status {
+        return TestModule.Status(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -37,12 +37,12 @@ extension Status: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Config: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Config {
+extension TestModule.Config: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Config {
         let enabled = Bool.bridgeJSStackPop()
         let value = Int.bridgeJSStackPop()
         let name = String.bridgeJSStackPop()
-        return Config(name: name, value: value, enabled: enabled)
+        return TestModule.Config(name: name, value: value, enabled: enabled)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -52,45 +52,45 @@ extension Config: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Config(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Config()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Config()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Config")
-fileprivate func _bjs_struct_lower_Config_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Config")
+fileprivate func _bjs_struct_lower_TestModule_Config_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Config_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Config_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Config_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Config(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Config_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Config")
-fileprivate func _bjs_struct_lift_Config_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Config")
+fileprivate func _bjs_struct_lift_TestModule_Config_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Config_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Config_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Config() -> Int32 {
-    return _bjs_struct_lift_Config_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Config() -> Int32 {
+    return _bjs_struct_lift_TestModule_Config_extern()
 }
 
-extension MathOperations: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> MathOperations {
+extension TestModule.MathOperations: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.MathOperations {
         let baseValue = Double.bridgeJSStackPop()
-        return MathOperations(baseValue: baseValue)
+        return TestModule.MathOperations(baseValue: baseValue)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -98,88 +98,88 @@ extension MathOperations: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_MathOperations(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_MathOperations()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_MathOperations()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MathOperations")
-fileprivate func _bjs_struct_lower_MathOperations_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_MathOperations")
+fileprivate func _bjs_struct_lower_TestModule_MathOperations_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_MathOperations_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_MathOperations_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_MathOperations_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_MathOperations(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_MathOperations_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_MathOperations")
-fileprivate func _bjs_struct_lift_MathOperations_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_MathOperations")
+fileprivate func _bjs_struct_lift_TestModule_MathOperations_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_MathOperations_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_MathOperations_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_MathOperations() -> Int32 {
-    return _bjs_struct_lift_MathOperations_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_MathOperations() -> Int32 {
+    return _bjs_struct_lift_TestModule_MathOperations_extern()
 }
 
-@_expose(wasm, "bjs_MathOperations_init")
-@_cdecl("bjs_MathOperations_init")
-public func _bjs_MathOperations_init(_ baseValue: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_MathOperations_init")
+@_cdecl("bjs_TestModule_MathOperations_init")
+public func _bjs_TestModule_MathOperations_init(_ baseValue: Float64) -> Void {
     #if arch(wasm32)
-    let ret = MathOperations(baseValue: Double.bridgeJSLiftParameter(baseValue))
+    let ret = TestModule.MathOperations(baseValue: Double.bridgeJSLiftParameter(baseValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathOperations_add")
-@_cdecl("bjs_MathOperations_add")
-public func _bjs_MathOperations_add(_ a: Float64, _ b: Float64) -> Float64 {
+@_expose(wasm, "bjs_TestModule_MathOperations_add")
+@_cdecl("bjs_TestModule_MathOperations_add")
+public func _bjs_TestModule_MathOperations_add(_ a: Float64, _ b: Float64) -> Float64 {
     #if arch(wasm32)
-    let ret = MathOperations.bridgeJSLiftParameter().add(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
+    let ret = TestModule.MathOperations.bridgeJSLiftParameter().add(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathOperations_multiply")
-@_cdecl("bjs_MathOperations_multiply")
-public func _bjs_MathOperations_multiply(_ a: Float64, _ b: Float64) -> Float64 {
+@_expose(wasm, "bjs_TestModule_MathOperations_multiply")
+@_cdecl("bjs_TestModule_MathOperations_multiply")
+public func _bjs_TestModule_MathOperations_multiply(_ a: Float64, _ b: Float64) -> Float64 {
     #if arch(wasm32)
-    let ret = MathOperations.bridgeJSLiftParameter().multiply(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
+    let ret = TestModule.MathOperations.bridgeJSLiftParameter().multiply(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathOperations_static_subtract")
-@_cdecl("bjs_MathOperations_static_subtract")
-public func _bjs_MathOperations_static_subtract(_ a: Float64, _ b: Float64) -> Float64 {
+@_expose(wasm, "bjs_TestModule_MathOperations_static_subtract")
+@_cdecl("bjs_TestModule_MathOperations_static_subtract")
+public func _bjs_TestModule_MathOperations_static_subtract(_ a: Float64, _ b: Float64) -> Float64 {
     #if arch(wasm32)
-    let ret = MathOperations.subtract(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
+    let ret = TestModule.MathOperations.subtract(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_testStringDefault")
-@_cdecl("bjs_testStringDefault")
-public func _bjs_testStringDefault(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_testStringDefault")
+@_cdecl("bjs_TestModule_testStringDefault")
+public func _bjs_TestModule_testStringDefault(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = testStringDefault(message: String.bridgeJSLiftParameter(messageBytes, messageLength))
     return ret.bridgeJSLowerReturn()
@@ -188,9 +188,9 @@ public func _bjs_testStringDefault(_ messageBytes: Int32, _ messageLength: Int32
     #endif
 }
 
-@_expose(wasm, "bjs_testNegativeIntDefault")
-@_cdecl("bjs_testNegativeIntDefault")
-public func _bjs_testNegativeIntDefault(_ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_testNegativeIntDefault")
+@_cdecl("bjs_TestModule_testNegativeIntDefault")
+public func _bjs_TestModule_testNegativeIntDefault(_ value: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = testNegativeIntDefault(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
@@ -199,9 +199,9 @@ public func _bjs_testNegativeIntDefault(_ value: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_testBoolDefault")
-@_cdecl("bjs_testBoolDefault")
-public func _bjs_testBoolDefault(_ flag: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_testBoolDefault")
+@_cdecl("bjs_TestModule_testBoolDefault")
+public func _bjs_TestModule_testBoolDefault(_ flag: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = testBoolDefault(flag: Bool.bridgeJSLiftParameter(flag))
     return ret.bridgeJSLowerReturn()
@@ -210,9 +210,9 @@ public func _bjs_testBoolDefault(_ flag: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_testNegativeFloatDefault")
-@_cdecl("bjs_testNegativeFloatDefault")
-public func _bjs_testNegativeFloatDefault(_ temp: Float32) -> Float32 {
+@_expose(wasm, "bjs_TestModule_testNegativeFloatDefault")
+@_cdecl("bjs_TestModule_testNegativeFloatDefault")
+public func _bjs_TestModule_testNegativeFloatDefault(_ temp: Float32) -> Float32 {
     #if arch(wasm32)
     let ret = testNegativeFloatDefault(temp: Float.bridgeJSLiftParameter(temp))
     return ret.bridgeJSLowerReturn()
@@ -221,9 +221,9 @@ public func _bjs_testNegativeFloatDefault(_ temp: Float32) -> Float32 {
     #endif
 }
 
-@_expose(wasm, "bjs_testDoubleDefault")
-@_cdecl("bjs_testDoubleDefault")
-public func _bjs_testDoubleDefault(_ precision: Float64) -> Float64 {
+@_expose(wasm, "bjs_TestModule_testDoubleDefault")
+@_cdecl("bjs_TestModule_testDoubleDefault")
+public func _bjs_TestModule_testDoubleDefault(_ precision: Float64) -> Float64 {
     #if arch(wasm32)
     let ret = testDoubleDefault(precision: Double.bridgeJSLiftParameter(precision))
     return ret.bridgeJSLowerReturn()
@@ -232,9 +232,9 @@ public func _bjs_testDoubleDefault(_ precision: Float64) -> Float64 {
     #endif
 }
 
-@_expose(wasm, "bjs_testOptionalDefault")
-@_cdecl("bjs_testOptionalDefault")
-public func _bjs_testOptionalDefault(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_testOptionalDefault")
+@_cdecl("bjs_TestModule_testOptionalDefault")
+public func _bjs_TestModule_testOptionalDefault(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = testOptionalDefault(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -243,9 +243,9 @@ public func _bjs_testOptionalDefault(_ nameIsSome: Int32, _ nameBytes: Int32, _ 
     #endif
 }
 
-@_expose(wasm, "bjs_testOptionalStringDefault")
-@_cdecl("bjs_testOptionalStringDefault")
-public func _bjs_testOptionalStringDefault(_ greetingIsSome: Int32, _ greetingBytes: Int32, _ greetingLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_testOptionalStringDefault")
+@_cdecl("bjs_TestModule_testOptionalStringDefault")
+public func _bjs_TestModule_testOptionalStringDefault(_ greetingIsSome: Int32, _ greetingBytes: Int32, _ greetingLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = testOptionalStringDefault(greeting: Optional<String>.bridgeJSLiftParameter(greetingIsSome, greetingBytes, greetingLength))
     return ret.bridgeJSLowerReturn()
@@ -254,9 +254,9 @@ public func _bjs_testOptionalStringDefault(_ greetingIsSome: Int32, _ greetingBy
     #endif
 }
 
-@_expose(wasm, "bjs_testMultipleDefaults")
-@_cdecl("bjs_testMultipleDefaults")
-public func _bjs_testMultipleDefaults(_ titleBytes: Int32, _ titleLength: Int32, _ count: Int32, _ enabled: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_testMultipleDefaults")
+@_cdecl("bjs_TestModule_testMultipleDefaults")
+public func _bjs_TestModule_testMultipleDefaults(_ titleBytes: Int32, _ titleLength: Int32, _ count: Int32, _ enabled: Int32) -> Void {
     #if arch(wasm32)
     let ret = testMultipleDefaults(title: String.bridgeJSLiftParameter(titleBytes, titleLength), count: Int.bridgeJSLiftParameter(count), enabled: Bool.bridgeJSLiftParameter(enabled))
     return ret.bridgeJSLowerReturn()
@@ -265,64 +265,64 @@ public func _bjs_testMultipleDefaults(_ titleBytes: Int32, _ titleLength: Int32,
     #endif
 }
 
-@_expose(wasm, "bjs_testEnumDefault")
-@_cdecl("bjs_testEnumDefault")
-public func _bjs_testEnumDefault(_ status: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_testEnumDefault")
+@_cdecl("bjs_TestModule_testEnumDefault")
+public func _bjs_TestModule_testEnumDefault(_ status: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = testEnumDefault(status: Status.bridgeJSLiftParameter(status))
+    let ret = testEnumDefault(status: TestModule.Status.bridgeJSLiftParameter(status))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_testComplexInit")
-@_cdecl("bjs_testComplexInit")
-public func _bjs_testComplexInit(_ greeter: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_testComplexInit")
+@_cdecl("bjs_TestModule_testComplexInit")
+public func _bjs_TestModule_testComplexInit(_ greeter: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = testComplexInit(greeter: DefaultGreeter.bridgeJSLiftParameter(greeter))
+    let ret = testComplexInit(greeter: TestModule.DefaultGreeter.bridgeJSLiftParameter(greeter))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_testEmptyInit")
-@_cdecl("bjs_testEmptyInit")
-public func _bjs_testEmptyInit(_ greeter: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_testEmptyInit")
+@_cdecl("bjs_TestModule_testEmptyInit")
+public func _bjs_TestModule_testEmptyInit(_ greeter: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = testEmptyInit(greeter: EmptyGreeter.bridgeJSLiftParameter(greeter))
+    let ret = testEmptyInit(greeter: TestModule.EmptyGreeter.bridgeJSLiftParameter(greeter))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_testOptionalStructDefault")
-@_cdecl("bjs_testOptionalStructDefault")
-public func _bjs_testOptionalStructDefault() -> Void {
+@_expose(wasm, "bjs_TestModule_testOptionalStructDefault")
+@_cdecl("bjs_TestModule_testOptionalStructDefault")
+public func _bjs_TestModule_testOptionalStructDefault() -> Void {
     #if arch(wasm32)
-    let ret = testOptionalStructDefault(point: Optional<Config>.bridgeJSLiftParameter())
+    let ret = testOptionalStructDefault(point: Optional<TestModule.Config>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_testOptionalStructWithValueDefault")
-@_cdecl("bjs_testOptionalStructWithValueDefault")
-public func _bjs_testOptionalStructWithValueDefault() -> Void {
+@_expose(wasm, "bjs_TestModule_testOptionalStructWithValueDefault")
+@_cdecl("bjs_TestModule_testOptionalStructWithValueDefault")
+public func _bjs_TestModule_testOptionalStructWithValueDefault() -> Void {
     #if arch(wasm32)
-    let ret = testOptionalStructWithValueDefault(point: Optional<Config>.bridgeJSLiftParameter())
+    let ret = testOptionalStructWithValueDefault(point: Optional<TestModule.Config>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_testIntArrayDefault")
-@_cdecl("bjs_testIntArrayDefault")
-public func _bjs_testIntArrayDefault() -> Void {
+@_expose(wasm, "bjs_TestModule_testIntArrayDefault")
+@_cdecl("bjs_TestModule_testIntArrayDefault")
+public func _bjs_TestModule_testIntArrayDefault() -> Void {
     #if arch(wasm32)
     let ret = testIntArrayDefault(values: [Int].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -331,9 +331,9 @@ public func _bjs_testIntArrayDefault() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_testStringArrayDefault")
-@_cdecl("bjs_testStringArrayDefault")
-public func _bjs_testStringArrayDefault() -> Void {
+@_expose(wasm, "bjs_TestModule_testStringArrayDefault")
+@_cdecl("bjs_TestModule_testStringArrayDefault")
+public func _bjs_TestModule_testStringArrayDefault() -> Void {
     #if arch(wasm32)
     let ret = testStringArrayDefault(names: [String].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -342,9 +342,9 @@ public func _bjs_testStringArrayDefault() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_testDoubleArrayDefault")
-@_cdecl("bjs_testDoubleArrayDefault")
-public func _bjs_testDoubleArrayDefault() -> Void {
+@_expose(wasm, "bjs_TestModule_testDoubleArrayDefault")
+@_cdecl("bjs_TestModule_testDoubleArrayDefault")
+public func _bjs_TestModule_testDoubleArrayDefault() -> Void {
     #if arch(wasm32)
     let ret = testDoubleArrayDefault(values: [Double].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -353,9 +353,9 @@ public func _bjs_testDoubleArrayDefault() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_testBoolArrayDefault")
-@_cdecl("bjs_testBoolArrayDefault")
-public func _bjs_testBoolArrayDefault() -> Void {
+@_expose(wasm, "bjs_TestModule_testBoolArrayDefault")
+@_cdecl("bjs_TestModule_testBoolArrayDefault")
+public func _bjs_TestModule_testBoolArrayDefault() -> Void {
     #if arch(wasm32)
     let ret = testBoolArrayDefault(flags: [Bool].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -364,9 +364,9 @@ public func _bjs_testBoolArrayDefault() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_testEmptyArrayDefault")
-@_cdecl("bjs_testEmptyArrayDefault")
-public func _bjs_testEmptyArrayDefault() -> Void {
+@_expose(wasm, "bjs_TestModule_testEmptyArrayDefault")
+@_cdecl("bjs_TestModule_testEmptyArrayDefault")
+public func _bjs_TestModule_testEmptyArrayDefault() -> Void {
     #if arch(wasm32)
     let ret = testEmptyArrayDefault(items: [Int].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -375,9 +375,9 @@ public func _bjs_testEmptyArrayDefault() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_testMixedWithArrayDefault")
-@_cdecl("bjs_testMixedWithArrayDefault")
-public func _bjs_testMixedWithArrayDefault(_ nameBytes: Int32, _ nameLength: Int32, _ enabled: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_testMixedWithArrayDefault")
+@_cdecl("bjs_TestModule_testMixedWithArrayDefault")
+public func _bjs_TestModule_testMixedWithArrayDefault(_ nameBytes: Int32, _ nameLength: Int32, _ enabled: Int32) -> Void {
     #if arch(wasm32)
     let ret = testMixedWithArrayDefault(name: String.bridgeJSLiftParameter(nameBytes, nameLength), values: [Int].bridgeJSStackPop(), enabled: Bool.bridgeJSLiftParameter(enabled))
     return ret.bridgeJSLowerReturn()
@@ -386,254 +386,254 @@ public func _bjs_testMixedWithArrayDefault(_ nameBytes: Int32, _ nameLength: Int
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultGreeter_init")
-@_cdecl("bjs_DefaultGreeter_init")
-public func _bjs_DefaultGreeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_DefaultGreeter_init")
+@_cdecl("bjs_TestModule_DefaultGreeter_init")
+public func _bjs_TestModule_DefaultGreeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = DefaultGreeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.DefaultGreeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultGreeter_name_get")
-@_cdecl("bjs_DefaultGreeter_name_get")
-public func _bjs_DefaultGreeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_DefaultGreeter_name_get")
+@_cdecl("bjs_TestModule_DefaultGreeter_name_get")
+public func _bjs_TestModule_DefaultGreeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DefaultGreeter.bridgeJSLiftParameter(_self).name
+    let ret = TestModule.DefaultGreeter.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultGreeter_name_set")
-@_cdecl("bjs_DefaultGreeter_name_set")
-public func _bjs_DefaultGreeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_DefaultGreeter_name_set")
+@_cdecl("bjs_TestModule_DefaultGreeter_name_set")
+public func _bjs_TestModule_DefaultGreeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    DefaultGreeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.DefaultGreeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultGreeter_deinit")
-@_cdecl("bjs_DefaultGreeter_deinit")
-public func _bjs_DefaultGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_DefaultGreeter_deinit")
+@_cdecl("bjs_TestModule_DefaultGreeter_deinit")
+public func _bjs_TestModule_DefaultGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<DefaultGreeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.DefaultGreeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension DefaultGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.DefaultGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_DefaultGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_DefaultGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_DefaultGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_DefaultGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_DefaultGreeter_wrap")
-fileprivate func _bjs_DefaultGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_DefaultGreeter_wrap")
+fileprivate func _bjs_TestModule_DefaultGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_DefaultGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_DefaultGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_DefaultGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_DefaultGreeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_DefaultGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_DefaultGreeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_EmptyGreeter_init")
-@_cdecl("bjs_EmptyGreeter_init")
-public func _bjs_EmptyGreeter_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_EmptyGreeter_init")
+@_cdecl("bjs_TestModule_EmptyGreeter_init")
+public func _bjs_TestModule_EmptyGreeter_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = EmptyGreeter()
+    let ret = TestModule.EmptyGreeter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_EmptyGreeter_deinit")
-@_cdecl("bjs_EmptyGreeter_deinit")
-public func _bjs_EmptyGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_EmptyGreeter_deinit")
+@_cdecl("bjs_TestModule_EmptyGreeter_deinit")
+public func _bjs_TestModule_EmptyGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<EmptyGreeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.EmptyGreeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension EmptyGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.EmptyGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_EmptyGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_EmptyGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_EmptyGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_EmptyGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_EmptyGreeter_wrap")
-fileprivate func _bjs_EmptyGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_EmptyGreeter_wrap")
+fileprivate func _bjs_TestModule_EmptyGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_EmptyGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_EmptyGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_EmptyGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_EmptyGreeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_EmptyGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_EmptyGreeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_init")
-@_cdecl("bjs_ConstructorDefaults_init")
-public func _bjs_ConstructorDefaults_init(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ enabled: Int32, _ status: Int32, _ tagIsSome: Int32, _ tagBytes: Int32, _ tagLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_init")
+@_cdecl("bjs_TestModule_ConstructorDefaults_init")
+public func _bjs_TestModule_ConstructorDefaults_init(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ enabled: Int32, _ status: Int32, _ tagIsSome: Int32, _ tagBytes: Int32, _ tagLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ConstructorDefaults(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), enabled: Bool.bridgeJSLiftParameter(enabled), status: Status.bridgeJSLiftParameter(status), tag: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
+    let ret = TestModule.ConstructorDefaults(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), enabled: Bool.bridgeJSLiftParameter(enabled), status: TestModule.Status.bridgeJSLiftParameter(status), tag: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_name_get")
-@_cdecl("bjs_ConstructorDefaults_name_get")
-public func _bjs_ConstructorDefaults_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_name_get")
+@_cdecl("bjs_TestModule_ConstructorDefaults_name_get")
+public func _bjs_TestModule_ConstructorDefaults_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ConstructorDefaults.bridgeJSLiftParameter(_self).name
+    let ret = TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_name_set")
-@_cdecl("bjs_ConstructorDefaults_name_set")
-public func _bjs_ConstructorDefaults_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_name_set")
+@_cdecl("bjs_TestModule_ConstructorDefaults_name_set")
+public func _bjs_TestModule_ConstructorDefaults_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    ConstructorDefaults.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_count_get")
-@_cdecl("bjs_ConstructorDefaults_count_get")
-public func _bjs_ConstructorDefaults_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_count_get")
+@_cdecl("bjs_TestModule_ConstructorDefaults_count_get")
+public func _bjs_TestModule_ConstructorDefaults_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = ConstructorDefaults.bridgeJSLiftParameter(_self).count
+    let ret = TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).count
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_count_set")
-@_cdecl("bjs_ConstructorDefaults_count_set")
-public func _bjs_ConstructorDefaults_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_count_set")
+@_cdecl("bjs_TestModule_ConstructorDefaults_count_set")
+public func _bjs_TestModule_ConstructorDefaults_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    ConstructorDefaults.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
+    TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_enabled_get")
-@_cdecl("bjs_ConstructorDefaults_enabled_get")
-public func _bjs_ConstructorDefaults_enabled_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_enabled_get")
+@_cdecl("bjs_TestModule_ConstructorDefaults_enabled_get")
+public func _bjs_TestModule_ConstructorDefaults_enabled_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = ConstructorDefaults.bridgeJSLiftParameter(_self).enabled
+    let ret = TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).enabled
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_enabled_set")
-@_cdecl("bjs_ConstructorDefaults_enabled_set")
-public func _bjs_ConstructorDefaults_enabled_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_enabled_set")
+@_cdecl("bjs_TestModule_ConstructorDefaults_enabled_set")
+public func _bjs_TestModule_ConstructorDefaults_enabled_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    ConstructorDefaults.bridgeJSLiftParameter(_self).enabled = Bool.bridgeJSLiftParameter(value)
+    TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).enabled = Bool.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_status_get")
-@_cdecl("bjs_ConstructorDefaults_status_get")
-public func _bjs_ConstructorDefaults_status_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_status_get")
+@_cdecl("bjs_TestModule_ConstructorDefaults_status_get")
+public func _bjs_TestModule_ConstructorDefaults_status_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = ConstructorDefaults.bridgeJSLiftParameter(_self).status
+    let ret = TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).status
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_status_set")
-@_cdecl("bjs_ConstructorDefaults_status_set")
-public func _bjs_ConstructorDefaults_status_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_status_set")
+@_cdecl("bjs_TestModule_ConstructorDefaults_status_set")
+public func _bjs_TestModule_ConstructorDefaults_status_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    ConstructorDefaults.bridgeJSLiftParameter(_self).status = Status.bridgeJSLiftParameter(value)
+    TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).status = TestModule.Status.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_tag_get")
-@_cdecl("bjs_ConstructorDefaults_tag_get")
-public func _bjs_ConstructorDefaults_tag_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_tag_get")
+@_cdecl("bjs_TestModule_ConstructorDefaults_tag_get")
+public func _bjs_TestModule_ConstructorDefaults_tag_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = ConstructorDefaults.bridgeJSLiftParameter(_self).tag
+    let ret = TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).tag
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_tag_set")
-@_cdecl("bjs_ConstructorDefaults_tag_set")
-public func _bjs_ConstructorDefaults_tag_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_tag_set")
+@_cdecl("bjs_TestModule_ConstructorDefaults_tag_set")
+public func _bjs_TestModule_ConstructorDefaults_tag_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    ConstructorDefaults.bridgeJSLiftParameter(_self).tag = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    TestModule.ConstructorDefaults.bridgeJSLiftParameter(_self).tag = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConstructorDefaults_deinit")
-@_cdecl("bjs_ConstructorDefaults_deinit")
-public func _bjs_ConstructorDefaults_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ConstructorDefaults_deinit")
+@_cdecl("bjs_TestModule_ConstructorDefaults_deinit")
+public func _bjs_TestModule_ConstructorDefaults_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ConstructorDefaults>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.ConstructorDefaults>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ConstructorDefaults: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.ConstructorDefaults: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ConstructorDefaults_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_ConstructorDefaults_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ConstructorDefaults_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_ConstructorDefaults_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_ConstructorDefaults_wrap")
-fileprivate func _bjs_ConstructorDefaults_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_ConstructorDefaults_wrap")
+fileprivate func _bjs_TestModule_ConstructorDefaults_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ConstructorDefaults_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_ConstructorDefaults_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ConstructorDefaults_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ConstructorDefaults_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_ConstructorDefaults_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_ConstructorDefaults_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DictionaryTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DictionaryTypes.json
@@ -12,7 +12,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Box"
+        "swiftCallName" : "TestModule.Box"
       }
     ],
     "enums" : [
@@ -21,7 +21,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_mirrorDictionary",
+        "abiName" : "bjs_TestModule_mirrorDictionary",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -60,7 +60,7 @@
         }
       },
       {
-        "abiName" : "bjs_optionalDictionary",
+        "abiName" : "bjs_TestModule_optionalDictionary",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -103,7 +103,7 @@
         }
       },
       {
-        "abiName" : "bjs_nestedDictionary",
+        "abiName" : "bjs_TestModule_nestedDictionary",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -150,7 +150,7 @@
         }
       },
       {
-        "abiName" : "bjs_boxDictionary",
+        "abiName" : "bjs_TestModule_boxDictionary",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -165,7 +165,7 @@
               "dictionary" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Box"
+                    "_0" : "TestModule.Box"
                   }
                 }
               }
@@ -176,14 +176,14 @@
           "dictionary" : {
             "_0" : {
               "swiftHeapObject" : {
-                "_0" : "Box"
+                "_0" : "TestModule.Box"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_optionalBoxDictionary",
+        "abiName" : "bjs_TestModule_optionalBoxDictionary",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -200,7 +200,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Box"
+                        "_0" : "TestModule.Box"
                       }
                     },
                     "_1" : "null"
@@ -216,7 +216,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Box"
+                    "_0" : "TestModule.Box"
                   }
                 },
                 "_1" : "null"
@@ -226,7 +226,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripCounters",
+        "abiName" : "bjs_TestModule_roundtripCounters",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -239,14 +239,14 @@
             "name" : "counters",
             "type" : {
               "swiftStruct" : {
-                "_0" : "Counters"
+                "_0" : "TestModule.Counters"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "Counters"
+            "_0" : "TestModule.Counters"
           }
         }
       }
@@ -294,7 +294,7 @@
             }
           }
         ],
-        "swiftCallName" : "Counters"
+        "swiftCallName" : "TestModule.Counters"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DictionaryTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DictionaryTypes.swift
@@ -1,8 +1,8 @@
-extension Counters: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Counters {
+extension TestModule.Counters: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Counters {
         let counts = [String: Optional<Int>].bridgeJSStackPop()
         let name = String.bridgeJSStackPop()
-        return Counters(name: name, counts: counts)
+        return TestModule.Counters(name: name, counts: counts)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -17,44 +17,44 @@ extension Counters: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Counters(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Counters(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Counters()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Counters()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Counters")
-fileprivate func _bjs_struct_lower_Counters_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Counters")
+fileprivate func _bjs_struct_lower_TestModule_Counters_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Counters_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Counters_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Counters(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Counters_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Counters(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Counters_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Counters")
-fileprivate func _bjs_struct_lift_Counters_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Counters")
+fileprivate func _bjs_struct_lift_TestModule_Counters_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Counters_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Counters_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Counters() -> Int32 {
-    return _bjs_struct_lift_Counters_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Counters() -> Int32 {
+    return _bjs_struct_lift_TestModule_Counters_extern()
 }
 
-@_expose(wasm, "bjs_mirrorDictionary")
-@_cdecl("bjs_mirrorDictionary")
-public func _bjs_mirrorDictionary() -> Void {
+@_expose(wasm, "bjs_TestModule_mirrorDictionary")
+@_cdecl("bjs_TestModule_mirrorDictionary")
+public func _bjs_TestModule_mirrorDictionary() -> Void {
     #if arch(wasm32)
     let ret = mirrorDictionary(_: [String: Int].bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
@@ -63,9 +63,9 @@ public func _bjs_mirrorDictionary() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_optionalDictionary")
-@_cdecl("bjs_optionalDictionary")
-public func _bjs_optionalDictionary() -> Void {
+@_expose(wasm, "bjs_TestModule_optionalDictionary")
+@_cdecl("bjs_TestModule_optionalDictionary")
+public func _bjs_TestModule_optionalDictionary() -> Void {
     #if arch(wasm32)
     let ret = optionalDictionary(_: Optional<[String: String]>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
@@ -74,9 +74,9 @@ public func _bjs_optionalDictionary() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_nestedDictionary")
-@_cdecl("bjs_nestedDictionary")
-public func _bjs_nestedDictionary() -> Void {
+@_expose(wasm, "bjs_TestModule_nestedDictionary")
+@_cdecl("bjs_TestModule_nestedDictionary")
+public func _bjs_TestModule_nestedDictionary() -> Void {
     #if arch(wasm32)
     let ret = nestedDictionary(_: [String: [Int]].bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
@@ -85,68 +85,68 @@ public func _bjs_nestedDictionary() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_boxDictionary")
-@_cdecl("bjs_boxDictionary")
-public func _bjs_boxDictionary() -> Void {
+@_expose(wasm, "bjs_TestModule_boxDictionary")
+@_cdecl("bjs_TestModule_boxDictionary")
+public func _bjs_TestModule_boxDictionary() -> Void {
     #if arch(wasm32)
-    let ret = boxDictionary(_: [String: Box].bridgeJSLiftParameter())
+    let ret = boxDictionary(_: [String: TestModule.Box].bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_optionalBoxDictionary")
-@_cdecl("bjs_optionalBoxDictionary")
-public func _bjs_optionalBoxDictionary() -> Void {
+@_expose(wasm, "bjs_TestModule_optionalBoxDictionary")
+@_cdecl("bjs_TestModule_optionalBoxDictionary")
+public func _bjs_TestModule_optionalBoxDictionary() -> Void {
     #if arch(wasm32)
-    let ret = optionalBoxDictionary(_: [String: Optional<Box>].bridgeJSLiftParameter())
+    let ret = optionalBoxDictionary(_: [String: Optional<TestModule.Box>].bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripCounters")
-@_cdecl("bjs_roundtripCounters")
-public func _bjs_roundtripCounters() -> Void {
+@_expose(wasm, "bjs_TestModule_roundtripCounters")
+@_cdecl("bjs_TestModule_roundtripCounters")
+public func _bjs_TestModule_roundtripCounters() -> Void {
     #if arch(wasm32)
-    let ret = roundtripCounters(_: Counters.bridgeJSLiftParameter())
+    let ret = roundtripCounters(_: TestModule.Counters.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Box_deinit")
-@_cdecl("bjs_Box_deinit")
-public func _bjs_Box_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Box_deinit")
+@_cdecl("bjs_TestModule_Box_deinit")
+public func _bjs_TestModule_Box_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Box>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Box>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Box: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Box: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Box_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Box_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Box_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Box_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Box_wrap")
-fileprivate func _bjs_Box_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Box_wrap")
+fileprivate func _bjs_TestModule_Box_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Box_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Box_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Box_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Box_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Box_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Box_wrap_extern(pointer)
 }
 
 #if arch(wasm32)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DocComments.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DocComments.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Greeter_init",
+          "abiName" : "bjs_TestModule_Greeter_init",
           "documentation" : "Create a greeter.\n- Parameter name: The name to greet.",
           "effects" : {
             "isAsync" : false,
@@ -28,7 +28,7 @@
         "documentation" : "A greeter that keeps the target name.",
         "methods" : [
           {
-            "abiName" : "bjs_Greeter_greet",
+            "abiName" : "bjs_TestModule_Greeter_greet",
             "documentation" : "Returns a greeting for the configured name.\n- Returns: The greeting message.",
             "effects" : {
               "isAsync" : false,
@@ -60,7 +60,7 @@
             }
           }
         ],
-        "swiftCallName" : "Greeter"
+        "swiftCallName" : "TestModule.Greeter"
       }
     ],
     "enums" : [
@@ -90,7 +90,7 @@
         "name" : "Color",
         "staticMethods" : [
           {
-            "abiName" : "bjs_Color_static_canonical",
+            "abiName" : "bjs_TestModule_Color_static_canonical",
             "documentation" : "Returns the canonical name for a channel label.\n- Parameter label: The raw label.\n- Returns: The canonical channel name.",
             "effects" : {
               "isAsync" : false,
@@ -116,7 +116,7 @@
             },
             "staticContext" : {
               "enumName" : {
-                "_0" : "Color"
+                "_0" : "TestModule.Color"
               }
             }
           }
@@ -129,7 +129,7 @@
             "name" : "fallback",
             "staticContext" : {
               "enumName" : {
-                "_0" : "Color"
+                "_0" : "TestModule.Color"
               }
             },
             "type" : {
@@ -139,14 +139,14 @@
             }
           }
         ],
-        "swiftCallName" : "Color",
+        "swiftCallName" : "TestModule.Color",
         "tsFullPath" : "Color"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_greet",
+        "abiName" : "bjs_TestModule_greet",
         "documentation" : "Returns a greeting for a user.\n- Parameters:\n  - name: The user's name.\n  - greeting: The greeting word to use.\n- Returns: The composed greeting message.",
         "effects" : {
           "isAsync" : false,
@@ -186,7 +186,7 @@
         }
       },
       {
-        "abiName" : "bjs_add",
+        "abiName" : "bjs_TestModule_add",
         "documentation" : "Adds two numbers together.\n- Parameter a: The first addend.\n- Parameter b: The second addend.\n- Returns: The sum of the inputs.",
         "effects" : {
           "isAsync" : false,
@@ -230,7 +230,7 @@
         }
       },
       {
-        "abiName" : "bjs_trimmed",
+        "abiName" : "bjs_TestModule_trimmed",
         "documentation" : "Has blank doc lines around the summary; boundaries should be trimmed.",
         "effects" : {
           "isAsync" : false,
@@ -248,7 +248,7 @@
         }
       },
       {
-        "abiName" : "bjs_hello",
+        "abiName" : "bjs_TestModule_hello",
         "documentation" : "Says hello to the world.\n\nDemonstrates that block doc comments are supported too.",
         "effects" : {
           "isAsync" : false,
@@ -266,7 +266,7 @@
         }
       },
       {
-        "abiName" : "bjs_parseInt",
+        "abiName" : "bjs_TestModule_parseInt",
         "documentation" : "Parses an integer from text.\n- Parameter text: The text to parse.\n- Returns: The parsed integer.\n- Throws: A `JSException` when the text is not a valid integer.",
         "effects" : {
           "isAsync" : false,
@@ -295,7 +295,7 @@
         }
       },
       {
-        "abiName" : "bjs_MathUtils_double",
+        "abiName" : "bjs_TestModule_MathUtils_double",
         "documentation" : "Doubles a value, in a namespace.\n- Parameter value: The value to double.\n- Returns: Twice the input.",
         "effects" : {
           "isAsync" : false,
@@ -330,7 +330,7 @@
         }
       },
       {
-        "abiName" : "bjs_terminator",
+        "abiName" : "bjs_TestModule_terminator",
         "documentation" : "Returns the JSDoc terminator *\/ embedded mid-sentence.",
         "effects" : {
           "isAsync" : false,
@@ -428,7 +428,7 @@
             }
           }
         ],
-        "swiftCallName" : "Point"
+        "swiftCallName" : "TestModule.Point"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DocComments.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/DocComments.swift
@@ -44,15 +44,15 @@ fileprivate func bjs_Listener_name_get_extern(_ jsObject: Int32) -> Int32 {
     return bjs_Listener_name_get_extern(jsObject)
 }
 
-extension Color: _BridgedSwiftCaseEnum {
+extension TestModule.Color: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Color {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Color {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Color {
-        return Color(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Color {
+        return TestModule.Color(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -83,33 +83,33 @@ extension Color: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_Color_static_canonical")
-@_cdecl("bjs_Color_static_canonical")
-public func _bjs_Color_static_canonical(_ labelBytes: Int32, _ labelLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Color_static_canonical")
+@_cdecl("bjs_TestModule_Color_static_canonical")
+public func _bjs_TestModule_Color_static_canonical(_ labelBytes: Int32, _ labelLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Color.canonical(label: String.bridgeJSLiftParameter(labelBytes, labelLength))
+    let ret = TestModule.Color.canonical(label: String.bridgeJSLiftParameter(labelBytes, labelLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Color_static_fallback_get")
-@_cdecl("bjs_Color_static_fallback_get")
-public func _bjs_Color_static_fallback_get() -> Void {
+@_expose(wasm, "bjs_TestModule_Color_static_fallback_get")
+@_cdecl("bjs_TestModule_Color_static_fallback_get")
+public func _bjs_TestModule_Color_static_fallback_get() -> Void {
     #if arch(wasm32)
-    let ret = Color.fallback
+    let ret = TestModule.Color.fallback
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+extension TestModule.Point: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Point {
         let y = Double.bridgeJSStackPop()
         let x = Double.bridgeJSStackPop()
-        return Point(x: x, y: y)
+        return TestModule.Point(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -118,44 +118,44 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Point()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Point")
+fileprivate func _bjs_struct_lower_TestModule_Point_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Point_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Point_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Point(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Point_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Point")
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Point")
+fileprivate func _bjs_struct_lift_TestModule_Point_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Point_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Point() -> Int32 {
-    return _bjs_struct_lift_Point_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Point() -> Int32 {
+    return _bjs_struct_lift_TestModule_Point_extern()
 }
 
-@_expose(wasm, "bjs_greet")
-@_cdecl("bjs_greet")
-public func _bjs_greet(_ nameBytes: Int32, _ nameLength: Int32, _ greetingBytes: Int32, _ greetingLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_greet")
+@_cdecl("bjs_TestModule_greet")
+public func _bjs_TestModule_greet(_ nameBytes: Int32, _ nameLength: Int32, _ greetingBytes: Int32, _ greetingLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = greet(name: String.bridgeJSLiftParameter(nameBytes, nameLength), greeting: String.bridgeJSLiftParameter(greetingBytes, greetingLength))
     return ret.bridgeJSLowerReturn()
@@ -164,9 +164,9 @@ public func _bjs_greet(_ nameBytes: Int32, _ nameLength: Int32, _ greetingBytes:
     #endif
 }
 
-@_expose(wasm, "bjs_add")
-@_cdecl("bjs_add")
-public func _bjs_add(_ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_add")
+@_cdecl("bjs_TestModule_add")
+public func _bjs_TestModule_add(_ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
@@ -175,9 +175,9 @@ public func _bjs_add(_ a: Int32, _ b: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_trimmed")
-@_cdecl("bjs_trimmed")
-public func _bjs_trimmed() -> Void {
+@_expose(wasm, "bjs_TestModule_trimmed")
+@_cdecl("bjs_TestModule_trimmed")
+public func _bjs_TestModule_trimmed() -> Void {
     #if arch(wasm32)
     trimmed()
     #else
@@ -185,9 +185,9 @@ public func _bjs_trimmed() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_hello")
-@_cdecl("bjs_hello")
-public func _bjs_hello() -> Void {
+@_expose(wasm, "bjs_TestModule_hello")
+@_cdecl("bjs_TestModule_hello")
+public func _bjs_TestModule_hello() -> Void {
     #if arch(wasm32)
     hello()
     #else
@@ -195,9 +195,9 @@ public func _bjs_hello() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_parseInt")
-@_cdecl("bjs_parseInt")
-public func _bjs_parseInt(_ textBytes: Int32, _ textLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_parseInt")
+@_cdecl("bjs_TestModule_parseInt")
+public func _bjs_TestModule_parseInt(_ textBytes: Int32, _ textLength: Int32) -> Int32 {
     #if arch(wasm32)
     do {
         let ret = try parseInt(text: String.bridgeJSLiftParameter(textBytes, textLength))
@@ -220,9 +220,9 @@ public func _bjs_parseInt(_ textBytes: Int32, _ textLength: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_double")
-@_cdecl("bjs_MathUtils_double")
-public func _bjs_MathUtils_double(_ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MathUtils_double")
+@_cdecl("bjs_TestModule_MathUtils_double")
+public func _bjs_TestModule_MathUtils_double(_ value: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = double(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
@@ -231,9 +231,9 @@ public func _bjs_MathUtils_double(_ value: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_terminator")
-@_cdecl("bjs_terminator")
-public func _bjs_terminator() -> Void {
+@_expose(wasm, "bjs_TestModule_terminator")
+@_cdecl("bjs_TestModule_terminator")
+public func _bjs_TestModule_terminator() -> Void {
     #if arch(wasm32)
     let ret = terminator()
     return ret.bridgeJSLowerReturn()
@@ -242,76 +242,76 @@ public func _bjs_terminator() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_init")
-@_cdecl("bjs_Greeter_init")
-public func _bjs_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Greeter_init")
+@_cdecl("bjs_TestModule_Greeter_init")
+public func _bjs_TestModule_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greet")
-@_cdecl("bjs_Greeter_greet")
-public func _bjs_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_greet")
+@_cdecl("bjs_TestModule_Greeter_greet")
+public func _bjs_TestModule_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greet()
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_get")
-@_cdecl("bjs_Greeter_name_get")
-public func _bjs_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_name_get")
+@_cdecl("bjs_TestModule_Greeter_name_get")
+public func _bjs_TestModule_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).name
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_set")
-@_cdecl("bjs_Greeter_name_set")
-public func _bjs_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_name_set")
+@_cdecl("bjs_TestModule_Greeter_name_set")
+public func _bjs_TestModule_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    Greeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.Greeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_deinit")
-@_cdecl("bjs_Greeter_deinit")
-public func _bjs_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_deinit")
+@_cdecl("bjs_TestModule_Greeter_deinit")
+public func _bjs_TestModule_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Greeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Greeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Greeter_wrap")
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Greeter_wrap")
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Greeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Greeter_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.json
@@ -2,10 +2,10 @@
   "exported" : {
     "aliases" : [
       {
-        "swiftCallName" : "Color",
+        "swiftCallName" : "TestModule.Color",
         "underlying" : {
           "swiftHeapObject" : {
-            "_0" : "ColorBox"
+            "_0" : "TestModule.ColorBox"
           }
         }
       }
@@ -13,7 +13,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_ColorBox_init",
+          "abiName" : "bjs_TestModule_ColorBox_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -38,7 +38,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ColorBox"
+        "swiftCallName" : "TestModule.ColorBox"
       }
     ],
     "enums" : [
@@ -47,7 +47,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_roundtripColor",
+        "abiName" : "bjs_TestModule_roundtripColor",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -60,10 +60,10 @@
             "name" : "color",
             "type" : {
               "alias" : {
-                "name" : "Color",
+                "name" : "TestModule.Color",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "ColorBox"
+                    "_0" : "TestModule.ColorBox"
                   }
                 }
               }
@@ -72,10 +72,10 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Color",
+            "name" : "TestModule.Color",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "ColorBox"
+                "_0" : "TestModule.ColorBox"
               }
             }
           }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAlias.swift
@@ -1,54 +1,54 @@
-@_expose(wasm, "bjs_roundtripColor")
-@_cdecl("bjs_roundtripColor")
-public func _bjs_roundtripColor(_ color: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_roundtripColor")
+@_cdecl("bjs_TestModule_roundtripColor")
+public func _bjs_TestModule_roundtripColor(_ color: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundtripColor(_: Color.bridgeJSLiftParameter(color))
+    let ret = roundtripColor(_: TestModule.Color.bridgeJSLiftParameter(color))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ColorBox_init")
-@_cdecl("bjs_ColorBox_init")
-public func _bjs_ColorBox_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_ColorBox_init")
+@_cdecl("bjs_TestModule_ColorBox_init")
+public func _bjs_TestModule_ColorBox_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ColorBox(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.ColorBox(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ColorBox_deinit")
-@_cdecl("bjs_ColorBox_deinit")
-public func _bjs_ColorBox_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ColorBox_deinit")
+@_cdecl("bjs_TestModule_ColorBox_deinit")
+public func _bjs_TestModule_ColorBox_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ColorBox>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.ColorBox>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ColorBox: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.ColorBox: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ColorBox_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_ColorBox_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ColorBox_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_ColorBox_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_ColorBox_wrap")
-fileprivate func _bjs_ColorBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_ColorBox_wrap")
+fileprivate func _bjs_TestModule_ColorBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ColorBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_ColorBox_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ColorBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ColorBox_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_ColorBox_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_ColorBox_wrap_extern(pointer)
 }
 
-extension Color: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension TestModule.Color: _BridgedSwiftAlias, _BridgedSwiftStackType {}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.json
@@ -12,7 +12,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "User"
+        "swiftCallName" : "TestModule.User"
       }
     ],
     "enums" : [
@@ -96,7 +96,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "APIResult",
+        "swiftCallName" : "TestModule.APIResult",
         "tsFullPath" : "APIResult"
       },
       {
@@ -279,7 +279,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "ComplexResult",
+        "swiftCallName" : "TestModule.ComplexResult",
         "tsFullPath" : "ComplexResult"
       },
       {
@@ -294,7 +294,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utilities",
+        "swiftCallName" : "TestModule.Utilities",
         "tsFullPath" : "Utilities"
       },
       {
@@ -374,7 +374,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utilities.Result",
+        "swiftCallName" : "TestModule.Utilities.Result",
         "tsFullPath" : "Utilities.Result"
       },
       {
@@ -425,7 +425,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "NetworkingResult",
+        "swiftCallName" : "TestModule.NetworkingResult",
         "tsFullPath" : "API.NetworkingResult"
       },
       {
@@ -532,7 +532,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "APIOptionalResult",
+        "swiftCallName" : "TestModule.APIOptionalResult",
         "tsFullPath" : "APIOptionalResult"
       },
       {
@@ -561,7 +561,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Precision",
+        "swiftCallName" : "TestModule.Precision",
         "tsFullPath" : "Precision"
       },
       {
@@ -599,7 +599,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "CardinalDirection",
+        "swiftCallName" : "TestModule.CardinalDirection",
         "tsFullPath" : "CardinalDirection"
       },
       {
@@ -609,7 +609,7 @@
               {
                 "type" : {
                   "rawValueEnum" : {
-                    "_0" : "Precision",
+                    "_0" : "TestModule.Precision",
                     "_1" : "Float"
                   }
                 }
@@ -622,7 +622,7 @@
               {
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "CardinalDirection"
+                    "_0" : "TestModule.CardinalDirection"
                   }
                 }
               }
@@ -636,7 +636,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "Precision",
+                        "_0" : "TestModule.Precision",
                         "_1" : "Float"
                       }
                     },
@@ -654,7 +654,7 @@
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "CardinalDirection"
+                        "_0" : "TestModule.CardinalDirection"
                       }
                     },
                     "_1" : "null"
@@ -679,7 +679,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "TypedPayloadResult",
+        "swiftCallName" : "TestModule.TypedPayloadResult",
         "tsFullPath" : "TypedPayloadResult"
       },
       {
@@ -689,7 +689,7 @@
               {
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "TestModule.Point"
                   }
                 }
               }
@@ -701,7 +701,7 @@
               {
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "User"
+                    "_0" : "TestModule.User"
                   }
                 }
               }
@@ -725,7 +725,7 @@
               {
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "TestModule.APIResult"
                   }
                 }
               }
@@ -766,7 +766,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "AllTypesResult",
+        "swiftCallName" : "TestModule.AllTypesResult",
         "tsFullPath" : "AllTypesResult"
       },
       {
@@ -778,7 +778,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "TestModule.Point"
                       }
                     },
                     "_1" : "null"
@@ -795,7 +795,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "User"
+                        "_0" : "TestModule.User"
                       }
                     },
                     "_1" : "null"
@@ -829,7 +829,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "TestModule.APIResult"
                       }
                     },
                     "_1" : "null"
@@ -878,14 +878,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "OptionalAllTypesResult",
+        "swiftCallName" : "TestModule.OptionalAllTypesResult",
         "tsFullPath" : "OptionalAllTypesResult"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_handle",
+        "abiName" : "bjs_TestModule_handle",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -898,7 +898,7 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "TestModule.APIResult"
               }
             }
           }
@@ -910,7 +910,7 @@
         }
       },
       {
-        "abiName" : "bjs_getResult",
+        "abiName" : "bjs_TestModule_getResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -922,12 +922,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "APIResult"
+            "_0" : "TestModule.APIResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripAPIResult",
+        "abiName" : "bjs_TestModule_roundtripAPIResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -940,19 +940,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "TestModule.APIResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "APIResult"
+            "_0" : "TestModule.APIResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalAPIResult",
+        "abiName" : "bjs_TestModule_roundTripOptionalAPIResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -967,7 +967,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "TestModule.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -979,7 +979,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "TestModule.APIResult"
               }
             },
             "_1" : "null"
@@ -987,7 +987,7 @@
         }
       },
       {
-        "abiName" : "bjs_handleComplex",
+        "abiName" : "bjs_TestModule_handleComplex",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1000,7 +1000,7 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "TestModule.ComplexResult"
               }
             }
           }
@@ -1012,7 +1012,7 @@
         }
       },
       {
-        "abiName" : "bjs_getComplexResult",
+        "abiName" : "bjs_TestModule_getComplexResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1024,12 +1024,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "TestModule.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripComplexResult",
+        "abiName" : "bjs_TestModule_roundtripComplexResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1042,19 +1042,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "TestModule.ComplexResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "TestModule.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalComplexResult",
+        "abiName" : "bjs_TestModule_roundTripOptionalComplexResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1069,7 +1069,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "ComplexResult"
+                    "_0" : "TestModule.ComplexResult"
                   }
                 },
                 "_1" : "null"
@@ -1081,7 +1081,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "TestModule.ComplexResult"
               }
             },
             "_1" : "null"
@@ -1089,7 +1089,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalUtilitiesResult",
+        "abiName" : "bjs_TestModule_roundTripOptionalUtilitiesResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1104,7 +1104,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "Utilities.Result"
+                    "_0" : "TestModule.Utilities.Result"
                   }
                 },
                 "_1" : "null"
@@ -1116,7 +1116,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "Utilities.Result"
+                "_0" : "TestModule.Utilities.Result"
               }
             },
             "_1" : "null"
@@ -1124,7 +1124,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalNetworkingResult",
+        "abiName" : "bjs_TestModule_roundTripOptionalNetworkingResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1139,7 +1139,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "NetworkingResult"
+                    "_0" : "TestModule.NetworkingResult"
                   }
                 },
                 "_1" : "null"
@@ -1151,7 +1151,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "NetworkingResult"
+                "_0" : "TestModule.NetworkingResult"
               }
             },
             "_1" : "null"
@@ -1159,7 +1159,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalAPIOptionalResult",
+        "abiName" : "bjs_TestModule_roundTripOptionalAPIOptionalResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1174,7 +1174,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIOptionalResult"
+                    "_0" : "TestModule.APIOptionalResult"
                   }
                 },
                 "_1" : "null"
@@ -1186,7 +1186,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "APIOptionalResult"
+                "_0" : "TestModule.APIOptionalResult"
               }
             },
             "_1" : "null"
@@ -1194,7 +1194,7 @@
         }
       },
       {
-        "abiName" : "bjs_compareAPIResults",
+        "abiName" : "bjs_TestModule_compareAPIResults",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1209,7 +1209,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIOptionalResult"
+                    "_0" : "TestModule.APIOptionalResult"
                   }
                 },
                 "_1" : "null"
@@ -1223,7 +1223,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIOptionalResult"
+                    "_0" : "TestModule.APIOptionalResult"
                   }
                 },
                 "_1" : "null"
@@ -1235,7 +1235,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "APIOptionalResult"
+                "_0" : "TestModule.APIOptionalResult"
               }
             },
             "_1" : "null"
@@ -1243,7 +1243,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripTypedPayloadResult",
+        "abiName" : "bjs_TestModule_roundTripTypedPayloadResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1256,19 +1256,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "TypedPayloadResult"
+                "_0" : "TestModule.TypedPayloadResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "TypedPayloadResult"
+            "_0" : "TestModule.TypedPayloadResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalTypedPayloadResult",
+        "abiName" : "bjs_TestModule_roundTripOptionalTypedPayloadResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1283,7 +1283,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "TypedPayloadResult"
+                    "_0" : "TestModule.TypedPayloadResult"
                   }
                 },
                 "_1" : "null"
@@ -1295,7 +1295,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "TypedPayloadResult"
+                "_0" : "TestModule.TypedPayloadResult"
               }
             },
             "_1" : "null"
@@ -1303,7 +1303,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripAllTypesResult",
+        "abiName" : "bjs_TestModule_roundTripAllTypesResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1316,19 +1316,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "AllTypesResult"
+                "_0" : "TestModule.AllTypesResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "AllTypesResult"
+            "_0" : "TestModule.AllTypesResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalAllTypesResult",
+        "abiName" : "bjs_TestModule_roundTripOptionalAllTypesResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1343,7 +1343,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "AllTypesResult"
+                    "_0" : "TestModule.AllTypesResult"
                   }
                 },
                 "_1" : "null"
@@ -1355,7 +1355,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "AllTypesResult"
+                "_0" : "TestModule.AllTypesResult"
               }
             },
             "_1" : "null"
@@ -1363,7 +1363,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalPayloadResult",
+        "abiName" : "bjs_TestModule_roundTripOptionalPayloadResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1376,19 +1376,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "OptionalAllTypesResult"
+                "_0" : "TestModule.OptionalAllTypesResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "OptionalAllTypesResult"
+            "_0" : "TestModule.OptionalAllTypesResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalPayloadResultOpt",
+        "abiName" : "bjs_TestModule_roundTripOptionalPayloadResultOpt",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1403,7 +1403,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "OptionalAllTypesResult"
+                    "_0" : "TestModule.OptionalAllTypesResult"
                   }
                 },
                 "_1" : "null"
@@ -1415,7 +1415,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "OptionalAllTypesResult"
+                "_0" : "TestModule.OptionalAllTypesResult"
               }
             },
             "_1" : "null"
@@ -1454,7 +1454,7 @@
             }
           }
         ],
-        "swiftCallName" : "Point"
+        "swiftCallName" : "TestModule.Point"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValue.swift
@@ -1,5 +1,5 @@
-extension APIResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
+extension TestModule.APIResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.APIResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -14,7 +14,7 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         case 5:
             return .info
         default:
-            fatalError("Unknown APIResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.APIResult case ID: \(caseId)")
         }
     }
 
@@ -41,8 +41,8 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ComplexResult {
+extension TestModule.ComplexResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.ComplexResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -57,7 +57,7 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
         case 5:
             return .info
         default:
-            fatalError("Unknown ComplexResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.ComplexResult case ID: \(caseId)")
         }
     }
 
@@ -97,8 +97,8 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Utilities.Result {
+extension TestModule.Utilities.Result: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.Utilities.Result {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -107,7 +107,7 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
         case 2:
             return .status(Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), String.bridgeJSStackPop())
         default:
-            fatalError("Unknown Utilities.Result case ID: \(caseId)")
+            fatalError("Unknown TestModule.Utilities.Result case ID: \(caseId)")
         }
     }
 
@@ -129,15 +129,15 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension NetworkingResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> NetworkingResult {
+extension TestModule.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.NetworkingResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
         case 1:
             return .failure(String.bridgeJSStackPop(), Int.bridgeJSStackPop())
         default:
-            fatalError("Unknown NetworkingResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.NetworkingResult case ID: \(caseId)")
         }
     }
 
@@ -154,8 +154,8 @@ extension NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIOptionalResult {
+extension TestModule.APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.APIOptionalResult {
         switch caseId {
         case 0:
             return .success(Optional<String>.bridgeJSStackPop())
@@ -164,7 +164,7 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
         case 2:
             return .status(Optional<Bool>.bridgeJSStackPop(), Optional<Int>.bridgeJSStackPop(), Optional<String>.bridgeJSStackPop())
         default:
-            fatalError("Unknown APIOptionalResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.APIOptionalResult case ID: \(caseId)")
         }
     }
 
@@ -186,18 +186,18 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension CardinalDirection: _BridgedSwiftCaseEnum {
+extension TestModule.CardinalDirection: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> CardinalDirection {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.CardinalDirection {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> CardinalDirection {
-        return CardinalDirection(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.CardinalDirection {
+        return TestModule.CardinalDirection(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -232,21 +232,21 @@ extension CardinalDirection: _BridgedSwiftCaseEnum {
     }
 }
 
-extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TypedPayloadResult {
+extension TestModule.TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.TypedPayloadResult {
         switch caseId {
         case 0:
-            return .precision(Precision.bridgeJSStackPop())
+            return .precision(TestModule.Precision.bridgeJSStackPop())
         case 1:
-            return .direction(CardinalDirection.bridgeJSStackPop())
+            return .direction(TestModule.CardinalDirection.bridgeJSStackPop())
         case 2:
-            return .optPrecision(Optional<Precision>.bridgeJSStackPop())
+            return .optPrecision(Optional<TestModule.Precision>.bridgeJSStackPop())
         case 3:
-            return .optDirection(Optional<CardinalDirection>.bridgeJSStackPop())
+            return .optDirection(Optional<TestModule.CardinalDirection>.bridgeJSStackPop())
         case 4:
             return .empty
         default:
-            fatalError("Unknown TypedPayloadResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.TypedPayloadResult case ID: \(caseId)")
         }
     }
 
@@ -270,23 +270,23 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AllTypesResult {
+extension TestModule.AllTypesResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.AllTypesResult {
         switch caseId {
         case 0:
-            return .structPayload(Point.bridgeJSStackPop())
+            return .structPayload(TestModule.Point.bridgeJSStackPop())
         case 1:
-            return .classPayload(User.bridgeJSStackPop())
+            return .classPayload(TestModule.User.bridgeJSStackPop())
         case 2:
             return .jsObjectPayload(JSObject.bridgeJSStackPop())
         case 3:
-            return .nestedEnum(APIResult.bridgeJSStackPop())
+            return .nestedEnum(TestModule.APIResult.bridgeJSStackPop())
         case 4:
             return .arrayPayload([Int].bridgeJSStackPop())
         case 5:
             return .empty
         default:
-            fatalError("Unknown AllTypesResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.AllTypesResult case ID: \(caseId)")
         }
     }
 
@@ -313,23 +313,23 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> OptionalAllTypesResult {
+extension TestModule.OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.OptionalAllTypesResult {
         switch caseId {
         case 0:
-            return .optStruct(Optional<Point>.bridgeJSStackPop())
+            return .optStruct(Optional<TestModule.Point>.bridgeJSStackPop())
         case 1:
-            return .optClass(Optional<User>.bridgeJSStackPop())
+            return .optClass(Optional<TestModule.User>.bridgeJSStackPop())
         case 2:
             return .optJSObject(Optional<JSObject>.bridgeJSStackPop())
         case 3:
-            return .optNestedEnum(Optional<APIResult>.bridgeJSStackPop())
+            return .optNestedEnum(Optional<TestModule.APIResult>.bridgeJSStackPop())
         case 4:
             return .optArray(Optional<[Int]>.bridgeJSStackPop())
         case 5:
             return .empty
         default:
-            fatalError("Unknown OptionalAllTypesResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.OptionalAllTypesResult case ID: \(caseId)")
         }
     }
 
@@ -356,11 +356,11 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+extension TestModule.Point: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Point {
         let y = Double.bridgeJSStackPop()
         let x = Double.bridgeJSStackPop()
-        return Point(x: x, y: y)
+        return TestModule.Point(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -369,54 +369,54 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Point()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Point")
+fileprivate func _bjs_struct_lower_TestModule_Point_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Point_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Point_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Point(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Point_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Point")
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Point")
+fileprivate func _bjs_struct_lift_TestModule_Point_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Point_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Point() -> Int32 {
-    return _bjs_struct_lift_Point_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Point() -> Int32 {
+    return _bjs_struct_lift_TestModule_Point_extern()
 }
 
-@_expose(wasm, "bjs_handle")
-@_cdecl("bjs_handle")
-public func _bjs_handle(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_handle")
+@_cdecl("bjs_TestModule_handle")
+public func _bjs_TestModule_handle(_ result: Int32) -> Void {
     #if arch(wasm32)
-    handle(result: APIResult.bridgeJSLiftParameter(result))
+    handle(result: TestModule.APIResult.bridgeJSLiftParameter(result))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getResult")
-@_cdecl("bjs_getResult")
-public func _bjs_getResult() -> Void {
+@_expose(wasm, "bjs_TestModule_getResult")
+@_cdecl("bjs_TestModule_getResult")
+public func _bjs_TestModule_getResult() -> Void {
     #if arch(wasm32)
     let ret = getResult()
     return ret.bridgeJSLowerReturn()
@@ -425,41 +425,41 @@ public func _bjs_getResult() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripAPIResult")
-@_cdecl("bjs_roundtripAPIResult")
-public func _bjs_roundtripAPIResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundtripAPIResult")
+@_cdecl("bjs_TestModule_roundtripAPIResult")
+public func _bjs_TestModule_roundtripAPIResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundtripAPIResult(result: APIResult.bridgeJSLiftParameter(result))
+    let ret = roundtripAPIResult(result: TestModule.APIResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalAPIResult")
-@_cdecl("bjs_roundTripOptionalAPIResult")
-public func _bjs_roundTripOptionalAPIResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalAPIResult")
+@_cdecl("bjs_TestModule_roundTripOptionalAPIResult")
+public func _bjs_TestModule_roundTripOptionalAPIResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalAPIResult(result: Optional<APIResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    let ret = roundTripOptionalAPIResult(result: Optional<TestModule.APIResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_handleComplex")
-@_cdecl("bjs_handleComplex")
-public func _bjs_handleComplex(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_handleComplex")
+@_cdecl("bjs_TestModule_handleComplex")
+public func _bjs_TestModule_handleComplex(_ result: Int32) -> Void {
     #if arch(wasm32)
-    handleComplex(result: ComplexResult.bridgeJSLiftParameter(result))
+    handleComplex(result: TestModule.ComplexResult.bridgeJSLiftParameter(result))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getComplexResult")
-@_cdecl("bjs_getComplexResult")
-public func _bjs_getComplexResult() -> Void {
+@_expose(wasm, "bjs_TestModule_getComplexResult")
+@_cdecl("bjs_TestModule_getComplexResult")
+public func _bjs_TestModule_getComplexResult() -> Void {
     #if arch(wasm32)
     let ret = getComplexResult()
     return ret.bridgeJSLowerReturn()
@@ -468,67 +468,67 @@ public func _bjs_getComplexResult() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripComplexResult")
-@_cdecl("bjs_roundtripComplexResult")
-public func _bjs_roundtripComplexResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundtripComplexResult")
+@_cdecl("bjs_TestModule_roundtripComplexResult")
+public func _bjs_TestModule_roundtripComplexResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundtripComplexResult(_: ComplexResult.bridgeJSLiftParameter(result))
+    let ret = roundtripComplexResult(_: TestModule.ComplexResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalComplexResult")
-@_cdecl("bjs_roundTripOptionalComplexResult")
-public func _bjs_roundTripOptionalComplexResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalComplexResult")
+@_cdecl("bjs_TestModule_roundTripOptionalComplexResult")
+public func _bjs_TestModule_roundTripOptionalComplexResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalComplexResult(result: Optional<ComplexResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    let ret = roundTripOptionalComplexResult(result: Optional<TestModule.ComplexResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalUtilitiesResult")
-@_cdecl("bjs_roundTripOptionalUtilitiesResult")
-public func _bjs_roundTripOptionalUtilitiesResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalUtilitiesResult")
+@_cdecl("bjs_TestModule_roundTripOptionalUtilitiesResult")
+public func _bjs_TestModule_roundTripOptionalUtilitiesResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalUtilitiesResult(result: Optional<Utilities.Result>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    let ret = roundTripOptionalUtilitiesResult(result: Optional<TestModule.Utilities.Result>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalNetworkingResult")
-@_cdecl("bjs_roundTripOptionalNetworkingResult")
-public func _bjs_roundTripOptionalNetworkingResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalNetworkingResult")
+@_cdecl("bjs_TestModule_roundTripOptionalNetworkingResult")
+public func _bjs_TestModule_roundTripOptionalNetworkingResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalNetworkingResult(result: Optional<NetworkingResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    let ret = roundTripOptionalNetworkingResult(result: Optional<TestModule.NetworkingResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalAPIOptionalResult")
-@_cdecl("bjs_roundTripOptionalAPIOptionalResult")
-public func _bjs_roundTripOptionalAPIOptionalResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalAPIOptionalResult")
+@_cdecl("bjs_TestModule_roundTripOptionalAPIOptionalResult")
+public func _bjs_TestModule_roundTripOptionalAPIOptionalResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalAPIOptionalResult(result: Optional<APIOptionalResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    let ret = roundTripOptionalAPIOptionalResult(result: Optional<TestModule.APIOptionalResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_compareAPIResults")
-@_cdecl("bjs_compareAPIResults")
-public func _bjs_compareAPIResults(_ result1IsSome: Int32, _ result1CaseId: Int32, _ result2IsSome: Int32, _ result2CaseId: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_compareAPIResults")
+@_cdecl("bjs_TestModule_compareAPIResults")
+public func _bjs_TestModule_compareAPIResults(_ result1IsSome: Int32, _ result1CaseId: Int32, _ result2IsSome: Int32, _ result2CaseId: Int32) -> Void {
     #if arch(wasm32)
-    let _tmp_result2 = Optional<APIOptionalResult>.bridgeJSLiftParameter(result2IsSome, result2CaseId)
-    let _tmp_result1 = Optional<APIOptionalResult>.bridgeJSLiftParameter(result1IsSome, result1CaseId)
+    let _tmp_result2 = Optional<TestModule.APIOptionalResult>.bridgeJSLiftParameter(result2IsSome, result2CaseId)
+    let _tmp_result1 = Optional<TestModule.APIOptionalResult>.bridgeJSLiftParameter(result1IsSome, result1CaseId)
     let ret = compareAPIResults(result1: _tmp_result1, result2: _tmp_result2)
     return ret.bridgeJSLowerReturn()
     #else
@@ -536,99 +536,99 @@ public func _bjs_compareAPIResults(_ result1IsSome: Int32, _ result1CaseId: Int3
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripTypedPayloadResult")
-@_cdecl("bjs_roundTripTypedPayloadResult")
-public func _bjs_roundTripTypedPayloadResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripTypedPayloadResult")
+@_cdecl("bjs_TestModule_roundTripTypedPayloadResult")
+public func _bjs_TestModule_roundTripTypedPayloadResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripTypedPayloadResult(_: TypedPayloadResult.bridgeJSLiftParameter(result))
+    let ret = roundTripTypedPayloadResult(_: TestModule.TypedPayloadResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalTypedPayloadResult")
-@_cdecl("bjs_roundTripOptionalTypedPayloadResult")
-public func _bjs_roundTripOptionalTypedPayloadResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalTypedPayloadResult")
+@_cdecl("bjs_TestModule_roundTripOptionalTypedPayloadResult")
+public func _bjs_TestModule_roundTripOptionalTypedPayloadResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalTypedPayloadResult(_: Optional<TypedPayloadResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    let ret = roundTripOptionalTypedPayloadResult(_: Optional<TestModule.TypedPayloadResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripAllTypesResult")
-@_cdecl("bjs_roundTripAllTypesResult")
-public func _bjs_roundTripAllTypesResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripAllTypesResult")
+@_cdecl("bjs_TestModule_roundTripAllTypesResult")
+public func _bjs_TestModule_roundTripAllTypesResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripAllTypesResult(_: AllTypesResult.bridgeJSLiftParameter(result))
+    let ret = roundTripAllTypesResult(_: TestModule.AllTypesResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalAllTypesResult")
-@_cdecl("bjs_roundTripOptionalAllTypesResult")
-public func _bjs_roundTripOptionalAllTypesResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalAllTypesResult")
+@_cdecl("bjs_TestModule_roundTripOptionalAllTypesResult")
+public func _bjs_TestModule_roundTripOptionalAllTypesResult(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalAllTypesResult(_: Optional<AllTypesResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    let ret = roundTripOptionalAllTypesResult(_: Optional<TestModule.AllTypesResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalPayloadResult")
-@_cdecl("bjs_roundTripOptionalPayloadResult")
-public func _bjs_roundTripOptionalPayloadResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalPayloadResult")
+@_cdecl("bjs_TestModule_roundTripOptionalPayloadResult")
+public func _bjs_TestModule_roundTripOptionalPayloadResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalPayloadResult(_: OptionalAllTypesResult.bridgeJSLiftParameter(result))
+    let ret = roundTripOptionalPayloadResult(_: TestModule.OptionalAllTypesResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalPayloadResultOpt")
-@_cdecl("bjs_roundTripOptionalPayloadResultOpt")
-public func _bjs_roundTripOptionalPayloadResultOpt(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalPayloadResultOpt")
+@_cdecl("bjs_TestModule_roundTripOptionalPayloadResultOpt")
+public func _bjs_TestModule_roundTripOptionalPayloadResultOpt(_ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalPayloadResultOpt(_: Optional<OptionalAllTypesResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    let ret = roundTripOptionalPayloadResultOpt(_: Optional<TestModule.OptionalAllTypesResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_User_deinit")
-@_cdecl("bjs_User_deinit")
-public func _bjs_User_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_User_deinit")
+@_cdecl("bjs_TestModule_User_deinit")
+public func _bjs_TestModule_User_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<User>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.User>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension User: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.User: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_User_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_User_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_User_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_User_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_User_wrap")
-fileprivate func _bjs_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_User_wrap")
+fileprivate func _bjs_TestModule_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_User_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_User_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_User_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_User_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValueImport.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValueImport.json
@@ -51,7 +51,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "PayloadSignal",
+        "swiftCallName" : "TestModule.PayloadSignal",
         "tsFullPath" : "PayloadSignal"
       }
     ],
@@ -92,7 +92,7 @@
                     "name" : "signal",
                     "type" : {
                       "associatedValueEnum" : {
-                        "_0" : "PayloadSignal"
+                        "_0" : "TestModule.PayloadSignal"
                       }
                     }
                   }
@@ -116,7 +116,7 @@
                 ],
                 "returnType" : {
                   "associatedValueEnum" : {
-                    "_0" : "PayloadSignal"
+                    "_0" : "TestModule.PayloadSignal"
                   }
                 }
               },
@@ -135,7 +135,7 @@
                       "nullable" : {
                         "_0" : {
                           "associatedValueEnum" : {
-                            "_0" : "PayloadSignal"
+                            "_0" : "TestModule.PayloadSignal"
                           }
                         },
                         "_1" : "null"
@@ -147,7 +147,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "PayloadSignal"
+                        "_0" : "TestModule.PayloadSignal"
                       }
                     },
                     "_1" : "null"
@@ -173,14 +173,14 @@
                     "name" : "signal",
                     "type" : {
                       "associatedValueEnum" : {
-                        "_0" : "PayloadSignal"
+                        "_0" : "TestModule.PayloadSignal"
                       }
                     }
                   }
                 ],
                 "returnType" : {
                   "associatedValueEnum" : {
-                    "_0" : "PayloadSignal"
+                    "_0" : "TestModule.PayloadSignal"
                   }
                 }
               }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValueImport.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumAssociatedValueImport.swift
@@ -1,5 +1,5 @@
-extension PayloadSignal: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> PayloadSignal {
+extension TestModule.PayloadSignal: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.PayloadSignal {
         switch caseId {
         case 0:
             return .start(String.bridgeJSStackPop())
@@ -8,7 +8,7 @@ extension PayloadSignal: _BridgedSwiftAssociatedValueEnum {
         case 2:
             return .idle
         default:
-            fatalError("Unknown PayloadSignal case ID: \(caseId)")
+            fatalError("Unknown TestModule.PayloadSignal case ID: \(caseId)")
         }
     }
 
@@ -74,16 +74,16 @@ fileprivate func bjs_PayloadSignalControls_roundTripOptional_extern(_ self: Int3
     return bjs_PayloadSignalControls_roundTripOptional_extern(self, signalIsSome, signalCaseId)
 }
 
-func _$PayloadSignalControls_roundTrip(_ signal: PayloadSignal) throws(JSException) -> PayloadSignal {
+func _$PayloadSignalControls_roundTrip(_ signal: TestModule.PayloadSignal) throws(JSException) -> TestModule.PayloadSignal {
     let signalCaseId = signal.bridgeJSLowerParameter()
     let ret = bjs_PayloadSignalControls_roundTrip_static(signalCaseId)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return PayloadSignal.bridgeJSLiftReturn(ret)
+    return TestModule.PayloadSignal.bridgeJSLiftReturn(ret)
 }
 
-func _$PayloadSignalControls_send(_ self: JSObject, _ signal: PayloadSignal) throws(JSException) -> Void {
+func _$PayloadSignalControls_send(_ self: JSObject, _ signal: TestModule.PayloadSignal) throws(JSException) -> Void {
     let selfValue = self.bridgeJSLowerParameter()
     let signalCaseId = signal.bridgeJSLowerParameter()
     bjs_PayloadSignalControls_send(selfValue, signalCaseId)
@@ -92,21 +92,21 @@ func _$PayloadSignalControls_send(_ self: JSObject, _ signal: PayloadSignal) thr
     }
 }
 
-func _$PayloadSignalControls_current(_ self: JSObject) throws(JSException) -> PayloadSignal {
+func _$PayloadSignalControls_current(_ self: JSObject) throws(JSException) -> TestModule.PayloadSignal {
     let selfValue = self.bridgeJSLowerParameter()
     let ret = bjs_PayloadSignalControls_current(selfValue)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return PayloadSignal.bridgeJSLiftReturn(ret)
+    return TestModule.PayloadSignal.bridgeJSLiftReturn(ret)
 }
 
-func _$PayloadSignalControls_roundTripOptional(_ self: JSObject, _ signal: Optional<PayloadSignal>) throws(JSException) -> Optional<PayloadSignal> {
+func _$PayloadSignalControls_roundTripOptional(_ self: JSObject, _ signal: Optional<TestModule.PayloadSignal>) throws(JSException) -> Optional<TestModule.PayloadSignal> {
     let selfValue = self.bridgeJSLowerParameter()
     let (signalIsSome, signalCaseId) = signal.bridgeJSLowerParameter()
     let ret = bjs_PayloadSignalControls_roundTripOptional(selfValue, signalIsSome, signalCaseId)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<PayloadSignal>.bridgeJSLiftReturn(ret)
+    return Optional<TestModule.PayloadSignal>.bridgeJSLiftReturn(ret)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCase.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCase.json
@@ -42,7 +42,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Direction",
+        "swiftCallName" : "TestModule.Direction",
         "tsFullPath" : "Direction"
       },
       {
@@ -74,7 +74,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Status",
+        "swiftCallName" : "TestModule.Status",
         "tsFullPath" : "Status"
       },
       {
@@ -112,7 +112,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "TSDirection",
+        "swiftCallName" : "TestModule.TSDirection",
         "tsFullPath" : "TSDirection"
       },
       {
@@ -133,14 +133,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "PublicStatus",
+        "swiftCallName" : "TestModule.PublicStatus",
         "tsFullPath" : "PublicStatus"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_setDirection",
+        "abiName" : "bjs_TestModule_setDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -153,7 +153,7 @@
             "name" : "direction",
             "type" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "TestModule.Direction"
               }
             }
           }
@@ -165,7 +165,7 @@
         }
       },
       {
-        "abiName" : "bjs_getDirection",
+        "abiName" : "bjs_TestModule_getDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -177,12 +177,12 @@
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "Direction"
+            "_0" : "TestModule.Direction"
           }
         }
       },
       {
-        "abiName" : "bjs_processDirection",
+        "abiName" : "bjs_TestModule_processDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -195,19 +195,19 @@
             "name" : "input",
             "type" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "TestModule.Direction"
               }
             }
           }
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "Status"
+            "_0" : "TestModule.Status"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalDirection",
+        "abiName" : "bjs_TestModule_roundTripOptionalDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -222,7 +222,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "TestModule.Direction"
                   }
                 },
                 "_1" : "null"
@@ -234,7 +234,7 @@
           "nullable" : {
             "_0" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "TestModule.Direction"
               }
             },
             "_1" : "null"
@@ -242,7 +242,7 @@
         }
       },
       {
-        "abiName" : "bjs_setTSDirection",
+        "abiName" : "bjs_TestModule_setTSDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -255,7 +255,7 @@
             "name" : "direction",
             "type" : {
               "caseEnum" : {
-                "_0" : "TSDirection"
+                "_0" : "TestModule.TSDirection"
               }
             }
           }
@@ -267,7 +267,7 @@
         }
       },
       {
-        "abiName" : "bjs_getTSDirection",
+        "abiName" : "bjs_TestModule_getTSDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -279,12 +279,12 @@
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "TSDirection"
+            "_0" : "TestModule.TSDirection"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalTSDirection",
+        "abiName" : "bjs_TestModule_roundTripOptionalTSDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -299,7 +299,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "TSDirection"
+                    "_0" : "TestModule.TSDirection"
                   }
                 },
                 "_1" : "null"
@@ -311,7 +311,7 @@
           "nullable" : {
             "_0" : {
               "caseEnum" : {
-                "_0" : "TSDirection"
+                "_0" : "TestModule.TSDirection"
               }
             },
             "_1" : "null"

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCase.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCase.swift
@@ -1,12 +1,12 @@
-extension Direction: _BridgedSwiftCaseEnum {
+extension TestModule.Direction: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Direction {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Direction {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Direction {
-        return Direction(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Direction {
+        return TestModule.Direction(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -41,15 +41,15 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Status: _BridgedSwiftCaseEnum {
+extension TestModule.Status: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Status {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Status {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Status {
-        return Status(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Status {
+        return TestModule.Status(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -80,15 +80,15 @@ extension Status: _BridgedSwiftCaseEnum {
     }
 }
 
-extension TSDirection: _BridgedSwiftCaseEnum {
+extension TestModule.TSDirection: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TSDirection {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.TSDirection {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TSDirection {
-        return TSDirection(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.TSDirection {
+        return TestModule.TSDirection(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -123,15 +123,15 @@ extension TSDirection: _BridgedSwiftCaseEnum {
     }
 }
 
-extension PublicStatus: _BridgedSwiftCaseEnum {
+extension TestModule.PublicStatus: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> PublicStatus {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.PublicStatus {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> PublicStatus {
-        return PublicStatus(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.PublicStatus {
+        return TestModule.PublicStatus(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -154,19 +154,19 @@ extension PublicStatus: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_setDirection")
-@_cdecl("bjs_setDirection")
-public func _bjs_setDirection(_ direction: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setDirection")
+@_cdecl("bjs_TestModule_setDirection")
+public func _bjs_TestModule_setDirection(_ direction: Int32) -> Void {
     #if arch(wasm32)
-    setDirection(_: Direction.bridgeJSLiftParameter(direction))
+    setDirection(_: TestModule.Direction.bridgeJSLiftParameter(direction))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getDirection")
-@_cdecl("bjs_getDirection")
-public func _bjs_getDirection() -> Int32 {
+@_expose(wasm, "bjs_TestModule_getDirection")
+@_cdecl("bjs_TestModule_getDirection")
+public func _bjs_TestModule_getDirection() -> Int32 {
     #if arch(wasm32)
     let ret = getDirection()
     return ret.bridgeJSLowerReturn()
@@ -175,41 +175,41 @@ public func _bjs_getDirection() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_processDirection")
-@_cdecl("bjs_processDirection")
-public func _bjs_processDirection(_ input: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_processDirection")
+@_cdecl("bjs_TestModule_processDirection")
+public func _bjs_TestModule_processDirection(_ input: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = processDirection(_: Direction.bridgeJSLiftParameter(input))
+    let ret = processDirection(_: TestModule.Direction.bridgeJSLiftParameter(input))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalDirection")
-@_cdecl("bjs_roundTripOptionalDirection")
-public func _bjs_roundTripOptionalDirection(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalDirection")
+@_cdecl("bjs_TestModule_roundTripOptionalDirection")
+public func _bjs_TestModule_roundTripOptionalDirection(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalDirection(_: Optional<Direction>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalDirection(_: Optional<TestModule.Direction>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setTSDirection")
-@_cdecl("bjs_setTSDirection")
-public func _bjs_setTSDirection(_ direction: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setTSDirection")
+@_cdecl("bjs_TestModule_setTSDirection")
+public func _bjs_TestModule_setTSDirection(_ direction: Int32) -> Void {
     #if arch(wasm32)
-    setTSDirection(_: TSDirection.bridgeJSLiftParameter(direction))
+    setTSDirection(_: TestModule.TSDirection.bridgeJSLiftParameter(direction))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getTSDirection")
-@_cdecl("bjs_getTSDirection")
-public func _bjs_getTSDirection() -> Int32 {
+@_expose(wasm, "bjs_TestModule_getTSDirection")
+@_cdecl("bjs_TestModule_getTSDirection")
+public func _bjs_TestModule_getTSDirection() -> Int32 {
     #if arch(wasm32)
     let ret = getTSDirection()
     return ret.bridgeJSLowerReturn()
@@ -218,11 +218,11 @@ public func _bjs_getTSDirection() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalTSDirection")
-@_cdecl("bjs_roundTripOptionalTSDirection")
-public func _bjs_roundTripOptionalTSDirection(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalTSDirection")
+@_cdecl("bjs_TestModule_roundTripOptionalTSDirection")
+public func _bjs_TestModule_roundTripOptionalTSDirection(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalTSDirection(_: Optional<TSDirection>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalTSDirection(_: Optional<TestModule.TSDirection>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCaseImport.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCaseImport.json
@@ -30,7 +30,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Signal",
+        "swiftCallName" : "TestModule.Signal",
         "tsFullPath" : "Signal"
       }
     ],
@@ -71,7 +71,7 @@
                     "name" : "signal",
                     "type" : {
                       "caseEnum" : {
-                        "_0" : "Signal"
+                        "_0" : "TestModule.Signal"
                       }
                     }
                   }
@@ -95,7 +95,7 @@
                 ],
                 "returnType" : {
                   "caseEnum" : {
-                    "_0" : "Signal"
+                    "_0" : "TestModule.Signal"
                   }
                 }
               }
@@ -118,14 +118,14 @@
                     "name" : "signal",
                     "type" : {
                       "caseEnum" : {
-                        "_0" : "Signal"
+                        "_0" : "TestModule.Signal"
                       }
                     }
                   }
                 ],
                 "returnType" : {
                   "caseEnum" : {
-                    "_0" : "Signal"
+                    "_0" : "TestModule.Signal"
                   }
                 }
               }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCaseImport.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumCaseImport.swift
@@ -1,12 +1,12 @@
-extension Signal: _BridgedSwiftCaseEnum {
+extension TestModule.Signal: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Signal {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Signal {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Signal {
-        return Signal(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Signal {
+        return TestModule.Signal(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -69,16 +69,16 @@ fileprivate func bjs_SignalControls_current_extern(_ self: Int32) -> Int32 {
     return bjs_SignalControls_current_extern(self)
 }
 
-func _$SignalControls_roundTrip(_ signal: Signal) throws(JSException) -> Signal {
+func _$SignalControls_roundTrip(_ signal: TestModule.Signal) throws(JSException) -> TestModule.Signal {
     let signalValue = signal.bridgeJSLowerParameter()
     let ret = bjs_SignalControls_roundTrip_static(signalValue)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Signal.bridgeJSLiftReturn(ret)
+    return TestModule.Signal.bridgeJSLiftReturn(ret)
 }
 
-func _$SignalControls_send(_ self: JSObject, _ signal: Signal) throws(JSException) -> Void {
+func _$SignalControls_send(_ self: JSObject, _ signal: TestModule.Signal) throws(JSException) -> Void {
     let selfValue = self.bridgeJSLowerParameter()
     let signalValue = signal.bridgeJSLowerParameter()
     bjs_SignalControls_send(selfValue, signalValue)
@@ -87,11 +87,11 @@ func _$SignalControls_send(_ self: JSObject, _ signal: Signal) throws(JSExceptio
     }
 }
 
-func _$SignalControls_current(_ self: JSObject) throws(JSException) -> Signal {
+func _$SignalControls_current(_ self: JSObject) throws(JSException) -> TestModule.Signal {
     let selfValue = self.bridgeJSLowerParameter()
     let ret = bjs_SignalControls_current(selfValue)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Signal.bridgeJSLiftReturn(ret)
+    return TestModule.Signal.bridgeJSLiftReturn(ret)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Utils_Converter_init",
+          "abiName" : "bjs_TestModule_Utils_Converter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Utils_Converter_toString",
+            "abiName" : "bjs_TestModule_Utils_Converter_toString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -71,11 +71,11 @@
             }
           }
         ],
-        "swiftCallName" : "Utils.Converter"
+        "swiftCallName" : "TestModule.Utils.Converter"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Networking_API_HTTPServer_init",
+          "abiName" : "bjs_TestModule_Networking_API_HTTPServer_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -87,7 +87,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Networking_API_HTTPServer_call",
+            "abiName" : "bjs_TestModule_Networking_API_HTTPServer_call",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -104,7 +104,7 @@
                 "name" : "method",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Networking.API.Method"
+                    "_0" : "TestModule.Networking.API.Method"
                   }
                 }
               }
@@ -124,11 +124,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Networking.API.HTTPServer"
+        "swiftCallName" : "TestModule.Networking.API.HTTPServer"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Networking_APIV2_Internal_TestServer_init",
+          "abiName" : "bjs_TestModule_Internal_TestServer_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -140,7 +140,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Networking_APIV2_Internal_TestServer_call",
+            "abiName" : "bjs_TestModule_Internal_TestServer_call",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -158,7 +158,7 @@
                 "name" : "method",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Internal.SupportedMethod"
+                    "_0" : "TestModule.Internal.SupportedMethod"
                   }
                 }
               }
@@ -179,11 +179,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Internal.TestServer"
+        "swiftCallName" : "TestModule.Internal.TestServer"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Formatting_Converter_init",
+          "abiName" : "bjs_TestModule_Formatting_Converter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -195,7 +195,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Formatting_Converter_format",
+            "abiName" : "bjs_TestModule_Formatting_Converter_format",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -233,7 +233,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Formatting.Converter"
+        "swiftCallName" : "TestModule.Formatting.Converter"
       }
     ],
     "enums" : [
@@ -249,7 +249,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utils",
+        "swiftCallName" : "TestModule.Utils",
         "tsFullPath" : "Utils"
       },
       {
@@ -264,7 +264,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Networking",
+        "swiftCallName" : "TestModule.Networking",
         "tsFullPath" : "Networking"
       },
       {
@@ -282,7 +282,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Networking.API",
+        "swiftCallName" : "TestModule.Networking.API",
         "tsFullPath" : "Networking.API"
       },
       {
@@ -324,7 +324,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Networking.API.Method",
+        "swiftCallName" : "TestModule.Networking.API.Method",
         "tsFullPath" : "Networking.API.Method"
       },
       {
@@ -339,7 +339,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Configuration",
+        "swiftCallName" : "TestModule.Configuration",
         "tsFullPath" : "Configuration"
       },
       {
@@ -385,7 +385,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Configuration.LogLevel",
+        "swiftCallName" : "TestModule.Configuration.LogLevel",
         "tsFullPath" : "Configuration.LogLevel"
       },
       {
@@ -424,7 +424,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Configuration.Port",
+        "swiftCallName" : "TestModule.Configuration.Port",
         "tsFullPath" : "Configuration.Port"
       },
       {
@@ -443,7 +443,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Internal",
+        "swiftCallName" : "TestModule.Internal",
         "tsFullPath" : "Networking.APIV2.Internal"
       },
       {
@@ -474,7 +474,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Internal.SupportedMethod",
+        "swiftCallName" : "TestModule.Internal.SupportedMethod",
         "tsFullPath" : "Networking.APIV2.Internal.SupportedMethod"
       },
       {
@@ -489,7 +489,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Formatting",
+        "swiftCallName" : "TestModule.Formatting",
         "tsFullPath" : "Formatting"
       },
       {
@@ -504,7 +504,7 @@
         ],
         "staticMethods" : [
           {
-            "abiName" : "bjs_Services_Graph_GraphOperations_static_createGraph",
+            "abiName" : "bjs_TestModule_GraphOperations_static_createGraph",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -540,12 +540,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GraphOperations"
+                "_0" : "TestModule.GraphOperations"
               }
             }
           },
           {
-            "abiName" : "bjs_Services_Graph_GraphOperations_static_nodeCount",
+            "abiName" : "bjs_TestModule_GraphOperations_static_nodeCount",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -581,12 +581,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GraphOperations"
+                "_0" : "TestModule.GraphOperations"
               }
             }
           },
           {
-            "abiName" : "bjs_Services_Graph_GraphOperations_static_validate",
+            "abiName" : "bjs_TestModule_GraphOperations_static_validate",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -619,7 +619,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GraphOperations"
+                "_0" : "TestModule.GraphOperations"
               }
             }
           }
@@ -627,7 +627,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GraphOperations",
+        "swiftCallName" : "TestModule.GraphOperations",
         "tsFullPath" : "Services.Graph.GraphOperations"
       }
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.Global.swift
@@ -1,12 +1,12 @@
-extension Networking.API.Method: _BridgedSwiftCaseEnum {
+extension TestModule.Networking.API.Method: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Networking.API.Method {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Networking.API.Method {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Networking.API.Method {
-        return Networking.API.Method(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Networking.API.Method {
+        return TestModule.Networking.API.Method(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -41,21 +41,21 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
+extension TestModule.Internal.SupportedMethod: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Internal.SupportedMethod {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Internal.SupportedMethod {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Internal.SupportedMethod {
-        return Internal.SupportedMethod(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Internal.SupportedMethod {
+        return TestModule.Internal.SupportedMethod(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -82,34 +82,34 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_createGraph")
-@_cdecl("bjs_Services_Graph_GraphOperations_static_createGraph")
-public func _bjs_Services_Graph_GraphOperations_static_createGraph(_ rootId: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_GraphOperations_static_createGraph")
+@_cdecl("bjs_TestModule_GraphOperations_static_createGraph")
+public func _bjs_TestModule_GraphOperations_static_createGraph(_ rootId: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = GraphOperations.createGraph(rootId: Int.bridgeJSLiftParameter(rootId))
+    let ret = TestModule.GraphOperations.createGraph(rootId: Int.bridgeJSLiftParameter(rootId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_nodeCount")
-@_cdecl("bjs_Services_Graph_GraphOperations_static_nodeCount")
-public func _bjs_Services_Graph_GraphOperations_static_nodeCount(_ graphId: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_GraphOperations_static_nodeCount")
+@_cdecl("bjs_TestModule_GraphOperations_static_nodeCount")
+public func _bjs_TestModule_GraphOperations_static_nodeCount(_ graphId: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = GraphOperations.nodeCount(graphId: Int.bridgeJSLiftParameter(graphId))
+    let ret = TestModule.GraphOperations.nodeCount(graphId: Int.bridgeJSLiftParameter(graphId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_validate")
-@_cdecl("bjs_Services_Graph_GraphOperations_static_validate")
-public func _bjs_Services_Graph_GraphOperations_static_validate(_ graphId: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_GraphOperations_static_validate")
+@_cdecl("bjs_TestModule_GraphOperations_static_validate")
+public func _bjs_TestModule_GraphOperations_static_validate(_ graphId: Int32) -> Int32 {
     #if arch(wasm32)
     do {
-        let ret = try GraphOperations.validate(graphId: Int.bridgeJSLiftParameter(graphId))
+        let ret = try TestModule.GraphOperations.validate(graphId: Int.bridgeJSLiftParameter(graphId))
         return ret.bridgeJSLowerReturn()
     } catch let error {
         if let error = error.thrownValue.object {
@@ -129,233 +129,233 @@ public func _bjs_Services_Graph_GraphOperations_static_validate(_ graphId: Int32
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_init")
-@_cdecl("bjs_Utils_Converter_init")
-public func _bjs_Utils_Converter_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_init")
+@_cdecl("bjs_TestModule_Utils_Converter_init")
+public func _bjs_TestModule_Utils_Converter_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Utils.Converter()
+    let ret = TestModule.Utils.Converter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_toString")
-@_cdecl("bjs_Utils_Converter_toString")
-public func _bjs_Utils_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_toString")
+@_cdecl("bjs_TestModule_Utils_Converter_toString")
+public func _bjs_TestModule_Utils_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Utils.Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Utils.Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_precision_get")
-@_cdecl("bjs_Utils_Converter_precision_get")
-public func _bjs_Utils_Converter_precision_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_precision_get")
+@_cdecl("bjs_TestModule_Utils_Converter_precision_get")
+public func _bjs_TestModule_Utils_Converter_precision_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = Utils.Converter.bridgeJSLiftParameter(_self).precision
+    let ret = TestModule.Utils.Converter.bridgeJSLiftParameter(_self).precision
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_precision_set")
-@_cdecl("bjs_Utils_Converter_precision_set")
-public func _bjs_Utils_Converter_precision_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_precision_set")
+@_cdecl("bjs_TestModule_Utils_Converter_precision_set")
+public func _bjs_TestModule_Utils_Converter_precision_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    Utils.Converter.bridgeJSLiftParameter(_self).precision = Int.bridgeJSLiftParameter(value)
+    TestModule.Utils.Converter.bridgeJSLiftParameter(_self).precision = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_deinit")
-@_cdecl("bjs_Utils_Converter_deinit")
-public func _bjs_Utils_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_deinit")
+@_cdecl("bjs_TestModule_Utils_Converter_deinit")
+public func _bjs_TestModule_Utils_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Utils.Converter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Utils.Converter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Utils.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Utils.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Utils_Converter_wrap")
-fileprivate func _bjs_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Utils_Converter_wrap")
+fileprivate func _bjs_TestModule_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Utils_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Utils_Converter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Utils_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Utils_Converter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Networking_API_HTTPServer_init")
-@_cdecl("bjs_Networking_API_HTTPServer_init")
-public func _bjs_Networking_API_HTTPServer_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Networking_API_HTTPServer_init")
+@_cdecl("bjs_TestModule_Networking_API_HTTPServer_init")
+public func _bjs_TestModule_Networking_API_HTTPServer_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Networking.API.HTTPServer()
+    let ret = TestModule.Networking.API.HTTPServer()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_API_HTTPServer_call")
-@_cdecl("bjs_Networking_API_HTTPServer_call")
-public func _bjs_Networking_API_HTTPServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Networking_API_HTTPServer_call")
+@_cdecl("bjs_TestModule_Networking_API_HTTPServer_call")
+public func _bjs_TestModule_Networking_API_HTTPServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
     #if arch(wasm32)
-    Networking.API.HTTPServer.bridgeJSLiftParameter(_self).call(_: Networking.API.Method.bridgeJSLiftParameter(method))
+    TestModule.Networking.API.HTTPServer.bridgeJSLiftParameter(_self).call(_: TestModule.Networking.API.Method.bridgeJSLiftParameter(method))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_API_HTTPServer_deinit")
-@_cdecl("bjs_Networking_API_HTTPServer_deinit")
-public func _bjs_Networking_API_HTTPServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Networking_API_HTTPServer_deinit")
+@_cdecl("bjs_TestModule_Networking_API_HTTPServer_deinit")
+public func _bjs_TestModule_Networking_API_HTTPServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Networking.API.HTTPServer>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Networking.API.HTTPServer>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Networking.API.HTTPServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Networking.API.HTTPServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Networking_API_HTTPServer_wrap")
-fileprivate func _bjs_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Networking_API_HTTPServer_wrap")
+fileprivate func _bjs_TestModule_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Networking_API_HTTPServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Networking_API_HTTPServer_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Networking_API_HTTPServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Networking_API_HTTPServer_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Networking_APIV2_Internal_TestServer_init")
-@_cdecl("bjs_Networking_APIV2_Internal_TestServer_init")
-public func _bjs_Networking_APIV2_Internal_TestServer_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Internal_TestServer_init")
+@_cdecl("bjs_TestModule_Internal_TestServer_init")
+public func _bjs_TestModule_Internal_TestServer_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Internal.TestServer()
+    let ret = TestModule.Internal.TestServer()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_APIV2_Internal_TestServer_call")
-@_cdecl("bjs_Networking_APIV2_Internal_TestServer_call")
-public func _bjs_Networking_APIV2_Internal_TestServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Internal_TestServer_call")
+@_cdecl("bjs_TestModule_Internal_TestServer_call")
+public func _bjs_TestModule_Internal_TestServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
     #if arch(wasm32)
-    Internal.TestServer.bridgeJSLiftParameter(_self).call(_: Internal.SupportedMethod.bridgeJSLiftParameter(method))
+    TestModule.Internal.TestServer.bridgeJSLiftParameter(_self).call(_: TestModule.Internal.SupportedMethod.bridgeJSLiftParameter(method))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_APIV2_Internal_TestServer_deinit")
-@_cdecl("bjs_Networking_APIV2_Internal_TestServer_deinit")
-public func _bjs_Networking_APIV2_Internal_TestServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Internal_TestServer_deinit")
+@_cdecl("bjs_TestModule_Internal_TestServer_deinit")
+public func _bjs_TestModule_Internal_TestServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Internal.TestServer>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Internal.TestServer>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Internal.TestServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Internal.TestServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Networking_APIV2_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Networking_APIV2_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Networking_APIV2_Internal_TestServer_wrap")
-fileprivate func _bjs_Networking_APIV2_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Internal_TestServer_wrap")
+fileprivate func _bjs_TestModule_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Networking_APIV2_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Networking_APIV2_Internal_TestServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Networking_APIV2_Internal_TestServer_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Internal_TestServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Internal_TestServer_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Formatting_Converter_init")
-@_cdecl("bjs_Formatting_Converter_init")
-public func _bjs_Formatting_Converter_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Formatting_Converter_init")
+@_cdecl("bjs_TestModule_Formatting_Converter_init")
+public func _bjs_TestModule_Formatting_Converter_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Formatting.Converter()
+    let ret = TestModule.Formatting.Converter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Formatting_Converter_format")
-@_cdecl("bjs_Formatting_Converter_format")
-public func _bjs_Formatting_Converter_format(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Formatting_Converter_format")
+@_cdecl("bjs_TestModule_Formatting_Converter_format")
+public func _bjs_TestModule_Formatting_Converter_format(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Formatting.Converter.bridgeJSLiftParameter(_self).format(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Formatting.Converter.bridgeJSLiftParameter(_self).format(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Formatting_Converter_deinit")
-@_cdecl("bjs_Formatting_Converter_deinit")
-public func _bjs_Formatting_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Formatting_Converter_deinit")
+@_cdecl("bjs_TestModule_Formatting_Converter_deinit")
+public func _bjs_TestModule_Formatting_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Formatting.Converter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Formatting.Converter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Formatting.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Formatting.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Formatting_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Formatting_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Formatting_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Formatting_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Formatting_Converter_wrap")
-fileprivate func _bjs_Formatting_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Formatting_Converter_wrap")
+fileprivate func _bjs_TestModule_Formatting_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Formatting_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Formatting_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Formatting_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Formatting_Converter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Formatting_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Formatting_Converter_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Utils_Converter_init",
+          "abiName" : "bjs_TestModule_Utils_Converter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Utils_Converter_toString",
+            "abiName" : "bjs_TestModule_Utils_Converter_toString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -71,11 +71,11 @@
             }
           }
         ],
-        "swiftCallName" : "Utils.Converter"
+        "swiftCallName" : "TestModule.Utils.Converter"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Networking_API_HTTPServer_init",
+          "abiName" : "bjs_TestModule_Networking_API_HTTPServer_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -87,7 +87,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Networking_API_HTTPServer_call",
+            "abiName" : "bjs_TestModule_Networking_API_HTTPServer_call",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -104,7 +104,7 @@
                 "name" : "method",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Networking.API.Method"
+                    "_0" : "TestModule.Networking.API.Method"
                   }
                 }
               }
@@ -124,11 +124,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Networking.API.HTTPServer"
+        "swiftCallName" : "TestModule.Networking.API.HTTPServer"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Networking_APIV2_Internal_TestServer_init",
+          "abiName" : "bjs_TestModule_Internal_TestServer_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -140,7 +140,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Networking_APIV2_Internal_TestServer_call",
+            "abiName" : "bjs_TestModule_Internal_TestServer_call",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -158,7 +158,7 @@
                 "name" : "method",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Internal.SupportedMethod"
+                    "_0" : "TestModule.Internal.SupportedMethod"
                   }
                 }
               }
@@ -179,11 +179,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Internal.TestServer"
+        "swiftCallName" : "TestModule.Internal.TestServer"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Formatting_Converter_init",
+          "abiName" : "bjs_TestModule_Formatting_Converter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -195,7 +195,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Formatting_Converter_format",
+            "abiName" : "bjs_TestModule_Formatting_Converter_format",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -233,7 +233,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Formatting.Converter"
+        "swiftCallName" : "TestModule.Formatting.Converter"
       }
     ],
     "enums" : [
@@ -249,7 +249,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utils",
+        "swiftCallName" : "TestModule.Utils",
         "tsFullPath" : "Utils"
       },
       {
@@ -264,7 +264,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Networking",
+        "swiftCallName" : "TestModule.Networking",
         "tsFullPath" : "Networking"
       },
       {
@@ -282,7 +282,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Networking.API",
+        "swiftCallName" : "TestModule.Networking.API",
         "tsFullPath" : "Networking.API"
       },
       {
@@ -324,7 +324,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Networking.API.Method",
+        "swiftCallName" : "TestModule.Networking.API.Method",
         "tsFullPath" : "Networking.API.Method"
       },
       {
@@ -339,7 +339,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Configuration",
+        "swiftCallName" : "TestModule.Configuration",
         "tsFullPath" : "Configuration"
       },
       {
@@ -385,7 +385,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Configuration.LogLevel",
+        "swiftCallName" : "TestModule.Configuration.LogLevel",
         "tsFullPath" : "Configuration.LogLevel"
       },
       {
@@ -424,7 +424,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Configuration.Port",
+        "swiftCallName" : "TestModule.Configuration.Port",
         "tsFullPath" : "Configuration.Port"
       },
       {
@@ -443,7 +443,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Internal",
+        "swiftCallName" : "TestModule.Internal",
         "tsFullPath" : "Networking.APIV2.Internal"
       },
       {
@@ -474,7 +474,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Internal.SupportedMethod",
+        "swiftCallName" : "TestModule.Internal.SupportedMethod",
         "tsFullPath" : "Networking.APIV2.Internal.SupportedMethod"
       },
       {
@@ -489,7 +489,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Formatting",
+        "swiftCallName" : "TestModule.Formatting",
         "tsFullPath" : "Formatting"
       },
       {
@@ -504,7 +504,7 @@
         ],
         "staticMethods" : [
           {
-            "abiName" : "bjs_Services_Graph_GraphOperations_static_createGraph",
+            "abiName" : "bjs_TestModule_GraphOperations_static_createGraph",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -540,12 +540,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GraphOperations"
+                "_0" : "TestModule.GraphOperations"
               }
             }
           },
           {
-            "abiName" : "bjs_Services_Graph_GraphOperations_static_nodeCount",
+            "abiName" : "bjs_TestModule_GraphOperations_static_nodeCount",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -581,12 +581,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GraphOperations"
+                "_0" : "TestModule.GraphOperations"
               }
             }
           },
           {
-            "abiName" : "bjs_Services_Graph_GraphOperations_static_validate",
+            "abiName" : "bjs_TestModule_GraphOperations_static_validate",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -619,7 +619,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GraphOperations"
+                "_0" : "TestModule.GraphOperations"
               }
             }
           }
@@ -627,7 +627,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GraphOperations",
+        "swiftCallName" : "TestModule.GraphOperations",
         "tsFullPath" : "Services.Graph.GraphOperations"
       }
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumNamespace.swift
@@ -1,12 +1,12 @@
-extension Networking.API.Method: _BridgedSwiftCaseEnum {
+extension TestModule.Networking.API.Method: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Networking.API.Method {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Networking.API.Method {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Networking.API.Method {
-        return Networking.API.Method(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Networking.API.Method {
+        return TestModule.Networking.API.Method(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -41,21 +41,21 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
+extension TestModule.Internal.SupportedMethod: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Internal.SupportedMethod {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Internal.SupportedMethod {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Internal.SupportedMethod {
-        return Internal.SupportedMethod(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Internal.SupportedMethod {
+        return TestModule.Internal.SupportedMethod(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -82,34 +82,34 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_createGraph")
-@_cdecl("bjs_Services_Graph_GraphOperations_static_createGraph")
-public func _bjs_Services_Graph_GraphOperations_static_createGraph(_ rootId: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_GraphOperations_static_createGraph")
+@_cdecl("bjs_TestModule_GraphOperations_static_createGraph")
+public func _bjs_TestModule_GraphOperations_static_createGraph(_ rootId: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = GraphOperations.createGraph(rootId: Int.bridgeJSLiftParameter(rootId))
+    let ret = TestModule.GraphOperations.createGraph(rootId: Int.bridgeJSLiftParameter(rootId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_nodeCount")
-@_cdecl("bjs_Services_Graph_GraphOperations_static_nodeCount")
-public func _bjs_Services_Graph_GraphOperations_static_nodeCount(_ graphId: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_GraphOperations_static_nodeCount")
+@_cdecl("bjs_TestModule_GraphOperations_static_nodeCount")
+public func _bjs_TestModule_GraphOperations_static_nodeCount(_ graphId: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = GraphOperations.nodeCount(graphId: Int.bridgeJSLiftParameter(graphId))
+    let ret = TestModule.GraphOperations.nodeCount(graphId: Int.bridgeJSLiftParameter(graphId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_validate")
-@_cdecl("bjs_Services_Graph_GraphOperations_static_validate")
-public func _bjs_Services_Graph_GraphOperations_static_validate(_ graphId: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_GraphOperations_static_validate")
+@_cdecl("bjs_TestModule_GraphOperations_static_validate")
+public func _bjs_TestModule_GraphOperations_static_validate(_ graphId: Int32) -> Int32 {
     #if arch(wasm32)
     do {
-        let ret = try GraphOperations.validate(graphId: Int.bridgeJSLiftParameter(graphId))
+        let ret = try TestModule.GraphOperations.validate(graphId: Int.bridgeJSLiftParameter(graphId))
         return ret.bridgeJSLowerReturn()
     } catch let error {
         if let error = error.thrownValue.object {
@@ -129,233 +129,233 @@ public func _bjs_Services_Graph_GraphOperations_static_validate(_ graphId: Int32
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_init")
-@_cdecl("bjs_Utils_Converter_init")
-public func _bjs_Utils_Converter_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_init")
+@_cdecl("bjs_TestModule_Utils_Converter_init")
+public func _bjs_TestModule_Utils_Converter_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Utils.Converter()
+    let ret = TestModule.Utils.Converter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_toString")
-@_cdecl("bjs_Utils_Converter_toString")
-public func _bjs_Utils_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_toString")
+@_cdecl("bjs_TestModule_Utils_Converter_toString")
+public func _bjs_TestModule_Utils_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Utils.Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Utils.Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_precision_get")
-@_cdecl("bjs_Utils_Converter_precision_get")
-public func _bjs_Utils_Converter_precision_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_precision_get")
+@_cdecl("bjs_TestModule_Utils_Converter_precision_get")
+public func _bjs_TestModule_Utils_Converter_precision_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = Utils.Converter.bridgeJSLiftParameter(_self).precision
+    let ret = TestModule.Utils.Converter.bridgeJSLiftParameter(_self).precision
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_precision_set")
-@_cdecl("bjs_Utils_Converter_precision_set")
-public func _bjs_Utils_Converter_precision_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_precision_set")
+@_cdecl("bjs_TestModule_Utils_Converter_precision_set")
+public func _bjs_TestModule_Utils_Converter_precision_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    Utils.Converter.bridgeJSLiftParameter(_self).precision = Int.bridgeJSLiftParameter(value)
+    TestModule.Utils.Converter.bridgeJSLiftParameter(_self).precision = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_deinit")
-@_cdecl("bjs_Utils_Converter_deinit")
-public func _bjs_Utils_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Utils_Converter_deinit")
+@_cdecl("bjs_TestModule_Utils_Converter_deinit")
+public func _bjs_TestModule_Utils_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Utils.Converter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Utils.Converter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Utils.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Utils.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Utils_Converter_wrap")
-fileprivate func _bjs_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Utils_Converter_wrap")
+fileprivate func _bjs_TestModule_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Utils_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Utils_Converter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Utils_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Utils_Converter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Networking_API_HTTPServer_init")
-@_cdecl("bjs_Networking_API_HTTPServer_init")
-public func _bjs_Networking_API_HTTPServer_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Networking_API_HTTPServer_init")
+@_cdecl("bjs_TestModule_Networking_API_HTTPServer_init")
+public func _bjs_TestModule_Networking_API_HTTPServer_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Networking.API.HTTPServer()
+    let ret = TestModule.Networking.API.HTTPServer()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_API_HTTPServer_call")
-@_cdecl("bjs_Networking_API_HTTPServer_call")
-public func _bjs_Networking_API_HTTPServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Networking_API_HTTPServer_call")
+@_cdecl("bjs_TestModule_Networking_API_HTTPServer_call")
+public func _bjs_TestModule_Networking_API_HTTPServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
     #if arch(wasm32)
-    Networking.API.HTTPServer.bridgeJSLiftParameter(_self).call(_: Networking.API.Method.bridgeJSLiftParameter(method))
+    TestModule.Networking.API.HTTPServer.bridgeJSLiftParameter(_self).call(_: TestModule.Networking.API.Method.bridgeJSLiftParameter(method))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_API_HTTPServer_deinit")
-@_cdecl("bjs_Networking_API_HTTPServer_deinit")
-public func _bjs_Networking_API_HTTPServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Networking_API_HTTPServer_deinit")
+@_cdecl("bjs_TestModule_Networking_API_HTTPServer_deinit")
+public func _bjs_TestModule_Networking_API_HTTPServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Networking.API.HTTPServer>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Networking.API.HTTPServer>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Networking.API.HTTPServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Networking.API.HTTPServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Networking_API_HTTPServer_wrap")
-fileprivate func _bjs_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Networking_API_HTTPServer_wrap")
+fileprivate func _bjs_TestModule_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Networking_API_HTTPServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Networking_API_HTTPServer_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Networking_API_HTTPServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Networking_API_HTTPServer_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Networking_APIV2_Internal_TestServer_init")
-@_cdecl("bjs_Networking_APIV2_Internal_TestServer_init")
-public func _bjs_Networking_APIV2_Internal_TestServer_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Internal_TestServer_init")
+@_cdecl("bjs_TestModule_Internal_TestServer_init")
+public func _bjs_TestModule_Internal_TestServer_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Internal.TestServer()
+    let ret = TestModule.Internal.TestServer()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_APIV2_Internal_TestServer_call")
-@_cdecl("bjs_Networking_APIV2_Internal_TestServer_call")
-public func _bjs_Networking_APIV2_Internal_TestServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Internal_TestServer_call")
+@_cdecl("bjs_TestModule_Internal_TestServer_call")
+public func _bjs_TestModule_Internal_TestServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
     #if arch(wasm32)
-    Internal.TestServer.bridgeJSLiftParameter(_self).call(_: Internal.SupportedMethod.bridgeJSLiftParameter(method))
+    TestModule.Internal.TestServer.bridgeJSLiftParameter(_self).call(_: TestModule.Internal.SupportedMethod.bridgeJSLiftParameter(method))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_APIV2_Internal_TestServer_deinit")
-@_cdecl("bjs_Networking_APIV2_Internal_TestServer_deinit")
-public func _bjs_Networking_APIV2_Internal_TestServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Internal_TestServer_deinit")
+@_cdecl("bjs_TestModule_Internal_TestServer_deinit")
+public func _bjs_TestModule_Internal_TestServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Internal.TestServer>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Internal.TestServer>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Internal.TestServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Internal.TestServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Networking_APIV2_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Networking_APIV2_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Networking_APIV2_Internal_TestServer_wrap")
-fileprivate func _bjs_Networking_APIV2_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Internal_TestServer_wrap")
+fileprivate func _bjs_TestModule_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Networking_APIV2_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Networking_APIV2_Internal_TestServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Networking_APIV2_Internal_TestServer_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Internal_TestServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Internal_TestServer_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Formatting_Converter_init")
-@_cdecl("bjs_Formatting_Converter_init")
-public func _bjs_Formatting_Converter_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Formatting_Converter_init")
+@_cdecl("bjs_TestModule_Formatting_Converter_init")
+public func _bjs_TestModule_Formatting_Converter_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Formatting.Converter()
+    let ret = TestModule.Formatting.Converter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Formatting_Converter_format")
-@_cdecl("bjs_Formatting_Converter_format")
-public func _bjs_Formatting_Converter_format(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Formatting_Converter_format")
+@_cdecl("bjs_TestModule_Formatting_Converter_format")
+public func _bjs_TestModule_Formatting_Converter_format(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Formatting.Converter.bridgeJSLiftParameter(_self).format(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Formatting.Converter.bridgeJSLiftParameter(_self).format(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Formatting_Converter_deinit")
-@_cdecl("bjs_Formatting_Converter_deinit")
-public func _bjs_Formatting_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Formatting_Converter_deinit")
+@_cdecl("bjs_TestModule_Formatting_Converter_deinit")
+public func _bjs_TestModule_Formatting_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Formatting.Converter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Formatting.Converter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Formatting.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Formatting.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Formatting_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Formatting_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Formatting_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Formatting_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Formatting_Converter_wrap")
-fileprivate func _bjs_Formatting_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Formatting_Converter_wrap")
+fileprivate func _bjs_TestModule_Formatting_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Formatting_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Formatting_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Formatting_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Formatting_Converter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Formatting_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Formatting_Converter_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumRawType.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumRawType.json
@@ -40,7 +40,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Theme",
+        "swiftCallName" : "TestModule.Theme",
         "tsFullPath" : "Theme"
       },
       {
@@ -76,7 +76,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "TSTheme",
+        "swiftCallName" : "TestModule.TSTheme",
         "tsFullPath" : "TSTheme"
       },
       {
@@ -105,7 +105,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "FeatureFlag",
+        "swiftCallName" : "TestModule.FeatureFlag",
         "tsFullPath" : "FeatureFlag"
       },
       {
@@ -141,7 +141,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "HttpStatus",
+        "swiftCallName" : "TestModule.HttpStatus",
         "tsFullPath" : "HttpStatus"
       },
       {
@@ -177,7 +177,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "TSHttpStatus",
+        "swiftCallName" : "TestModule.TSHttpStatus",
         "tsFullPath" : "TSHttpStatus"
       },
       {
@@ -227,7 +227,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Priority",
+        "swiftCallName" : "TestModule.Priority",
         "tsFullPath" : "Priority"
       },
       {
@@ -270,7 +270,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "FileSize",
+        "swiftCallName" : "TestModule.FileSize",
         "tsFullPath" : "FileSize"
       },
       {
@@ -306,7 +306,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "UserId",
+        "swiftCallName" : "TestModule.UserId",
         "tsFullPath" : "UserId"
       },
       {
@@ -342,7 +342,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "TokenId",
+        "swiftCallName" : "TestModule.TokenId",
         "tsFullPath" : "TokenId"
       },
       {
@@ -378,7 +378,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "SessionId",
+        "swiftCallName" : "TestModule.SessionId",
         "tsFullPath" : "SessionId"
       },
       {
@@ -414,7 +414,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Precision",
+        "swiftCallName" : "TestModule.Precision",
         "tsFullPath" : "Precision"
       },
       {
@@ -457,14 +457,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Ratio",
+        "swiftCallName" : "TestModule.Ratio",
         "tsFullPath" : "Ratio"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_setTheme",
+        "abiName" : "bjs_TestModule_setTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -477,7 +477,7 @@
             "name" : "theme",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "TestModule.Theme",
                 "_1" : "String"
               }
             }
@@ -490,7 +490,7 @@
         }
       },
       {
-        "abiName" : "bjs_getTheme",
+        "abiName" : "bjs_TestModule_getTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -502,13 +502,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Theme",
+            "_0" : "TestModule.Theme",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalTheme",
+        "abiName" : "bjs_TestModule_roundTripOptionalTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -523,7 +523,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "TestModule.Theme",
                     "_1" : "String"
                   }
                 },
@@ -536,7 +536,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "TestModule.Theme",
                 "_1" : "String"
               }
             },
@@ -545,7 +545,7 @@
         }
       },
       {
-        "abiName" : "bjs_setTSTheme",
+        "abiName" : "bjs_TestModule_setTSTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -558,7 +558,7 @@
             "name" : "theme",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "TSTheme",
+                "_0" : "TestModule.TSTheme",
                 "_1" : "String"
               }
             }
@@ -571,7 +571,7 @@
         }
       },
       {
-        "abiName" : "bjs_getTSTheme",
+        "abiName" : "bjs_TestModule_getTSTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -583,13 +583,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "TSTheme",
+            "_0" : "TestModule.TSTheme",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalTSTheme",
+        "abiName" : "bjs_TestModule_roundTripOptionalTSTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -604,7 +604,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "TSTheme",
+                    "_0" : "TestModule.TSTheme",
                     "_1" : "String"
                   }
                 },
@@ -617,7 +617,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "TSTheme",
+                "_0" : "TestModule.TSTheme",
                 "_1" : "String"
               }
             },
@@ -626,7 +626,7 @@
         }
       },
       {
-        "abiName" : "bjs_setFeatureFlag",
+        "abiName" : "bjs_TestModule_setFeatureFlag",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -639,7 +639,7 @@
             "name" : "flag",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "FeatureFlag",
+                "_0" : "TestModule.FeatureFlag",
                 "_1" : "String"
               }
             }
@@ -652,7 +652,7 @@
         }
       },
       {
-        "abiName" : "bjs_getFeatureFlag",
+        "abiName" : "bjs_TestModule_getFeatureFlag",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -664,13 +664,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "FeatureFlag",
+            "_0" : "TestModule.FeatureFlag",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalFeatureFlag",
+        "abiName" : "bjs_TestModule_roundTripOptionalFeatureFlag",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -685,7 +685,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "FeatureFlag",
+                    "_0" : "TestModule.FeatureFlag",
                     "_1" : "String"
                   }
                 },
@@ -698,7 +698,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "FeatureFlag",
+                "_0" : "TestModule.FeatureFlag",
                 "_1" : "String"
               }
             },
@@ -707,7 +707,7 @@
         }
       },
       {
-        "abiName" : "bjs_setHttpStatus",
+        "abiName" : "bjs_TestModule_setHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -720,7 +720,7 @@
             "name" : "status",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "HttpStatus",
+                "_0" : "TestModule.HttpStatus",
                 "_1" : "Int"
               }
             }
@@ -733,7 +733,7 @@
         }
       },
       {
-        "abiName" : "bjs_getHttpStatus",
+        "abiName" : "bjs_TestModule_getHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -745,13 +745,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "HttpStatus",
+            "_0" : "TestModule.HttpStatus",
             "_1" : "Int"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalHttpStatus",
+        "abiName" : "bjs_TestModule_roundTripOptionalHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -766,7 +766,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "HttpStatus",
+                    "_0" : "TestModule.HttpStatus",
                     "_1" : "Int"
                   }
                 },
@@ -779,7 +779,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "HttpStatus",
+                "_0" : "TestModule.HttpStatus",
                 "_1" : "Int"
               }
             },
@@ -788,7 +788,7 @@
         }
       },
       {
-        "abiName" : "bjs_setTSHttpStatus",
+        "abiName" : "bjs_TestModule_setTSHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -801,7 +801,7 @@
             "name" : "status",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "TSHttpStatus",
+                "_0" : "TestModule.TSHttpStatus",
                 "_1" : "Int"
               }
             }
@@ -814,7 +814,7 @@
         }
       },
       {
-        "abiName" : "bjs_getTSHttpStatus",
+        "abiName" : "bjs_TestModule_getTSHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -826,13 +826,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "TSHttpStatus",
+            "_0" : "TestModule.TSHttpStatus",
             "_1" : "Int"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalHttpStatus",
+        "abiName" : "bjs_TestModule_roundTripOptionalHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -847,7 +847,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "TSHttpStatus",
+                    "_0" : "TestModule.TSHttpStatus",
                     "_1" : "Int"
                   }
                 },
@@ -860,7 +860,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "TSHttpStatus",
+                "_0" : "TestModule.TSHttpStatus",
                 "_1" : "Int"
               }
             },
@@ -869,7 +869,7 @@
         }
       },
       {
-        "abiName" : "bjs_setPriority",
+        "abiName" : "bjs_TestModule_setPriority",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -882,7 +882,7 @@
             "name" : "priority",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Priority",
+                "_0" : "TestModule.Priority",
                 "_1" : "Int32"
               }
             }
@@ -895,7 +895,7 @@
         }
       },
       {
-        "abiName" : "bjs_getPriority",
+        "abiName" : "bjs_TestModule_getPriority",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -907,13 +907,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Priority",
+            "_0" : "TestModule.Priority",
             "_1" : "Int32"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalPriority",
+        "abiName" : "bjs_TestModule_roundTripOptionalPriority",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -928,7 +928,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Priority",
+                    "_0" : "TestModule.Priority",
                     "_1" : "Int32"
                   }
                 },
@@ -941,7 +941,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "Priority",
+                "_0" : "TestModule.Priority",
                 "_1" : "Int32"
               }
             },
@@ -950,7 +950,7 @@
         }
       },
       {
-        "abiName" : "bjs_setFileSize",
+        "abiName" : "bjs_TestModule_setFileSize",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -963,7 +963,7 @@
             "name" : "size",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "FileSize",
+                "_0" : "TestModule.FileSize",
                 "_1" : "Int64"
               }
             }
@@ -976,7 +976,7 @@
         }
       },
       {
-        "abiName" : "bjs_getFileSize",
+        "abiName" : "bjs_TestModule_getFileSize",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -988,13 +988,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "FileSize",
+            "_0" : "TestModule.FileSize",
             "_1" : "Int64"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalFileSize",
+        "abiName" : "bjs_TestModule_roundTripOptionalFileSize",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1009,7 +1009,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "FileSize",
+                    "_0" : "TestModule.FileSize",
                     "_1" : "Int64"
                   }
                 },
@@ -1022,7 +1022,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "FileSize",
+                "_0" : "TestModule.FileSize",
                 "_1" : "Int64"
               }
             },
@@ -1031,7 +1031,7 @@
         }
       },
       {
-        "abiName" : "bjs_setUserId",
+        "abiName" : "bjs_TestModule_setUserId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1044,7 +1044,7 @@
             "name" : "id",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "UserId",
+                "_0" : "TestModule.UserId",
                 "_1" : "UInt"
               }
             }
@@ -1057,7 +1057,7 @@
         }
       },
       {
-        "abiName" : "bjs_getUserId",
+        "abiName" : "bjs_TestModule_getUserId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1069,13 +1069,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "UserId",
+            "_0" : "TestModule.UserId",
             "_1" : "UInt"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalUserId",
+        "abiName" : "bjs_TestModule_roundTripOptionalUserId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1090,7 +1090,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "UserId",
+                    "_0" : "TestModule.UserId",
                     "_1" : "UInt"
                   }
                 },
@@ -1103,7 +1103,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "UserId",
+                "_0" : "TestModule.UserId",
                 "_1" : "UInt"
               }
             },
@@ -1112,7 +1112,7 @@
         }
       },
       {
-        "abiName" : "bjs_setTokenId",
+        "abiName" : "bjs_TestModule_setTokenId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1125,7 +1125,7 @@
             "name" : "token",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "TokenId",
+                "_0" : "TestModule.TokenId",
                 "_1" : "UInt32"
               }
             }
@@ -1138,7 +1138,7 @@
         }
       },
       {
-        "abiName" : "bjs_getTokenId",
+        "abiName" : "bjs_TestModule_getTokenId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1150,13 +1150,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "TokenId",
+            "_0" : "TestModule.TokenId",
             "_1" : "UInt32"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalTokenId",
+        "abiName" : "bjs_TestModule_roundTripOptionalTokenId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1171,7 +1171,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "TokenId",
+                    "_0" : "TestModule.TokenId",
                     "_1" : "UInt32"
                   }
                 },
@@ -1184,7 +1184,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "TokenId",
+                "_0" : "TestModule.TokenId",
                 "_1" : "UInt32"
               }
             },
@@ -1193,7 +1193,7 @@
         }
       },
       {
-        "abiName" : "bjs_setSessionId",
+        "abiName" : "bjs_TestModule_setSessionId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1206,7 +1206,7 @@
             "name" : "session",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "SessionId",
+                "_0" : "TestModule.SessionId",
                 "_1" : "UInt64"
               }
             }
@@ -1219,7 +1219,7 @@
         }
       },
       {
-        "abiName" : "bjs_getSessionId",
+        "abiName" : "bjs_TestModule_getSessionId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1231,13 +1231,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "SessionId",
+            "_0" : "TestModule.SessionId",
             "_1" : "UInt64"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalSessionId",
+        "abiName" : "bjs_TestModule_roundTripOptionalSessionId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1252,7 +1252,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "SessionId",
+                    "_0" : "TestModule.SessionId",
                     "_1" : "UInt64"
                   }
                 },
@@ -1265,7 +1265,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "SessionId",
+                "_0" : "TestModule.SessionId",
                 "_1" : "UInt64"
               }
             },
@@ -1274,7 +1274,7 @@
         }
       },
       {
-        "abiName" : "bjs_setPrecision",
+        "abiName" : "bjs_TestModule_setPrecision",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1287,7 +1287,7 @@
             "name" : "precision",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Precision",
+                "_0" : "TestModule.Precision",
                 "_1" : "Float"
               }
             }
@@ -1300,7 +1300,7 @@
         }
       },
       {
-        "abiName" : "bjs_getPrecision",
+        "abiName" : "bjs_TestModule_getPrecision",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1312,13 +1312,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Precision",
+            "_0" : "TestModule.Precision",
             "_1" : "Float"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalPrecision",
+        "abiName" : "bjs_TestModule_roundTripOptionalPrecision",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1333,7 +1333,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Precision",
+                    "_0" : "TestModule.Precision",
                     "_1" : "Float"
                   }
                 },
@@ -1346,7 +1346,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "Precision",
+                "_0" : "TestModule.Precision",
                 "_1" : "Float"
               }
             },
@@ -1355,7 +1355,7 @@
         }
       },
       {
-        "abiName" : "bjs_setRatio",
+        "abiName" : "bjs_TestModule_setRatio",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1368,7 +1368,7 @@
             "name" : "ratio",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Ratio",
+                "_0" : "TestModule.Ratio",
                 "_1" : "Double"
               }
             }
@@ -1381,7 +1381,7 @@
         }
       },
       {
-        "abiName" : "bjs_getRatio",
+        "abiName" : "bjs_TestModule_getRatio",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1393,13 +1393,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Ratio",
+            "_0" : "TestModule.Ratio",
             "_1" : "Double"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalRatio",
+        "abiName" : "bjs_TestModule_roundTripOptionalRatio",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1414,7 +1414,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Ratio",
+                    "_0" : "TestModule.Ratio",
                     "_1" : "Double"
                   }
                 },
@@ -1427,7 +1427,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "Ratio",
+                "_0" : "TestModule.Ratio",
                 "_1" : "Double"
               }
             },
@@ -1436,7 +1436,7 @@
         }
       },
       {
-        "abiName" : "bjs_processTheme",
+        "abiName" : "bjs_TestModule_processTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1449,7 +1449,7 @@
             "name" : "theme",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "TestModule.Theme",
                 "_1" : "String"
               }
             }
@@ -1457,13 +1457,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "HttpStatus",
+            "_0" : "TestModule.HttpStatus",
             "_1" : "Int"
           }
         }
       },
       {
-        "abiName" : "bjs_convertPriority",
+        "abiName" : "bjs_TestModule_convertPriority",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1476,7 +1476,7 @@
             "name" : "status",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "HttpStatus",
+                "_0" : "TestModule.HttpStatus",
                 "_1" : "Int"
               }
             }
@@ -1484,13 +1484,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Priority",
+            "_0" : "TestModule.Priority",
             "_1" : "Int32"
           }
         }
       },
       {
-        "abiName" : "bjs_validateSession",
+        "abiName" : "bjs_TestModule_validateSession",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1503,7 +1503,7 @@
             "name" : "session",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "SessionId",
+                "_0" : "TestModule.SessionId",
                 "_1" : "UInt64"
               }
             }
@@ -1511,7 +1511,7 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Theme",
+            "_0" : "TestModule.Theme",
             "_1" : "String"
           }
         }
@@ -1541,7 +1541,7 @@
                 "name" : "flag",
                 "type" : {
                   "rawValueEnum" : {
-                    "_0" : "FeatureFlag",
+                    "_0" : "TestModule.FeatureFlag",
                     "_1" : "String"
                   }
                 }
@@ -1566,7 +1566,7 @@
             ],
             "returnType" : {
               "rawValueEnum" : {
-                "_0" : "FeatureFlag",
+                "_0" : "TestModule.FeatureFlag",
                 "_1" : "String"
               }
             }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumRawType.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/EnumRawType.swift
@@ -1,52 +1,52 @@
-extension Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension FeatureFlag: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.FeatureFlag: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension TSHttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.TSHttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Priority: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Priority: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension FileSize: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.FileSize: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension UserId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.UserId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension TokenId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.TokenId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension SessionId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.SessionId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Ratio: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Ratio: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-@_expose(wasm, "bjs_setTheme")
-@_cdecl("bjs_setTheme")
-public func _bjs_setTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setTheme")
+@_cdecl("bjs_TestModule_setTheme")
+public func _bjs_TestModule_setTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
     #if arch(wasm32)
-    setTheme(_: Theme.bridgeJSLiftParameter(themeBytes, themeLength))
+    setTheme(_: TestModule.Theme.bridgeJSLiftParameter(themeBytes, themeLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getTheme")
-@_cdecl("bjs_getTheme")
-public func _bjs_getTheme() -> Void {
+@_expose(wasm, "bjs_TestModule_getTheme")
+@_cdecl("bjs_TestModule_getTheme")
+public func _bjs_TestModule_getTheme() -> Void {
     #if arch(wasm32)
     let ret = getTheme()
     return ret.bridgeJSLowerReturn()
@@ -55,30 +55,30 @@ public func _bjs_getTheme() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalTheme")
-@_cdecl("bjs_roundTripOptionalTheme")
-public func _bjs_roundTripOptionalTheme(_ inputIsSome: Int32, _ inputBytes: Int32, _ inputLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalTheme")
+@_cdecl("bjs_TestModule_roundTripOptionalTheme")
+public func _bjs_TestModule_roundTripOptionalTheme(_ inputIsSome: Int32, _ inputBytes: Int32, _ inputLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalTheme(_: Optional<Theme>.bridgeJSLiftParameter(inputIsSome, inputBytes, inputLength))
+    let ret = roundTripOptionalTheme(_: Optional<TestModule.Theme>.bridgeJSLiftParameter(inputIsSome, inputBytes, inputLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setTSTheme")
-@_cdecl("bjs_setTSTheme")
-public func _bjs_setTSTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setTSTheme")
+@_cdecl("bjs_TestModule_setTSTheme")
+public func _bjs_TestModule_setTSTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
     #if arch(wasm32)
-    setTSTheme(_: TSTheme.bridgeJSLiftParameter(themeBytes, themeLength))
+    setTSTheme(_: TestModule.TSTheme.bridgeJSLiftParameter(themeBytes, themeLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getTSTheme")
-@_cdecl("bjs_getTSTheme")
-public func _bjs_getTSTheme() -> Void {
+@_expose(wasm, "bjs_TestModule_getTSTheme")
+@_cdecl("bjs_TestModule_getTSTheme")
+public func _bjs_TestModule_getTSTheme() -> Void {
     #if arch(wasm32)
     let ret = getTSTheme()
     return ret.bridgeJSLowerReturn()
@@ -87,30 +87,30 @@ public func _bjs_getTSTheme() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalTSTheme")
-@_cdecl("bjs_roundTripOptionalTSTheme")
-public func _bjs_roundTripOptionalTSTheme(_ inputIsSome: Int32, _ inputBytes: Int32, _ inputLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalTSTheme")
+@_cdecl("bjs_TestModule_roundTripOptionalTSTheme")
+public func _bjs_TestModule_roundTripOptionalTSTheme(_ inputIsSome: Int32, _ inputBytes: Int32, _ inputLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalTSTheme(_: Optional<TSTheme>.bridgeJSLiftParameter(inputIsSome, inputBytes, inputLength))
+    let ret = roundTripOptionalTSTheme(_: Optional<TestModule.TSTheme>.bridgeJSLiftParameter(inputIsSome, inputBytes, inputLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setFeatureFlag")
-@_cdecl("bjs_setFeatureFlag")
-public func _bjs_setFeatureFlag(_ flagBytes: Int32, _ flagLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setFeatureFlag")
+@_cdecl("bjs_TestModule_setFeatureFlag")
+public func _bjs_TestModule_setFeatureFlag(_ flagBytes: Int32, _ flagLength: Int32) -> Void {
     #if arch(wasm32)
-    setFeatureFlag(_: FeatureFlag.bridgeJSLiftParameter(flagBytes, flagLength))
+    setFeatureFlag(_: TestModule.FeatureFlag.bridgeJSLiftParameter(flagBytes, flagLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getFeatureFlag")
-@_cdecl("bjs_getFeatureFlag")
-public func _bjs_getFeatureFlag() -> Void {
+@_expose(wasm, "bjs_TestModule_getFeatureFlag")
+@_cdecl("bjs_TestModule_getFeatureFlag")
+public func _bjs_TestModule_getFeatureFlag() -> Void {
     #if arch(wasm32)
     let ret = getFeatureFlag()
     return ret.bridgeJSLowerReturn()
@@ -119,30 +119,30 @@ public func _bjs_getFeatureFlag() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalFeatureFlag")
-@_cdecl("bjs_roundTripOptionalFeatureFlag")
-public func _bjs_roundTripOptionalFeatureFlag(_ inputIsSome: Int32, _ inputBytes: Int32, _ inputLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalFeatureFlag")
+@_cdecl("bjs_TestModule_roundTripOptionalFeatureFlag")
+public func _bjs_TestModule_roundTripOptionalFeatureFlag(_ inputIsSome: Int32, _ inputBytes: Int32, _ inputLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalFeatureFlag(_: Optional<FeatureFlag>.bridgeJSLiftParameter(inputIsSome, inputBytes, inputLength))
+    let ret = roundTripOptionalFeatureFlag(_: Optional<TestModule.FeatureFlag>.bridgeJSLiftParameter(inputIsSome, inputBytes, inputLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setHttpStatus")
-@_cdecl("bjs_setHttpStatus")
-public func _bjs_setHttpStatus(_ status: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setHttpStatus")
+@_cdecl("bjs_TestModule_setHttpStatus")
+public func _bjs_TestModule_setHttpStatus(_ status: Int32) -> Void {
     #if arch(wasm32)
-    setHttpStatus(_: HttpStatus.bridgeJSLiftParameter(status))
+    setHttpStatus(_: TestModule.HttpStatus.bridgeJSLiftParameter(status))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getHttpStatus")
-@_cdecl("bjs_getHttpStatus")
-public func _bjs_getHttpStatus() -> Int32 {
+@_expose(wasm, "bjs_TestModule_getHttpStatus")
+@_cdecl("bjs_TestModule_getHttpStatus")
+public func _bjs_TestModule_getHttpStatus() -> Int32 {
     #if arch(wasm32)
     let ret = getHttpStatus()
     return ret.bridgeJSLowerReturn()
@@ -151,30 +151,30 @@ public func _bjs_getHttpStatus() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalHttpStatus")
-@_cdecl("bjs_roundTripOptionalHttpStatus")
-public func _bjs_roundTripOptionalHttpStatus(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalHttpStatus")
+@_cdecl("bjs_TestModule_roundTripOptionalHttpStatus")
+public func _bjs_TestModule_roundTripOptionalHttpStatus(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalHttpStatus(_: Optional<HttpStatus>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalHttpStatus(_: Optional<TestModule.HttpStatus>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setTSHttpStatus")
-@_cdecl("bjs_setTSHttpStatus")
-public func _bjs_setTSHttpStatus(_ status: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setTSHttpStatus")
+@_cdecl("bjs_TestModule_setTSHttpStatus")
+public func _bjs_TestModule_setTSHttpStatus(_ status: Int32) -> Void {
     #if arch(wasm32)
-    setTSHttpStatus(_: TSHttpStatus.bridgeJSLiftParameter(status))
+    setTSHttpStatus(_: TestModule.TSHttpStatus.bridgeJSLiftParameter(status))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getTSHttpStatus")
-@_cdecl("bjs_getTSHttpStatus")
-public func _bjs_getTSHttpStatus() -> Int32 {
+@_expose(wasm, "bjs_TestModule_getTSHttpStatus")
+@_cdecl("bjs_TestModule_getTSHttpStatus")
+public func _bjs_TestModule_getTSHttpStatus() -> Int32 {
     #if arch(wasm32)
     let ret = getTSHttpStatus()
     return ret.bridgeJSLowerReturn()
@@ -183,30 +183,30 @@ public func _bjs_getTSHttpStatus() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalHttpStatus")
-@_cdecl("bjs_roundTripOptionalHttpStatus")
-public func _bjs_roundTripOptionalHttpStatus(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalHttpStatus")
+@_cdecl("bjs_TestModule_roundTripOptionalHttpStatus")
+public func _bjs_TestModule_roundTripOptionalHttpStatus(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalHttpStatus(_: Optional<TSHttpStatus>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalHttpStatus(_: Optional<TestModule.TSHttpStatus>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setPriority")
-@_cdecl("bjs_setPriority")
-public func _bjs_setPriority(_ priority: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setPriority")
+@_cdecl("bjs_TestModule_setPriority")
+public func _bjs_TestModule_setPriority(_ priority: Int32) -> Void {
     #if arch(wasm32)
-    setPriority(_: Priority.bridgeJSLiftParameter(priority))
+    setPriority(_: TestModule.Priority.bridgeJSLiftParameter(priority))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getPriority")
-@_cdecl("bjs_getPriority")
-public func _bjs_getPriority() -> Int32 {
+@_expose(wasm, "bjs_TestModule_getPriority")
+@_cdecl("bjs_TestModule_getPriority")
+public func _bjs_TestModule_getPriority() -> Int32 {
     #if arch(wasm32)
     let ret = getPriority()
     return ret.bridgeJSLowerReturn()
@@ -215,30 +215,30 @@ public func _bjs_getPriority() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalPriority")
-@_cdecl("bjs_roundTripOptionalPriority")
-public func _bjs_roundTripOptionalPriority(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalPriority")
+@_cdecl("bjs_TestModule_roundTripOptionalPriority")
+public func _bjs_TestModule_roundTripOptionalPriority(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalPriority(_: Optional<Priority>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalPriority(_: Optional<TestModule.Priority>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setFileSize")
-@_cdecl("bjs_setFileSize")
-public func _bjs_setFileSize(_ size: Int64) -> Void {
+@_expose(wasm, "bjs_TestModule_setFileSize")
+@_cdecl("bjs_TestModule_setFileSize")
+public func _bjs_TestModule_setFileSize(_ size: Int64) -> Void {
     #if arch(wasm32)
-    setFileSize(_: FileSize.bridgeJSLiftParameter(size))
+    setFileSize(_: TestModule.FileSize.bridgeJSLiftParameter(size))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getFileSize")
-@_cdecl("bjs_getFileSize")
-public func _bjs_getFileSize() -> Int64 {
+@_expose(wasm, "bjs_TestModule_getFileSize")
+@_cdecl("bjs_TestModule_getFileSize")
+public func _bjs_TestModule_getFileSize() -> Int64 {
     #if arch(wasm32)
     let ret = getFileSize()
     return ret.bridgeJSLowerReturn()
@@ -247,30 +247,30 @@ public func _bjs_getFileSize() -> Int64 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalFileSize")
-@_cdecl("bjs_roundTripOptionalFileSize")
-public func _bjs_roundTripOptionalFileSize(_ inputIsSome: Int32, _ inputValue: Int64) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalFileSize")
+@_cdecl("bjs_TestModule_roundTripOptionalFileSize")
+public func _bjs_TestModule_roundTripOptionalFileSize(_ inputIsSome: Int32, _ inputValue: Int64) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalFileSize(_: Optional<FileSize>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalFileSize(_: Optional<TestModule.FileSize>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setUserId")
-@_cdecl("bjs_setUserId")
-public func _bjs_setUserId(_ id: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setUserId")
+@_cdecl("bjs_TestModule_setUserId")
+public func _bjs_TestModule_setUserId(_ id: Int32) -> Void {
     #if arch(wasm32)
-    setUserId(_: UserId.bridgeJSLiftParameter(id))
+    setUserId(_: TestModule.UserId.bridgeJSLiftParameter(id))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getUserId")
-@_cdecl("bjs_getUserId")
-public func _bjs_getUserId() -> Int32 {
+@_expose(wasm, "bjs_TestModule_getUserId")
+@_cdecl("bjs_TestModule_getUserId")
+public func _bjs_TestModule_getUserId() -> Int32 {
     #if arch(wasm32)
     let ret = getUserId()
     return ret.bridgeJSLowerReturn()
@@ -279,30 +279,30 @@ public func _bjs_getUserId() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalUserId")
-@_cdecl("bjs_roundTripOptionalUserId")
-public func _bjs_roundTripOptionalUserId(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalUserId")
+@_cdecl("bjs_TestModule_roundTripOptionalUserId")
+public func _bjs_TestModule_roundTripOptionalUserId(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalUserId(_: Optional<UserId>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalUserId(_: Optional<TestModule.UserId>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setTokenId")
-@_cdecl("bjs_setTokenId")
-public func _bjs_setTokenId(_ token: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_setTokenId")
+@_cdecl("bjs_TestModule_setTokenId")
+public func _bjs_TestModule_setTokenId(_ token: Int32) -> Void {
     #if arch(wasm32)
-    setTokenId(_: TokenId.bridgeJSLiftParameter(token))
+    setTokenId(_: TestModule.TokenId.bridgeJSLiftParameter(token))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getTokenId")
-@_cdecl("bjs_getTokenId")
-public func _bjs_getTokenId() -> Int32 {
+@_expose(wasm, "bjs_TestModule_getTokenId")
+@_cdecl("bjs_TestModule_getTokenId")
+public func _bjs_TestModule_getTokenId() -> Int32 {
     #if arch(wasm32)
     let ret = getTokenId()
     return ret.bridgeJSLowerReturn()
@@ -311,30 +311,30 @@ public func _bjs_getTokenId() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalTokenId")
-@_cdecl("bjs_roundTripOptionalTokenId")
-public func _bjs_roundTripOptionalTokenId(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalTokenId")
+@_cdecl("bjs_TestModule_roundTripOptionalTokenId")
+public func _bjs_TestModule_roundTripOptionalTokenId(_ inputIsSome: Int32, _ inputValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalTokenId(_: Optional<TokenId>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalTokenId(_: Optional<TestModule.TokenId>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setSessionId")
-@_cdecl("bjs_setSessionId")
-public func _bjs_setSessionId(_ session: Int64) -> Void {
+@_expose(wasm, "bjs_TestModule_setSessionId")
+@_cdecl("bjs_TestModule_setSessionId")
+public func _bjs_TestModule_setSessionId(_ session: Int64) -> Void {
     #if arch(wasm32)
-    setSessionId(_: SessionId.bridgeJSLiftParameter(session))
+    setSessionId(_: TestModule.SessionId.bridgeJSLiftParameter(session))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getSessionId")
-@_cdecl("bjs_getSessionId")
-public func _bjs_getSessionId() -> Int64 {
+@_expose(wasm, "bjs_TestModule_getSessionId")
+@_cdecl("bjs_TestModule_getSessionId")
+public func _bjs_TestModule_getSessionId() -> Int64 {
     #if arch(wasm32)
     let ret = getSessionId()
     return ret.bridgeJSLowerReturn()
@@ -343,30 +343,30 @@ public func _bjs_getSessionId() -> Int64 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalSessionId")
-@_cdecl("bjs_roundTripOptionalSessionId")
-public func _bjs_roundTripOptionalSessionId(_ inputIsSome: Int32, _ inputValue: Int64) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalSessionId")
+@_cdecl("bjs_TestModule_roundTripOptionalSessionId")
+public func _bjs_TestModule_roundTripOptionalSessionId(_ inputIsSome: Int32, _ inputValue: Int64) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalSessionId(_: Optional<SessionId>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalSessionId(_: Optional<TestModule.SessionId>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setPrecision")
-@_cdecl("bjs_setPrecision")
-public func _bjs_setPrecision(_ precision: Float32) -> Void {
+@_expose(wasm, "bjs_TestModule_setPrecision")
+@_cdecl("bjs_TestModule_setPrecision")
+public func _bjs_TestModule_setPrecision(_ precision: Float32) -> Void {
     #if arch(wasm32)
-    setPrecision(_: Precision.bridgeJSLiftParameter(precision))
+    setPrecision(_: TestModule.Precision.bridgeJSLiftParameter(precision))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getPrecision")
-@_cdecl("bjs_getPrecision")
-public func _bjs_getPrecision() -> Float32 {
+@_expose(wasm, "bjs_TestModule_getPrecision")
+@_cdecl("bjs_TestModule_getPrecision")
+public func _bjs_TestModule_getPrecision() -> Float32 {
     #if arch(wasm32)
     let ret = getPrecision()
     return ret.bridgeJSLowerReturn()
@@ -375,30 +375,30 @@ public func _bjs_getPrecision() -> Float32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalPrecision")
-@_cdecl("bjs_roundTripOptionalPrecision")
-public func _bjs_roundTripOptionalPrecision(_ inputIsSome: Int32, _ inputValue: Float32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalPrecision")
+@_cdecl("bjs_TestModule_roundTripOptionalPrecision")
+public func _bjs_TestModule_roundTripOptionalPrecision(_ inputIsSome: Int32, _ inputValue: Float32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalPrecision(_: Optional<Precision>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalPrecision(_: Optional<TestModule.Precision>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setRatio")
-@_cdecl("bjs_setRatio")
-public func _bjs_setRatio(_ ratio: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_setRatio")
+@_cdecl("bjs_TestModule_setRatio")
+public func _bjs_TestModule_setRatio(_ ratio: Float64) -> Void {
     #if arch(wasm32)
-    setRatio(_: Ratio.bridgeJSLiftParameter(ratio))
+    setRatio(_: TestModule.Ratio.bridgeJSLiftParameter(ratio))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getRatio")
-@_cdecl("bjs_getRatio")
-public func _bjs_getRatio() -> Float64 {
+@_expose(wasm, "bjs_TestModule_getRatio")
+@_cdecl("bjs_TestModule_getRatio")
+public func _bjs_TestModule_getRatio() -> Float64 {
     #if arch(wasm32)
     let ret = getRatio()
     return ret.bridgeJSLowerReturn()
@@ -407,44 +407,44 @@ public func _bjs_getRatio() -> Float64 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalRatio")
-@_cdecl("bjs_roundTripOptionalRatio")
-public func _bjs_roundTripOptionalRatio(_ inputIsSome: Int32, _ inputValue: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalRatio")
+@_cdecl("bjs_TestModule_roundTripOptionalRatio")
+public func _bjs_TestModule_roundTripOptionalRatio(_ inputIsSome: Int32, _ inputValue: Float64) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalRatio(_: Optional<Ratio>.bridgeJSLiftParameter(inputIsSome, inputValue))
+    let ret = roundTripOptionalRatio(_: Optional<TestModule.Ratio>.bridgeJSLiftParameter(inputIsSome, inputValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processTheme")
-@_cdecl("bjs_processTheme")
-public func _bjs_processTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_processTheme")
+@_cdecl("bjs_TestModule_processTheme")
+public func _bjs_TestModule_processTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = processTheme(_: Theme.bridgeJSLiftParameter(themeBytes, themeLength))
+    let ret = processTheme(_: TestModule.Theme.bridgeJSLiftParameter(themeBytes, themeLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_convertPriority")
-@_cdecl("bjs_convertPriority")
-public func _bjs_convertPriority(_ status: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_convertPriority")
+@_cdecl("bjs_TestModule_convertPriority")
+public func _bjs_TestModule_convertPriority(_ status: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = convertPriority(_: HttpStatus.bridgeJSLiftParameter(status))
+    let ret = convertPriority(_: TestModule.HttpStatus.bridgeJSLiftParameter(status))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_validateSession")
-@_cdecl("bjs_validateSession")
-public func _bjs_validateSession(_ session: Int64) -> Void {
+@_expose(wasm, "bjs_TestModule_validateSession")
+@_cdecl("bjs_TestModule_validateSession")
+public func _bjs_TestModule_validateSession(_ session: Int64) -> Void {
     #if arch(wasm32)
-    let ret = validateSession(_: SessionId.bridgeJSLiftParameter(session))
+    let ret = validateSession(_: TestModule.SessionId.bridgeJSLiftParameter(session))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -463,7 +463,7 @@ fileprivate func bjs_takesFeatureFlag_extern(_ flagBytes: Int32, _ flagLength: I
     return bjs_takesFeatureFlag_extern(flagBytes, flagLength)
 }
 
-func _$takesFeatureFlag(_ flag: FeatureFlag) throws(JSException) -> Void {
+func _$takesFeatureFlag(_ flag: TestModule.FeatureFlag) throws(JSException) -> Void {
     flag.bridgeJSWithLoweredParameter { (flagBytes, flagLength) in
         bjs_takesFeatureFlag(flagBytes, flagLength)
     }
@@ -484,10 +484,10 @@ fileprivate func bjs_returnsFeatureFlag_extern() -> Int32 {
     return bjs_returnsFeatureFlag_extern()
 }
 
-func _$returnsFeatureFlag() throws(JSException) -> FeatureFlag {
+func _$returnsFeatureFlag() throws(JSException) -> TestModule.FeatureFlag {
     let ret = bjs_returnsFeatureFlag()
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return FeatureFlag.bridgeJSLiftReturn(ret)
+    return TestModule.FeatureFlag.bridgeJSLiftReturn(ret)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/FixedWidthIntegers.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/FixedWidthIntegers.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_roundTripInt8",
+        "abiName" : "bjs_TestModule_roundTripInt8",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -43,7 +43,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUInt8",
+        "abiName" : "bjs_TestModule_roundTripUInt8",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -74,7 +74,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripInt16",
+        "abiName" : "bjs_TestModule_roundTripInt16",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -105,7 +105,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUInt16",
+        "abiName" : "bjs_TestModule_roundTripUInt16",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -136,7 +136,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripInt32",
+        "abiName" : "bjs_TestModule_roundTripInt32",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -167,7 +167,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUInt32",
+        "abiName" : "bjs_TestModule_roundTripUInt32",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -198,7 +198,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripInt64",
+        "abiName" : "bjs_TestModule_roundTripInt64",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -229,7 +229,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUInt64",
+        "abiName" : "bjs_TestModule_roundTripUInt64",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/FixedWidthIntegers.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/FixedWidthIntegers.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_roundTripInt8")
-@_cdecl("bjs_roundTripInt8")
-public func _bjs_roundTripInt8(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundTripInt8")
+@_cdecl("bjs_TestModule_roundTripInt8")
+public func _bjs_TestModule_roundTripInt8(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundTripInt8(_: Int8.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -9,9 +9,9 @@ public func _bjs_roundTripInt8(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUInt8")
-@_cdecl("bjs_roundTripUInt8")
-public func _bjs_roundTripUInt8(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundTripUInt8")
+@_cdecl("bjs_TestModule_roundTripUInt8")
+public func _bjs_TestModule_roundTripUInt8(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundTripUInt8(_: UInt8.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -20,9 +20,9 @@ public func _bjs_roundTripUInt8(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripInt16")
-@_cdecl("bjs_roundTripInt16")
-public func _bjs_roundTripInt16(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundTripInt16")
+@_cdecl("bjs_TestModule_roundTripInt16")
+public func _bjs_TestModule_roundTripInt16(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundTripInt16(_: Int16.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -31,9 +31,9 @@ public func _bjs_roundTripInt16(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUInt16")
-@_cdecl("bjs_roundTripUInt16")
-public func _bjs_roundTripUInt16(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundTripUInt16")
+@_cdecl("bjs_TestModule_roundTripUInt16")
+public func _bjs_TestModule_roundTripUInt16(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundTripUInt16(_: UInt16.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -42,9 +42,9 @@ public func _bjs_roundTripUInt16(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripInt32")
-@_cdecl("bjs_roundTripInt32")
-public func _bjs_roundTripInt32(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundTripInt32")
+@_cdecl("bjs_TestModule_roundTripInt32")
+public func _bjs_TestModule_roundTripInt32(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundTripInt32(_: Int32.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -53,9 +53,9 @@ public func _bjs_roundTripInt32(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUInt32")
-@_cdecl("bjs_roundTripUInt32")
-public func _bjs_roundTripUInt32(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundTripUInt32")
+@_cdecl("bjs_TestModule_roundTripUInt32")
+public func _bjs_TestModule_roundTripUInt32(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundTripUInt32(_: UInt32.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -64,9 +64,9 @@ public func _bjs_roundTripUInt32(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripInt64")
-@_cdecl("bjs_roundTripInt64")
-public func _bjs_roundTripInt64(_ v: Int64) -> Int64 {
+@_expose(wasm, "bjs_TestModule_roundTripInt64")
+@_cdecl("bjs_TestModule_roundTripInt64")
+public func _bjs_TestModule_roundTripInt64(_ v: Int64) -> Int64 {
     #if arch(wasm32)
     let ret = roundTripInt64(_: Int64.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -75,9 +75,9 @@ public func _bjs_roundTripInt64(_ v: Int64) -> Int64 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUInt64")
-@_cdecl("bjs_roundTripUInt64")
-public func _bjs_roundTripUInt64(_ v: Int64) -> Int64 {
+@_expose(wasm, "bjs_TestModule_roundTripUInt64")
+@_cdecl("bjs_TestModule_roundTripUInt64")
+public func _bjs_TestModule_roundTripUInt64(_ v: Int64) -> Int64 {
     #if arch(wasm32)
     let ret = roundTripUInt64(_: UInt64.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/IdentityModeClass.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/IdentityModeClass.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_CachedModel_init",
+          "abiName" : "bjs_TestModule_CachedModel_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -41,11 +41,11 @@
             }
           }
         ],
-        "swiftCallName" : "CachedModel"
+        "swiftCallName" : "TestModule.CachedModel"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_UncachedModel_init",
+          "abiName" : "bjs_TestModule_UncachedModel_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -85,11 +85,11 @@
             }
           }
         ],
-        "swiftCallName" : "UncachedModel"
+        "swiftCallName" : "TestModule.UncachedModel"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_ExplicitlyUncachedModel_init",
+          "abiName" : "bjs_TestModule_ExplicitlyUncachedModel_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -130,7 +130,7 @@
             }
           }
         ],
-        "swiftCallName" : "ExplicitlyUncachedModel"
+        "swiftCallName" : "TestModule.ExplicitlyUncachedModel"
       }
     ],
     "enums" : [

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/IdentityModeClass.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/IdentityModeClass.swift
@@ -1,188 +1,188 @@
-@_expose(wasm, "bjs_CachedModel_init")
-@_cdecl("bjs_CachedModel_init")
-public func _bjs_CachedModel_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_CachedModel_init")
+@_cdecl("bjs_TestModule_CachedModel_init")
+public func _bjs_TestModule_CachedModel_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = CachedModel(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.CachedModel(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_CachedModel_name_get")
-@_cdecl("bjs_CachedModel_name_get")
-public func _bjs_CachedModel_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_CachedModel_name_get")
+@_cdecl("bjs_TestModule_CachedModel_name_get")
+public func _bjs_TestModule_CachedModel_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = CachedModel.bridgeJSLiftParameter(_self).name
+    let ret = TestModule.CachedModel.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_CachedModel_name_set")
-@_cdecl("bjs_CachedModel_name_set")
-public func _bjs_CachedModel_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_CachedModel_name_set")
+@_cdecl("bjs_TestModule_CachedModel_name_set")
+public func _bjs_TestModule_CachedModel_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    CachedModel.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.CachedModel.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_CachedModel_deinit")
-@_cdecl("bjs_CachedModel_deinit")
-public func _bjs_CachedModel_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_CachedModel_deinit")
+@_cdecl("bjs_TestModule_CachedModel_deinit")
+public func _bjs_TestModule_CachedModel_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<CachedModel>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.CachedModel>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension CachedModel: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.CachedModel: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_CachedModel_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_CachedModel_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_CachedModel_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_CachedModel_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_CachedModel_wrap")
-fileprivate func _bjs_CachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_CachedModel_wrap")
+fileprivate func _bjs_TestModule_CachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_CachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_CachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_CachedModel_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_CachedModel_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_CachedModel_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_CachedModel_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_UncachedModel_init")
-@_cdecl("bjs_UncachedModel_init")
-public func _bjs_UncachedModel_init(_ value: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_UncachedModel_init")
+@_cdecl("bjs_TestModule_UncachedModel_init")
+public func _bjs_TestModule_UncachedModel_init(_ value: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = UncachedModel(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.UncachedModel(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_UncachedModel_value_get")
-@_cdecl("bjs_UncachedModel_value_get")
-public func _bjs_UncachedModel_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_UncachedModel_value_get")
+@_cdecl("bjs_TestModule_UncachedModel_value_get")
+public func _bjs_TestModule_UncachedModel_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = UncachedModel.bridgeJSLiftParameter(_self).value
+    let ret = TestModule.UncachedModel.bridgeJSLiftParameter(_self).value
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_UncachedModel_value_set")
-@_cdecl("bjs_UncachedModel_value_set")
-public func _bjs_UncachedModel_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_UncachedModel_value_set")
+@_cdecl("bjs_TestModule_UncachedModel_value_set")
+public func _bjs_TestModule_UncachedModel_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    UncachedModel.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
+    TestModule.UncachedModel.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_UncachedModel_deinit")
-@_cdecl("bjs_UncachedModel_deinit")
-public func _bjs_UncachedModel_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_UncachedModel_deinit")
+@_cdecl("bjs_TestModule_UncachedModel_deinit")
+public func _bjs_TestModule_UncachedModel_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<UncachedModel>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.UncachedModel>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension UncachedModel: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.UncachedModel: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_UncachedModel_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_UncachedModel_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_UncachedModel_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_UncachedModel_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_UncachedModel_wrap")
-fileprivate func _bjs_UncachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_UncachedModel_wrap")
+fileprivate func _bjs_TestModule_UncachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_UncachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_UncachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_UncachedModel_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_UncachedModel_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_UncachedModel_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_UncachedModel_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ExplicitlyUncachedModel_init")
-@_cdecl("bjs_ExplicitlyUncachedModel_init")
-public func _bjs_ExplicitlyUncachedModel_init(_ count: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_ExplicitlyUncachedModel_init")
+@_cdecl("bjs_TestModule_ExplicitlyUncachedModel_init")
+public func _bjs_TestModule_ExplicitlyUncachedModel_init(_ count: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ExplicitlyUncachedModel(count: Int.bridgeJSLiftParameter(count))
+    let ret = TestModule.ExplicitlyUncachedModel(count: Int.bridgeJSLiftParameter(count))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ExplicitlyUncachedModel_count_get")
-@_cdecl("bjs_ExplicitlyUncachedModel_count_get")
-public func _bjs_ExplicitlyUncachedModel_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_ExplicitlyUncachedModel_count_get")
+@_cdecl("bjs_TestModule_ExplicitlyUncachedModel_count_get")
+public func _bjs_TestModule_ExplicitlyUncachedModel_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = ExplicitlyUncachedModel.bridgeJSLiftParameter(_self).count
+    let ret = TestModule.ExplicitlyUncachedModel.bridgeJSLiftParameter(_self).count
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ExplicitlyUncachedModel_count_set")
-@_cdecl("bjs_ExplicitlyUncachedModel_count_set")
-public func _bjs_ExplicitlyUncachedModel_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_ExplicitlyUncachedModel_count_set")
+@_cdecl("bjs_TestModule_ExplicitlyUncachedModel_count_set")
+public func _bjs_TestModule_ExplicitlyUncachedModel_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    ExplicitlyUncachedModel.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
+    TestModule.ExplicitlyUncachedModel.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ExplicitlyUncachedModel_deinit")
-@_cdecl("bjs_ExplicitlyUncachedModel_deinit")
-public func _bjs_ExplicitlyUncachedModel_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_ExplicitlyUncachedModel_deinit")
+@_cdecl("bjs_TestModule_ExplicitlyUncachedModel_deinit")
+public func _bjs_TestModule_ExplicitlyUncachedModel_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ExplicitlyUncachedModel>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.ExplicitlyUncachedModel>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ExplicitlyUncachedModel: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.ExplicitlyUncachedModel: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ExplicitlyUncachedModel_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_ExplicitlyUncachedModel_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ExplicitlyUncachedModel_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_ExplicitlyUncachedModel_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_ExplicitlyUncachedModel_wrap")
-fileprivate func _bjs_ExplicitlyUncachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_ExplicitlyUncachedModel_wrap")
+fileprivate func _bjs_TestModule_ExplicitlyUncachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ExplicitlyUncachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_ExplicitlyUncachedModel_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ExplicitlyUncachedModel_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ExplicitlyUncachedModel_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_ExplicitlyUncachedModel_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_ExplicitlyUncachedModel_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_makeFoo",
+        "abiName" : "bjs_TestModule_makeFoo",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -29,7 +29,7 @@
         }
       },
       {
-        "abiName" : "bjs_processFooArray",
+        "abiName" : "bjs_TestModule_processFooArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -62,7 +62,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOptionalFooArray",
+        "abiName" : "bjs_TestModule_processOptionalFooArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -105,7 +105,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripFooContainer",
+        "abiName" : "bjs_TestModule_roundtripFooContainer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -118,14 +118,14 @@
             "name" : "container",
             "type" : {
               "swiftStruct" : {
-                "_0" : "FooContainer"
+                "_0" : "TestModule.FooContainer"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "FooContainer"
+            "_0" : "TestModule.FooContainer"
           }
         }
       }
@@ -166,7 +166,7 @@
             }
           }
         ],
-        "swiftCallName" : "FooContainer"
+        "swiftCallName" : "TestModule.FooContainer"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ImportedTypeInExportedInterface.swift
@@ -1,8 +1,8 @@
-extension FooContainer: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> FooContainer {
+extension TestModule.FooContainer: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.FooContainer {
         let optionalFoo = Optional<JSObject>.bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) }
         let foo = Foo(unsafelyWrapping: JSObject.bridgeJSStackPop())
-        return FooContainer(foo: foo, optionalFoo: optionalFoo)
+        return TestModule.FooContainer(foo: foo, optionalFoo: optionalFoo)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -11,44 +11,44 @@ extension FooContainer: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_FooContainer(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_FooContainer()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_FooContainer()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_FooContainer")
-fileprivate func _bjs_struct_lower_FooContainer_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_FooContainer")
+fileprivate func _bjs_struct_lower_TestModule_FooContainer_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_FooContainer_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_FooContainer_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_FooContainer_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_FooContainer(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_FooContainer_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_FooContainer")
-fileprivate func _bjs_struct_lift_FooContainer_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_FooContainer")
+fileprivate func _bjs_struct_lift_TestModule_FooContainer_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_FooContainer_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_FooContainer_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_FooContainer() -> Int32 {
-    return _bjs_struct_lift_FooContainer_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_FooContainer() -> Int32 {
+    return _bjs_struct_lift_TestModule_FooContainer_extern()
 }
 
-@_expose(wasm, "bjs_makeFoo")
-@_cdecl("bjs_makeFoo")
-public func _bjs_makeFoo() -> Int32 {
+@_expose(wasm, "bjs_TestModule_makeFoo")
+@_cdecl("bjs_TestModule_makeFoo")
+public func _bjs_TestModule_makeFoo() -> Int32 {
     #if arch(wasm32)
     do {
         let ret = try makeFoo()
@@ -71,9 +71,9 @@ public func _bjs_makeFoo() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_processFooArray")
-@_cdecl("bjs_processFooArray")
-public func _bjs_processFooArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processFooArray")
+@_cdecl("bjs_TestModule_processFooArray")
+public func _bjs_TestModule_processFooArray() -> Void {
     #if arch(wasm32)
     let ret = processFooArray(_: [Foo].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -82,9 +82,9 @@ public func _bjs_processFooArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processOptionalFooArray")
-@_cdecl("bjs_processOptionalFooArray")
-public func _bjs_processOptionalFooArray() -> Void {
+@_expose(wasm, "bjs_TestModule_processOptionalFooArray")
+@_cdecl("bjs_TestModule_processOptionalFooArray")
+public func _bjs_TestModule_processOptionalFooArray() -> Void {
     #if arch(wasm32)
     let ret = processOptionalFooArray(_: [Optional<Foo>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -93,11 +93,11 @@ public func _bjs_processOptionalFooArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripFooContainer")
-@_cdecl("bjs_roundtripFooContainer")
-public func _bjs_roundtripFooContainer() -> Void {
+@_expose(wasm, "bjs_TestModule_roundtripFooContainer")
+@_cdecl("bjs_TestModule_roundtripFooContainer")
+public func _bjs_TestModule_roundtripFooContainer() -> Void {
     #if arch(wasm32)
-    let ret = roundtripFooContainer(_: FooContainer.bridgeJSLiftParameter())
+    let ret = roundtripFooContainer(_: TestModule.FooContainer.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_processBytes",
+        "abiName" : "bjs_TestModule_processBytes",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -37,7 +37,7 @@
         }
       },
       {
-        "abiName" : "bjs_processFloats",
+        "abiName" : "bjs_TestModule_processFloats",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -62,7 +62,7 @@
         }
       },
       {
-        "abiName" : "bjs_processGenericDoubles",
+        "abiName" : "bjs_TestModule_processGenericDoubles",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -87,7 +87,7 @@
         }
       },
       {
-        "abiName" : "bjs_processGenericInts",
+        "abiName" : "bjs_TestModule_processGenericInts",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSTypedArrayTypes.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_processBytes")
-@_cdecl("bjs_processBytes")
-public func _bjs_processBytes(_ data: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_processBytes")
+@_cdecl("bjs_TestModule_processBytes")
+public func _bjs_TestModule_processBytes(_ data: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = processBytes(_: JSUint8Array.bridgeJSLiftParameter(data))
     return ret.bridgeJSLowerReturn()
@@ -9,9 +9,9 @@ public func _bjs_processBytes(_ data: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_processFloats")
-@_cdecl("bjs_processFloats")
-public func _bjs_processFloats(_ data: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_processFloats")
+@_cdecl("bjs_TestModule_processFloats")
+public func _bjs_TestModule_processFloats(_ data: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = processFloats(_: JSFloat32Array.bridgeJSLiftParameter(data))
     return ret.bridgeJSLowerReturn()
@@ -20,9 +20,9 @@ public func _bjs_processFloats(_ data: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_processGenericDoubles")
-@_cdecl("bjs_processGenericDoubles")
-public func _bjs_processGenericDoubles(_ data: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_processGenericDoubles")
+@_cdecl("bjs_TestModule_processGenericDoubles")
+public func _bjs_TestModule_processGenericDoubles(_ data: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = processGenericDoubles(_: JSFloat64Array.bridgeJSLiftParameter(data))
     return ret.bridgeJSLowerReturn()
@@ -31,9 +31,9 @@ public func _bjs_processGenericDoubles(_ data: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_processGenericInts")
-@_cdecl("bjs_processGenericInts")
-public func _bjs_processGenericInts(_ data: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_processGenericInts")
+@_cdecl("bjs_TestModule_processGenericInts")
+public func _bjs_TestModule_processGenericInts(_ data: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = processGenericInts(_: JSInt32Array.bridgeJSLiftParameter(data))
     return ret.bridgeJSLowerReturn()

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_JSValueHolder_init",
+          "abiName" : "bjs_TestModule_JSValueHolder_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -40,7 +40,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_JSValueHolder_update",
+            "abiName" : "bjs_TestModule_JSValueHolder_update",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -79,7 +79,7 @@
             }
           },
           {
-            "abiName" : "bjs_JSValueHolder_echo",
+            "abiName" : "bjs_TestModule_JSValueHolder_echo",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -104,7 +104,7 @@
             }
           },
           {
-            "abiName" : "bjs_JSValueHolder_echoOptional",
+            "abiName" : "bjs_TestModule_JSValueHolder_echoOptional",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -167,7 +167,7 @@
             }
           }
         ],
-        "swiftCallName" : "JSValueHolder"
+        "swiftCallName" : "TestModule.JSValueHolder"
       }
     ],
     "enums" : [
@@ -176,7 +176,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_roundTripJSValue",
+        "abiName" : "bjs_TestModule_roundTripJSValue",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -201,7 +201,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalJSValue",
+        "abiName" : "bjs_TestModule_roundTripOptionalJSValue",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -236,7 +236,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripJSValueArray",
+        "abiName" : "bjs_TestModule_roundTripJSValueArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -269,7 +269,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalJSValueArray",
+        "abiName" : "bjs_TestModule_roundTripOptionalJSValueArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/JSValue.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_roundTripJSValue")
-@_cdecl("bjs_roundTripJSValue")
-public func _bjs_roundTripJSValue(_ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripJSValue")
+@_cdecl("bjs_TestModule_roundTripJSValue")
+public func _bjs_TestModule_roundTripJSValue(_ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
     #if arch(wasm32)
     let ret = roundTripJSValue(_: JSValue.bridgeJSLiftParameter(valueKind, valuePayload1, valuePayload2))
     return ret.bridgeJSLowerReturn()
@@ -9,9 +9,9 @@ public func _bjs_roundTripJSValue(_ valueKind: Int32, _ valuePayload1: Int32, _ 
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalJSValue")
-@_cdecl("bjs_roundTripOptionalJSValue")
-public func _bjs_roundTripOptionalJSValue(_ valueIsSome: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalJSValue")
+@_cdecl("bjs_TestModule_roundTripOptionalJSValue")
+public func _bjs_TestModule_roundTripOptionalJSValue(_ valueIsSome: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalJSValue(_: Optional<JSValue>.bridgeJSLiftParameter(valueIsSome, valueKind, valuePayload1, valuePayload2))
     return ret.bridgeJSLowerReturn()
@@ -20,9 +20,9 @@ public func _bjs_roundTripOptionalJSValue(_ valueIsSome: Int32, _ valueKind: Int
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripJSValueArray")
-@_cdecl("bjs_roundTripJSValueArray")
-public func _bjs_roundTripJSValueArray() -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripJSValueArray")
+@_cdecl("bjs_TestModule_roundTripJSValueArray")
+public func _bjs_TestModule_roundTripJSValueArray() -> Void {
     #if arch(wasm32)
     let ret = roundTripJSValueArray(_: [JSValue].bridgeJSStackPop())
     ret.bridgeJSStackPush()
@@ -31,9 +31,9 @@ public func _bjs_roundTripJSValueArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalJSValueArray")
-@_cdecl("bjs_roundTripOptionalJSValueArray")
-public func _bjs_roundTripOptionalJSValueArray() -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalJSValueArray")
+@_cdecl("bjs_TestModule_roundTripOptionalJSValueArray")
+public func _bjs_TestModule_roundTripOptionalJSValueArray() -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalJSValueArray(_: Optional<[JSValue]>.bridgeJSLiftParameter())
     ret.bridgeJSStackPush()
@@ -42,120 +42,120 @@ public func _bjs_roundTripOptionalJSValueArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_JSValueHolder_init")
-@_cdecl("bjs_JSValueHolder_init")
-public func _bjs_JSValueHolder_init(_ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64, _ optionalValueIsSome: Int32, _ optionalValueKind: Int32, _ optionalValuePayload1: Int32, _ optionalValuePayload2: Float64) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_JSValueHolder_init")
+@_cdecl("bjs_TestModule_JSValueHolder_init")
+public func _bjs_TestModule_JSValueHolder_init(_ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64, _ optionalValueIsSome: Int32, _ optionalValueKind: Int32, _ optionalValuePayload1: Int32, _ optionalValuePayload2: Float64) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = JSValueHolder(value: JSValue.bridgeJSLiftParameter(valueKind, valuePayload1, valuePayload2), optionalValue: Optional<JSValue>.bridgeJSLiftParameter(optionalValueIsSome, optionalValueKind, optionalValuePayload1, optionalValuePayload2))
+    let ret = TestModule.JSValueHolder(value: JSValue.bridgeJSLiftParameter(valueKind, valuePayload1, valuePayload2), optionalValue: Optional<JSValue>.bridgeJSLiftParameter(optionalValueIsSome, optionalValueKind, optionalValuePayload1, optionalValuePayload2))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSValueHolder_update")
-@_cdecl("bjs_JSValueHolder_update")
-public func _bjs_JSValueHolder_update(_ _self: UnsafeMutableRawPointer, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64, _ optionalValueIsSome: Int32, _ optionalValueKind: Int32, _ optionalValuePayload1: Int32, _ optionalValuePayload2: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_JSValueHolder_update")
+@_cdecl("bjs_TestModule_JSValueHolder_update")
+public func _bjs_TestModule_JSValueHolder_update(_ _self: UnsafeMutableRawPointer, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64, _ optionalValueIsSome: Int32, _ optionalValueKind: Int32, _ optionalValuePayload1: Int32, _ optionalValuePayload2: Float64) -> Void {
     #if arch(wasm32)
-    JSValueHolder.bridgeJSLiftParameter(_self).update(value: JSValue.bridgeJSLiftParameter(valueKind, valuePayload1, valuePayload2), optionalValue: Optional<JSValue>.bridgeJSLiftParameter(optionalValueIsSome, optionalValueKind, optionalValuePayload1, optionalValuePayload2))
+    TestModule.JSValueHolder.bridgeJSLiftParameter(_self).update(value: JSValue.bridgeJSLiftParameter(valueKind, valuePayload1, valuePayload2), optionalValue: Optional<JSValue>.bridgeJSLiftParameter(optionalValueIsSome, optionalValueKind, optionalValuePayload1, optionalValuePayload2))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSValueHolder_echo")
-@_cdecl("bjs_JSValueHolder_echo")
-public func _bjs_JSValueHolder_echo(_ _self: UnsafeMutableRawPointer, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_JSValueHolder_echo")
+@_cdecl("bjs_TestModule_JSValueHolder_echo")
+public func _bjs_TestModule_JSValueHolder_echo(_ _self: UnsafeMutableRawPointer, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
     #if arch(wasm32)
-    let ret = JSValueHolder.bridgeJSLiftParameter(_self).echo(value: JSValue.bridgeJSLiftParameter(valueKind, valuePayload1, valuePayload2))
+    let ret = TestModule.JSValueHolder.bridgeJSLiftParameter(_self).echo(value: JSValue.bridgeJSLiftParameter(valueKind, valuePayload1, valuePayload2))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSValueHolder_echoOptional")
-@_cdecl("bjs_JSValueHolder_echoOptional")
-public func _bjs_JSValueHolder_echoOptional(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_JSValueHolder_echoOptional")
+@_cdecl("bjs_TestModule_JSValueHolder_echoOptional")
+public func _bjs_TestModule_JSValueHolder_echoOptional(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
     #if arch(wasm32)
-    let ret = JSValueHolder.bridgeJSLiftParameter(_self).echoOptional(_: Optional<JSValue>.bridgeJSLiftParameter(valueIsSome, valueKind, valuePayload1, valuePayload2))
+    let ret = TestModule.JSValueHolder.bridgeJSLiftParameter(_self).echoOptional(_: Optional<JSValue>.bridgeJSLiftParameter(valueIsSome, valueKind, valuePayload1, valuePayload2))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSValueHolder_value_get")
-@_cdecl("bjs_JSValueHolder_value_get")
-public func _bjs_JSValueHolder_value_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_JSValueHolder_value_get")
+@_cdecl("bjs_TestModule_JSValueHolder_value_get")
+public func _bjs_TestModule_JSValueHolder_value_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = JSValueHolder.bridgeJSLiftParameter(_self).value
+    let ret = TestModule.JSValueHolder.bridgeJSLiftParameter(_self).value
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSValueHolder_value_set")
-@_cdecl("bjs_JSValueHolder_value_set")
-public func _bjs_JSValueHolder_value_set(_ _self: UnsafeMutableRawPointer, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_JSValueHolder_value_set")
+@_cdecl("bjs_TestModule_JSValueHolder_value_set")
+public func _bjs_TestModule_JSValueHolder_value_set(_ _self: UnsafeMutableRawPointer, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
     #if arch(wasm32)
-    JSValueHolder.bridgeJSLiftParameter(_self).value = JSValue.bridgeJSLiftParameter(valueKind, valuePayload1, valuePayload2)
+    TestModule.JSValueHolder.bridgeJSLiftParameter(_self).value = JSValue.bridgeJSLiftParameter(valueKind, valuePayload1, valuePayload2)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSValueHolder_optionalValue_get")
-@_cdecl("bjs_JSValueHolder_optionalValue_get")
-public func _bjs_JSValueHolder_optionalValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_JSValueHolder_optionalValue_get")
+@_cdecl("bjs_TestModule_JSValueHolder_optionalValue_get")
+public func _bjs_TestModule_JSValueHolder_optionalValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = JSValueHolder.bridgeJSLiftParameter(_self).optionalValue
+    let ret = TestModule.JSValueHolder.bridgeJSLiftParameter(_self).optionalValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSValueHolder_optionalValue_set")
-@_cdecl("bjs_JSValueHolder_optionalValue_set")
-public func _bjs_JSValueHolder_optionalValue_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_JSValueHolder_optionalValue_set")
+@_cdecl("bjs_TestModule_JSValueHolder_optionalValue_set")
+public func _bjs_TestModule_JSValueHolder_optionalValue_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueKind: Int32, _ valuePayload1: Int32, _ valuePayload2: Float64) -> Void {
     #if arch(wasm32)
-    JSValueHolder.bridgeJSLiftParameter(_self).optionalValue = Optional<JSValue>.bridgeJSLiftParameter(valueIsSome, valueKind, valuePayload1, valuePayload2)
+    TestModule.JSValueHolder.bridgeJSLiftParameter(_self).optionalValue = Optional<JSValue>.bridgeJSLiftParameter(valueIsSome, valueKind, valuePayload1, valuePayload2)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSValueHolder_deinit")
-@_cdecl("bjs_JSValueHolder_deinit")
-public func _bjs_JSValueHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_JSValueHolder_deinit")
+@_cdecl("bjs_TestModule_JSValueHolder_deinit")
+public func _bjs_TestModule_JSValueHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<JSValueHolder>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.JSValueHolder>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension JSValueHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.JSValueHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_JSValueHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_JSValueHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_JSValueHolder_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_JSValueHolder_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_JSValueHolder_wrap")
-fileprivate func _bjs_JSValueHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_JSValueHolder_wrap")
+fileprivate func _bjs_TestModule_JSValueHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_JSValueHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_JSValueHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_JSValueHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_JSValueHolder_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_JSValueHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_JSValueHolder_wrap_extern(pointer)
 }
 
 #if arch(wasm32)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedGlobal.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedGlobal.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_GlobalAPI_GlobalClass_init",
+          "abiName" : "bjs_TestModule_GlobalClass_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_GlobalAPI_GlobalClass_greet",
+            "abiName" : "bjs_TestModule_GlobalClass_greet",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -42,7 +42,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "GlobalClass"
+        "swiftCallName" : "TestModule.GlobalClass"
       }
     ],
     "enums" : [
@@ -51,7 +51,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_GlobalAPI_globalFunction",
+        "abiName" : "bjs_TestModule_GlobalAPI_globalFunction",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedGlobal.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedGlobal.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_GlobalAPI_globalFunction")
-@_cdecl("bjs_GlobalAPI_globalFunction")
-public func _bjs_GlobalAPI_globalFunction() -> Void {
+@_expose(wasm, "bjs_TestModule_GlobalAPI_globalFunction")
+@_cdecl("bjs_TestModule_GlobalAPI_globalFunction")
+public func _bjs_TestModule_GlobalAPI_globalFunction() -> Void {
     #if arch(wasm32)
     let ret = globalFunction()
     return ret.bridgeJSLowerReturn()
@@ -9,55 +9,55 @@ public func _bjs_GlobalAPI_globalFunction() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalAPI_GlobalClass_init")
-@_cdecl("bjs_GlobalAPI_GlobalClass_init")
-public func _bjs_GlobalAPI_GlobalClass_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_GlobalClass_init")
+@_cdecl("bjs_TestModule_GlobalClass_init")
+public func _bjs_TestModule_GlobalClass_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = GlobalClass()
+    let ret = TestModule.GlobalClass()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalAPI_GlobalClass_greet")
-@_cdecl("bjs_GlobalAPI_GlobalClass_greet")
-public func _bjs_GlobalAPI_GlobalClass_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_GlobalClass_greet")
+@_cdecl("bjs_TestModule_GlobalClass_greet")
+public func _bjs_TestModule_GlobalClass_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = GlobalClass.bridgeJSLiftParameter(_self).greet()
+    let ret = TestModule.GlobalClass.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalAPI_GlobalClass_deinit")
-@_cdecl("bjs_GlobalAPI_GlobalClass_deinit")
-public func _bjs_GlobalAPI_GlobalClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_GlobalClass_deinit")
+@_cdecl("bjs_TestModule_GlobalClass_deinit")
+public func _bjs_TestModule_GlobalClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<GlobalClass>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.GlobalClass>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension GlobalClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.GlobalClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_GlobalAPI_GlobalClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_GlobalClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_GlobalAPI_GlobalClass_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_GlobalClass_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_GlobalAPI_GlobalClass_wrap")
-fileprivate func _bjs_GlobalAPI_GlobalClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_GlobalClass_wrap")
+fileprivate func _bjs_TestModule_GlobalClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_GlobalAPI_GlobalClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_GlobalClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_GlobalAPI_GlobalClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_GlobalAPI_GlobalClass_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_GlobalClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_GlobalClass_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedPrivate.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedPrivate.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_PrivateAPI_PrivateClass_init",
+          "abiName" : "bjs_TestModule_PrivateClass_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_PrivateAPI_PrivateClass_greet",
+            "abiName" : "bjs_TestModule_PrivateClass_greet",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -42,7 +42,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PrivateClass"
+        "swiftCallName" : "TestModule.PrivateClass"
       }
     ],
     "enums" : [
@@ -51,7 +51,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_PrivateAPI_privateFunction",
+        "abiName" : "bjs_TestModule_PrivateAPI_privateFunction",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedPrivate.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/MixedPrivate.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_PrivateAPI_privateFunction")
-@_cdecl("bjs_PrivateAPI_privateFunction")
-public func _bjs_PrivateAPI_privateFunction() -> Void {
+@_expose(wasm, "bjs_TestModule_PrivateAPI_privateFunction")
+@_cdecl("bjs_TestModule_PrivateAPI_privateFunction")
+public func _bjs_TestModule_PrivateAPI_privateFunction() -> Void {
     #if arch(wasm32)
     let ret = privateFunction()
     return ret.bridgeJSLowerReturn()
@@ -9,55 +9,55 @@ public func _bjs_PrivateAPI_privateFunction() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_PrivateAPI_PrivateClass_init")
-@_cdecl("bjs_PrivateAPI_PrivateClass_init")
-public func _bjs_PrivateAPI_PrivateClass_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PrivateClass_init")
+@_cdecl("bjs_TestModule_PrivateClass_init")
+public func _bjs_TestModule_PrivateClass_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PrivateClass()
+    let ret = TestModule.PrivateClass()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PrivateAPI_PrivateClass_greet")
-@_cdecl("bjs_PrivateAPI_PrivateClass_greet")
-public func _bjs_PrivateAPI_PrivateClass_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PrivateClass_greet")
+@_cdecl("bjs_TestModule_PrivateClass_greet")
+public func _bjs_TestModule_PrivateClass_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PrivateClass.bridgeJSLiftParameter(_self).greet()
+    let ret = TestModule.PrivateClass.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PrivateAPI_PrivateClass_deinit")
-@_cdecl("bjs_PrivateAPI_PrivateClass_deinit")
-public func _bjs_PrivateAPI_PrivateClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PrivateClass_deinit")
+@_cdecl("bjs_TestModule_PrivateClass_deinit")
+public func _bjs_TestModule_PrivateClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PrivateClass>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.PrivateClass>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PrivateClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.PrivateClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PrivateAPI_PrivateClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_PrivateClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PrivateAPI_PrivateClass_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_PrivateClass_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_PrivateAPI_PrivateClass_wrap")
-fileprivate func _bjs_PrivateAPI_PrivateClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_PrivateClass_wrap")
+fileprivate func _bjs_TestModule_PrivateClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PrivateAPI_PrivateClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_PrivateClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PrivateAPI_PrivateClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PrivateAPI_PrivateClass_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_PrivateClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_PrivateClass_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs___Swift_Foundation_Greeter_init",
+          "abiName" : "bjs_TestModule_Greeter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -27,7 +27,7 @@
         "documentation" : "A greeter living in a namespace.",
         "methods" : [
           {
-            "abiName" : "bjs___Swift_Foundation_Greeter_greet",
+            "abiName" : "bjs_TestModule_Greeter_greet",
             "documentation" : "Produces a greeting for the configured name.\n- Returns: The greeting message.",
             "effects" : {
               "isAsync" : false,
@@ -45,7 +45,7 @@
             }
           },
           {
-            "abiName" : "bjs___Swift_Foundation_Greeter_static_makeDefault",
+            "abiName" : "bjs_TestModule_Greeter_static_makeDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -57,12 +57,12 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "TestModule.Greeter"
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "__Swift_Foundation_Greeter"
+                "_0" : "TestModule_Greeter"
               }
             }
           }
@@ -79,7 +79,7 @@
             "name" : "defaultGreeting",
             "staticContext" : {
               "className" : {
-                "_0" : "__Swift_Foundation_Greeter"
+                "_0" : "TestModule_Greeter"
               }
             },
             "type" : {
@@ -89,11 +89,11 @@
             }
           }
         ],
-        "swiftCallName" : "Greeter"
+        "swiftCallName" : "TestModule.Greeter"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Utils_Converters_Converter_init",
+          "abiName" : "bjs_TestModule_Converter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -105,7 +105,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Utils_Converters_Converter_toString",
+            "abiName" : "bjs_TestModule_Converter_toString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -141,12 +141,12 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Converter"
+        "swiftCallName" : "TestModule.Converter"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs___Swift_Foundation_UUID_uuidString",
+            "abiName" : "bjs_TestModule_UUID_uuidString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -171,11 +171,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "UUID"
+        "swiftCallName" : "TestModule.UUID"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Collections_Container_init",
+          "abiName" : "bjs_TestModule_Container_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -187,7 +187,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Collections_Container_getItems",
+            "abiName" : "bjs_TestModule_Container_getItems",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -201,14 +201,14 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "TestModule.Greeter"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_Collections_Container_addItem",
+            "abiName" : "bjs_TestModule_Container_addItem",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -221,7 +221,7 @@
                 "name" : "item",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "TestModule.Greeter"
                   }
                 }
               }
@@ -240,7 +240,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Container"
+        "swiftCallName" : "TestModule.Container"
       }
     ],
     "enums" : [
@@ -249,7 +249,7 @@
     "exposeToGlobal" : true,
     "functions" : [
       {
-        "abiName" : "bjs_plainFunction",
+        "abiName" : "bjs_TestModule_plainFunction",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -266,7 +266,7 @@
         }
       },
       {
-        "abiName" : "bjs_MyModule_Utils_namespacedFunction",
+        "abiName" : "bjs_TestModule_MyModule_Utils_namespacedFunction",
         "documentation" : "A namespaced free function.\n- Returns: A fixed namespaced string.",
         "effects" : {
           "isAsync" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.Global.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_plainFunction")
-@_cdecl("bjs_plainFunction")
-public func _bjs_plainFunction() -> Void {
+@_expose(wasm, "bjs_TestModule_plainFunction")
+@_cdecl("bjs_TestModule_plainFunction")
+public func _bjs_TestModule_plainFunction() -> Void {
     #if arch(wasm32)
     let ret = plainFunction()
     return ret.bridgeJSLowerReturn()
@@ -9,9 +9,9 @@ public func _bjs_plainFunction() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_MyModule_Utils_namespacedFunction")
-@_cdecl("bjs_MyModule_Utils_namespacedFunction")
-public func _bjs_MyModule_Utils_namespacedFunction() -> Void {
+@_expose(wasm, "bjs_TestModule_MyModule_Utils_namespacedFunction")
+@_cdecl("bjs_TestModule_MyModule_Utils_namespacedFunction")
+public func _bjs_TestModule_MyModule_Utils_namespacedFunction() -> Void {
     #if arch(wasm32)
     let ret = namespacedFunction()
     return ret.bridgeJSLowerReturn()
@@ -20,235 +20,235 @@ public func _bjs_MyModule_Utils_namespacedFunction() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_init")
-@_cdecl("bjs___Swift_Foundation_Greeter_init")
-public func _bjs___Swift_Foundation_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Greeter_init")
+@_cdecl("bjs_TestModule_Greeter_init")
+public func _bjs_TestModule_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_greet")
-@_cdecl("bjs___Swift_Foundation_Greeter_greet")
-public func _bjs___Swift_Foundation_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_greet")
+@_cdecl("bjs_TestModule_Greeter_greet")
+public func _bjs_TestModule_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greet()
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_static_makeDefault")
-@_cdecl("bjs___Swift_Foundation_Greeter_static_makeDefault")
-public func _bjs___Swift_Foundation_Greeter_static_makeDefault() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Greeter_static_makeDefault")
+@_cdecl("bjs_TestModule_Greeter_static_makeDefault")
+public func _bjs_TestModule_Greeter_static_makeDefault() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter.makeDefault()
+    let ret = TestModule.Greeter.makeDefault()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
-@_cdecl("bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
-public func _bjs___Swift_Foundation_Greeter_static_defaultGreeting_get() -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_static_defaultGreeting_get")
+@_cdecl("bjs_TestModule_Greeter_static_defaultGreeting_get")
+public func _bjs_TestModule_Greeter_static_defaultGreeting_get() -> Void {
     #if arch(wasm32)
-    let ret = Greeter.defaultGreeting
+    let ret = TestModule.Greeter.defaultGreeting
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_deinit")
-@_cdecl("bjs___Swift_Foundation_Greeter_deinit")
-public func _bjs___Swift_Foundation_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_deinit")
+@_cdecl("bjs_TestModule_Greeter_deinit")
+public func _bjs_TestModule_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Greeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Greeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs___Swift_Foundation_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs___Swift_Foundation_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs___Swift_Foundation_Greeter_wrap")
-fileprivate func _bjs___Swift_Foundation_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Greeter_wrap")
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs___Swift_Foundation_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs___Swift_Foundation_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs___Swift_Foundation_Greeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Greeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Utils_Converters_Converter_init")
-@_cdecl("bjs_Utils_Converters_Converter_init")
-public func _bjs_Utils_Converters_Converter_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Converter_init")
+@_cdecl("bjs_TestModule_Converter_init")
+public func _bjs_TestModule_Converter_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Converter()
+    let ret = TestModule.Converter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converters_Converter_toString")
-@_cdecl("bjs_Utils_Converters_Converter_toString")
-public func _bjs_Utils_Converters_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Converter_toString")
+@_cdecl("bjs_TestModule_Converter_toString")
+public func _bjs_TestModule_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converters_Converter_deinit")
-@_cdecl("bjs_Utils_Converters_Converter_deinit")
-public func _bjs_Utils_Converters_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Converter_deinit")
+@_cdecl("bjs_TestModule_Converter_deinit")
+public func _bjs_TestModule_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Converter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Converter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Utils_Converters_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Utils_Converters_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Utils_Converters_Converter_wrap")
-fileprivate func _bjs_Utils_Converters_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Converter_wrap")
+fileprivate func _bjs_TestModule_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Utils_Converters_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Utils_Converters_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Utils_Converters_Converter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Converter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_UUID_uuidString")
-@_cdecl("bjs___Swift_Foundation_UUID_uuidString")
-public func _bjs___Swift_Foundation_UUID_uuidString(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_UUID_uuidString")
+@_cdecl("bjs_TestModule_UUID_uuidString")
+public func _bjs_TestModule_UUID_uuidString(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = UUID.bridgeJSLiftParameter(_self).uuidString()
+    let ret = TestModule.UUID.bridgeJSLiftParameter(_self).uuidString()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_UUID_deinit")
-@_cdecl("bjs___Swift_Foundation_UUID_deinit")
-public func _bjs___Swift_Foundation_UUID_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_UUID_deinit")
+@_cdecl("bjs_TestModule_UUID_deinit")
+public func _bjs_TestModule_UUID_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<UUID>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.UUID>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension UUID: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.UUID: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs___Swift_Foundation_UUID_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_UUID_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs___Swift_Foundation_UUID_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_UUID_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs___Swift_Foundation_UUID_wrap")
-fileprivate func _bjs___Swift_Foundation_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_UUID_wrap")
+fileprivate func _bjs_TestModule_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs___Swift_Foundation_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs___Swift_Foundation_UUID_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs___Swift_Foundation_UUID_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_UUID_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_UUID_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Collections_Container_init")
-@_cdecl("bjs_Collections_Container_init")
-public func _bjs_Collections_Container_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Container_init")
+@_cdecl("bjs_TestModule_Container_init")
+public func _bjs_TestModule_Container_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Container()
+    let ret = TestModule.Container()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Collections_Container_getItems")
-@_cdecl("bjs_Collections_Container_getItems")
-public func _bjs_Collections_Container_getItems(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Container_getItems")
+@_cdecl("bjs_TestModule_Container_getItems")
+public func _bjs_TestModule_Container_getItems(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Container.bridgeJSLiftParameter(_self).getItems()
+    let ret = TestModule.Container.bridgeJSLiftParameter(_self).getItems()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Collections_Container_addItem")
-@_cdecl("bjs_Collections_Container_addItem")
-public func _bjs_Collections_Container_addItem(_ _self: UnsafeMutableRawPointer, _ item: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Container_addItem")
+@_cdecl("bjs_TestModule_Container_addItem")
+public func _bjs_TestModule_Container_addItem(_ _self: UnsafeMutableRawPointer, _ item: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Container.bridgeJSLiftParameter(_self).addItem(_: Greeter.bridgeJSLiftParameter(item))
+    TestModule.Container.bridgeJSLiftParameter(_self).addItem(_: TestModule.Greeter.bridgeJSLiftParameter(item))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Collections_Container_deinit")
-@_cdecl("bjs_Collections_Container_deinit")
-public func _bjs_Collections_Container_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Container_deinit")
+@_cdecl("bjs_TestModule_Container_deinit")
+public func _bjs_TestModule_Container_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Container>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Container>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Container: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Container: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Collections_Container_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Container_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Collections_Container_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Container_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Collections_Container_wrap")
-fileprivate func _bjs_Collections_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Container_wrap")
+fileprivate func _bjs_TestModule_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Collections_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Collections_Container_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Collections_Container_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Container_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Container_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs___Swift_Foundation_Greeter_init",
+          "abiName" : "bjs_TestModule_Greeter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -27,7 +27,7 @@
         "documentation" : "A greeter living in a namespace.",
         "methods" : [
           {
-            "abiName" : "bjs___Swift_Foundation_Greeter_greet",
+            "abiName" : "bjs_TestModule_Greeter_greet",
             "documentation" : "Produces a greeting for the configured name.\n- Returns: The greeting message.",
             "effects" : {
               "isAsync" : false,
@@ -45,7 +45,7 @@
             }
           },
           {
-            "abiName" : "bjs___Swift_Foundation_Greeter_static_makeDefault",
+            "abiName" : "bjs_TestModule_Greeter_static_makeDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -57,12 +57,12 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "TestModule.Greeter"
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "__Swift_Foundation_Greeter"
+                "_0" : "TestModule_Greeter"
               }
             }
           }
@@ -79,7 +79,7 @@
             "name" : "defaultGreeting",
             "staticContext" : {
               "className" : {
-                "_0" : "__Swift_Foundation_Greeter"
+                "_0" : "TestModule_Greeter"
               }
             },
             "type" : {
@@ -89,11 +89,11 @@
             }
           }
         ],
-        "swiftCallName" : "Greeter"
+        "swiftCallName" : "TestModule.Greeter"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Utils_Converters_Converter_init",
+          "abiName" : "bjs_TestModule_Converter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -105,7 +105,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Utils_Converters_Converter_toString",
+            "abiName" : "bjs_TestModule_Converter_toString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -141,12 +141,12 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Converter"
+        "swiftCallName" : "TestModule.Converter"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs___Swift_Foundation_UUID_uuidString",
+            "abiName" : "bjs_TestModule_UUID_uuidString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -171,11 +171,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "UUID"
+        "swiftCallName" : "TestModule.UUID"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Collections_Container_init",
+          "abiName" : "bjs_TestModule_Container_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -187,7 +187,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Collections_Container_getItems",
+            "abiName" : "bjs_TestModule_Container_getItems",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -201,14 +201,14 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "TestModule.Greeter"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_Collections_Container_addItem",
+            "abiName" : "bjs_TestModule_Container_addItem",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -221,7 +221,7 @@
                 "name" : "item",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "TestModule.Greeter"
                   }
                 }
               }
@@ -240,7 +240,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Container"
+        "swiftCallName" : "TestModule.Container"
       }
     ],
     "enums" : [
@@ -249,7 +249,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_plainFunction",
+        "abiName" : "bjs_TestModule_plainFunction",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -266,7 +266,7 @@
         }
       },
       {
-        "abiName" : "bjs_MyModule_Utils_namespacedFunction",
+        "abiName" : "bjs_TestModule_MyModule_Utils_namespacedFunction",
         "documentation" : "A namespaced free function.\n- Returns: A fixed namespaced string.",
         "effects" : {
           "isAsync" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Namespaces.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_plainFunction")
-@_cdecl("bjs_plainFunction")
-public func _bjs_plainFunction() -> Void {
+@_expose(wasm, "bjs_TestModule_plainFunction")
+@_cdecl("bjs_TestModule_plainFunction")
+public func _bjs_TestModule_plainFunction() -> Void {
     #if arch(wasm32)
     let ret = plainFunction()
     return ret.bridgeJSLowerReturn()
@@ -9,9 +9,9 @@ public func _bjs_plainFunction() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_MyModule_Utils_namespacedFunction")
-@_cdecl("bjs_MyModule_Utils_namespacedFunction")
-public func _bjs_MyModule_Utils_namespacedFunction() -> Void {
+@_expose(wasm, "bjs_TestModule_MyModule_Utils_namespacedFunction")
+@_cdecl("bjs_TestModule_MyModule_Utils_namespacedFunction")
+public func _bjs_TestModule_MyModule_Utils_namespacedFunction() -> Void {
     #if arch(wasm32)
     let ret = namespacedFunction()
     return ret.bridgeJSLowerReturn()
@@ -20,235 +20,235 @@ public func _bjs_MyModule_Utils_namespacedFunction() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_init")
-@_cdecl("bjs___Swift_Foundation_Greeter_init")
-public func _bjs___Swift_Foundation_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Greeter_init")
+@_cdecl("bjs_TestModule_Greeter_init")
+public func _bjs_TestModule_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_greet")
-@_cdecl("bjs___Swift_Foundation_Greeter_greet")
-public func _bjs___Swift_Foundation_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_greet")
+@_cdecl("bjs_TestModule_Greeter_greet")
+public func _bjs_TestModule_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greet()
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_static_makeDefault")
-@_cdecl("bjs___Swift_Foundation_Greeter_static_makeDefault")
-public func _bjs___Swift_Foundation_Greeter_static_makeDefault() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Greeter_static_makeDefault")
+@_cdecl("bjs_TestModule_Greeter_static_makeDefault")
+public func _bjs_TestModule_Greeter_static_makeDefault() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter.makeDefault()
+    let ret = TestModule.Greeter.makeDefault()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
-@_cdecl("bjs___Swift_Foundation_Greeter_static_defaultGreeting_get")
-public func _bjs___Swift_Foundation_Greeter_static_defaultGreeting_get() -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_static_defaultGreeting_get")
+@_cdecl("bjs_TestModule_Greeter_static_defaultGreeting_get")
+public func _bjs_TestModule_Greeter_static_defaultGreeting_get() -> Void {
     #if arch(wasm32)
-    let ret = Greeter.defaultGreeting
+    let ret = TestModule.Greeter.defaultGreeting
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_Greeter_deinit")
-@_cdecl("bjs___Swift_Foundation_Greeter_deinit")
-public func _bjs___Swift_Foundation_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_deinit")
+@_cdecl("bjs_TestModule_Greeter_deinit")
+public func _bjs_TestModule_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Greeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Greeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs___Swift_Foundation_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs___Swift_Foundation_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs___Swift_Foundation_Greeter_wrap")
-fileprivate func _bjs___Swift_Foundation_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Greeter_wrap")
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs___Swift_Foundation_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs___Swift_Foundation_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs___Swift_Foundation_Greeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Greeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Utils_Converters_Converter_init")
-@_cdecl("bjs_Utils_Converters_Converter_init")
-public func _bjs_Utils_Converters_Converter_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Converter_init")
+@_cdecl("bjs_TestModule_Converter_init")
+public func _bjs_TestModule_Converter_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Converter()
+    let ret = TestModule.Converter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converters_Converter_toString")
-@_cdecl("bjs_Utils_Converters_Converter_toString")
-public func _bjs_Utils_Converters_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Converter_toString")
+@_cdecl("bjs_TestModule_Converter_toString")
+public func _bjs_TestModule_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converters_Converter_deinit")
-@_cdecl("bjs_Utils_Converters_Converter_deinit")
-public func _bjs_Utils_Converters_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Converter_deinit")
+@_cdecl("bjs_TestModule_Converter_deinit")
+public func _bjs_TestModule_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Converter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Converter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Utils_Converters_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Utils_Converters_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Utils_Converters_Converter_wrap")
-fileprivate func _bjs_Utils_Converters_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Converter_wrap")
+fileprivate func _bjs_TestModule_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Utils_Converters_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Utils_Converters_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Utils_Converters_Converter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Converter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_UUID_uuidString")
-@_cdecl("bjs___Swift_Foundation_UUID_uuidString")
-public func _bjs___Swift_Foundation_UUID_uuidString(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_UUID_uuidString")
+@_cdecl("bjs_TestModule_UUID_uuidString")
+public func _bjs_TestModule_UUID_uuidString(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = UUID.bridgeJSLiftParameter(_self).uuidString()
+    let ret = TestModule.UUID.bridgeJSLiftParameter(_self).uuidString()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_UUID_deinit")
-@_cdecl("bjs___Swift_Foundation_UUID_deinit")
-public func _bjs___Swift_Foundation_UUID_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_UUID_deinit")
+@_cdecl("bjs_TestModule_UUID_deinit")
+public func _bjs_TestModule_UUID_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<UUID>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.UUID>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension UUID: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.UUID: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs___Swift_Foundation_UUID_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_UUID_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs___Swift_Foundation_UUID_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_UUID_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs___Swift_Foundation_UUID_wrap")
-fileprivate func _bjs___Swift_Foundation_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_UUID_wrap")
+fileprivate func _bjs_TestModule_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs___Swift_Foundation_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs___Swift_Foundation_UUID_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs___Swift_Foundation_UUID_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_UUID_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_UUID_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Collections_Container_init")
-@_cdecl("bjs_Collections_Container_init")
-public func _bjs_Collections_Container_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Container_init")
+@_cdecl("bjs_TestModule_Container_init")
+public func _bjs_TestModule_Container_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Container()
+    let ret = TestModule.Container()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Collections_Container_getItems")
-@_cdecl("bjs_Collections_Container_getItems")
-public func _bjs_Collections_Container_getItems(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Container_getItems")
+@_cdecl("bjs_TestModule_Container_getItems")
+public func _bjs_TestModule_Container_getItems(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Container.bridgeJSLiftParameter(_self).getItems()
+    let ret = TestModule.Container.bridgeJSLiftParameter(_self).getItems()
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Collections_Container_addItem")
-@_cdecl("bjs_Collections_Container_addItem")
-public func _bjs_Collections_Container_addItem(_ _self: UnsafeMutableRawPointer, _ item: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Container_addItem")
+@_cdecl("bjs_TestModule_Container_addItem")
+public func _bjs_TestModule_Container_addItem(_ _self: UnsafeMutableRawPointer, _ item: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Container.bridgeJSLiftParameter(_self).addItem(_: Greeter.bridgeJSLiftParameter(item))
+    TestModule.Container.bridgeJSLiftParameter(_self).addItem(_: TestModule.Greeter.bridgeJSLiftParameter(item))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Collections_Container_deinit")
-@_cdecl("bjs_Collections_Container_deinit")
-public func _bjs_Collections_Container_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Container_deinit")
+@_cdecl("bjs_TestModule_Container_deinit")
+public func _bjs_TestModule_Container_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Container>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Container>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Container: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Container: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Collections_Container_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Container_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Collections_Container_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Container_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Collections_Container_wrap")
-fileprivate func _bjs_Collections_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Container_wrap")
+fileprivate func _bjs_TestModule_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Collections_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Collections_Container_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Collections_Container_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Container_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Container_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.json
@@ -7,7 +7,7 @@
       {
         "methods" : [
           {
-            "abiName" : "bjs_User_getName",
+            "abiName" : "bjs_TestModule_User_getName",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -28,12 +28,12 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "User"
+        "swiftCallName" : "TestModule.User"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_Player_getTag",
+            "abiName" : "bjs_TestModule_Player_getTag",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -54,7 +54,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Player"
+        "swiftCallName" : "TestModule.Player"
       }
     ],
     "enums" : [
@@ -107,7 +107,7 @@
             }
           }
         ],
-        "swiftCallName" : "User.Stats"
+        "swiftCallName" : "TestModule.User.Stats"
       },
       {
         "methods" : [
@@ -148,7 +148,7 @@
             }
           }
         ],
-        "swiftCallName" : "Player.Stats"
+        "swiftCallName" : "TestModule.Player.Stats"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/NestedType.swift
@@ -1,8 +1,8 @@
-extension User.Stats: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> User.Stats {
+extension TestModule.User.Stats: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.User.Stats {
         let score = Double.bridgeJSStackPop()
         let health = Int.bridgeJSStackPop()
-        return User.Stats(health: health, score: score)
+        return TestModule.User.Stats(health: health, score: score)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -11,46 +11,46 @@ extension User.Stats: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_User_Stats(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_User_Stats(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_User_Stats()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_User_Stats()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_User_Stats")
-fileprivate func _bjs_struct_lower_User_Stats_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_User_Stats")
+fileprivate func _bjs_struct_lower_TestModule_User_Stats_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_User_Stats_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_User_Stats_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_User_Stats(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_User_Stats_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_User_Stats(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_User_Stats_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_User_Stats")
-fileprivate func _bjs_struct_lift_User_Stats_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_User_Stats")
+fileprivate func _bjs_struct_lift_TestModule_User_Stats_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_User_Stats_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_User_Stats_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_User_Stats() -> Int32 {
-    return _bjs_struct_lift_User_Stats_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_User_Stats() -> Int32 {
+    return _bjs_struct_lift_TestModule_User_Stats_extern()
 }
 
-extension Player.Stats: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Player.Stats {
+extension TestModule.Player.Stats: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Player.Stats {
         let rating = String.bridgeJSStackPop()
         let level = Int.bridgeJSStackPop()
-        return Player.Stats(level: level, rating: rating)
+        return TestModule.Player.Stats(level: level, rating: rating)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -59,121 +59,121 @@ extension Player.Stats: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Player_Stats(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Player_Stats(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Player_Stats()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Player_Stats()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Player_Stats")
-fileprivate func _bjs_struct_lower_Player_Stats_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Player_Stats")
+fileprivate func _bjs_struct_lower_TestModule_Player_Stats_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Player_Stats_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Player_Stats_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Player_Stats(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Player_Stats_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Player_Stats(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Player_Stats_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Player_Stats")
-fileprivate func _bjs_struct_lift_Player_Stats_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Player_Stats")
+fileprivate func _bjs_struct_lift_TestModule_Player_Stats_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Player_Stats_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Player_Stats_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Player_Stats() -> Int32 {
-    return _bjs_struct_lift_Player_Stats_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Player_Stats() -> Int32 {
+    return _bjs_struct_lift_TestModule_Player_Stats_extern()
 }
 
-@_expose(wasm, "bjs_User_getName")
-@_cdecl("bjs_User_getName")
-public func _bjs_User_getName(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_User_getName")
+@_cdecl("bjs_TestModule_User_getName")
+public func _bjs_TestModule_User_getName(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = User.bridgeJSLiftParameter(_self).getName()
+    let ret = TestModule.User.bridgeJSLiftParameter(_self).getName()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_User_deinit")
-@_cdecl("bjs_User_deinit")
-public func _bjs_User_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_User_deinit")
+@_cdecl("bjs_TestModule_User_deinit")
+public func _bjs_TestModule_User_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<User>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.User>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension User: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.User: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_User_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_User_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_User_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_User_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_User_wrap")
-fileprivate func _bjs_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_User_wrap")
+fileprivate func _bjs_TestModule_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_User_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_User_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_User_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_User_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_User_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Player_getTag")
-@_cdecl("bjs_Player_getTag")
-public func _bjs_Player_getTag(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Player_getTag")
+@_cdecl("bjs_TestModule_Player_getTag")
+public func _bjs_TestModule_Player_getTag(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Player.bridgeJSLiftParameter(_self).getTag()
+    let ret = TestModule.Player.bridgeJSLiftParameter(_self).getTag()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Player_deinit")
-@_cdecl("bjs_Player_deinit")
-public func _bjs_Player_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Player_deinit")
+@_cdecl("bjs_TestModule_Player_deinit")
+public func _bjs_TestModule_Player_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Player>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Player>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Player: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Player: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Player_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Player_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Player_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Player_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Player_wrap")
-fileprivate func _bjs_Player_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Player_wrap")
+fileprivate func _bjs_TestModule_Player_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Player_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Player_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Player_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Player_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Player_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Player_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Greeter_init",
+          "abiName" : "bjs_TestModule_Greeter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -31,7 +31,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Greeter_greet",
+            "abiName" : "bjs_TestModule_Greeter_greet",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -48,7 +48,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_changeName",
+            "abiName" : "bjs_TestModule_Greeter_changeName",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -96,11 +96,11 @@
             }
           }
         ],
-        "swiftCallName" : "Greeter"
+        "swiftCallName" : "TestModule.Greeter"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_OptionalPropertyHolder_init",
+          "abiName" : "bjs_TestModule_OptionalPropertyHolder_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -156,7 +156,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "TestModule.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -164,7 +164,7 @@
             }
           }
         ],
-        "swiftCallName" : "OptionalPropertyHolder"
+        "swiftCallName" : "TestModule.OptionalPropertyHolder"
       }
     ],
     "enums" : [
@@ -173,7 +173,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_roundTripOptionalClass",
+        "abiName" : "bjs_TestModule_roundTripOptionalClass",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -188,7 +188,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "TestModule.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -200,7 +200,7 @@
           "nullable" : {
             "_0" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "TestModule.Greeter"
               }
             },
             "_1" : "null"
@@ -208,7 +208,7 @@
         }
       },
       {
-        "abiName" : "bjs_testOptionalPropertyRoundtrip",
+        "abiName" : "bjs_TestModule_testOptionalPropertyRoundtrip",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -223,7 +223,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "OptionalPropertyHolder"
+                    "_0" : "TestModule.OptionalPropertyHolder"
                   }
                 },
                 "_1" : "null"
@@ -235,7 +235,7 @@
           "nullable" : {
             "_0" : {
               "swiftHeapObject" : {
-                "_0" : "OptionalPropertyHolder"
+                "_0" : "TestModule.OptionalPropertyHolder"
               }
             },
             "_1" : "null"
@@ -243,7 +243,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripExportedOptionalJSObject",
+        "abiName" : "bjs_TestModule_roundTripExportedOptionalJSObject",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -278,7 +278,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripExportedOptionalJSClass",
+        "abiName" : "bjs_TestModule_roundTripExportedOptionalJSClass",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -313,7 +313,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripString",
+        "abiName" : "bjs_TestModule_roundTripString",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -348,7 +348,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripInt",
+        "abiName" : "bjs_TestModule_roundTripInt",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -389,7 +389,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripInt8",
+        "abiName" : "bjs_TestModule_roundTripInt8",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -430,7 +430,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUInt8",
+        "abiName" : "bjs_TestModule_roundTripUInt8",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -471,7 +471,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripInt16",
+        "abiName" : "bjs_TestModule_roundTripInt16",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -512,7 +512,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUInt16",
+        "abiName" : "bjs_TestModule_roundTripUInt16",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -553,7 +553,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripInt32",
+        "abiName" : "bjs_TestModule_roundTripInt32",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -594,7 +594,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUInt32",
+        "abiName" : "bjs_TestModule_roundTripUInt32",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -635,7 +635,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripBool",
+        "abiName" : "bjs_TestModule_roundTripBool",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -670,7 +670,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripFloat",
+        "abiName" : "bjs_TestModule_roundTripFloat",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -705,7 +705,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripDouble",
+        "abiName" : "bjs_TestModule_roundTripDouble",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -740,7 +740,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripSyntax",
+        "abiName" : "bjs_TestModule_roundTripSyntax",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -775,7 +775,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripMixSyntax",
+        "abiName" : "bjs_TestModule_roundTripMixSyntax",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -810,7 +810,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripSwiftSyntax",
+        "abiName" : "bjs_TestModule_roundTripSwiftSyntax",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -845,7 +845,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripMixedSwiftSyntax",
+        "abiName" : "bjs_TestModule_roundTripMixedSwiftSyntax",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -880,7 +880,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripWithSpaces",
+        "abiName" : "bjs_TestModule_roundTripWithSpaces",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -915,7 +915,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripAlias",
+        "abiName" : "bjs_TestModule_roundTripAlias",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -956,7 +956,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalAlias",
+        "abiName" : "bjs_TestModule_roundTripOptionalAlias",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -991,7 +991,7 @@
         }
       },
       {
-        "abiName" : "bjs_testMixedOptionals",
+        "abiName" : "bjs_TestModule_testMixedOptionals",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Optionals.swift
@@ -1,28 +1,28 @@
-@_expose(wasm, "bjs_roundTripOptionalClass")
-@_cdecl("bjs_roundTripOptionalClass")
-public func _bjs_roundTripOptionalClass(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalClass")
+@_cdecl("bjs_TestModule_roundTripOptionalClass")
+public func _bjs_TestModule_roundTripOptionalClass(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalClass(value: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    let ret = roundTripOptionalClass(value: Optional<TestModule.Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_testOptionalPropertyRoundtrip")
-@_cdecl("bjs_testOptionalPropertyRoundtrip")
-public func _bjs_testOptionalPropertyRoundtrip(_ holderIsSome: Int32, _ holderValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_testOptionalPropertyRoundtrip")
+@_cdecl("bjs_TestModule_testOptionalPropertyRoundtrip")
+public func _bjs_TestModule_testOptionalPropertyRoundtrip(_ holderIsSome: Int32, _ holderValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = testOptionalPropertyRoundtrip(_: Optional<OptionalPropertyHolder>.bridgeJSLiftParameter(holderIsSome, holderValue))
+    let ret = testOptionalPropertyRoundtrip(_: Optional<TestModule.OptionalPropertyHolder>.bridgeJSLiftParameter(holderIsSome, holderValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripExportedOptionalJSObject")
-@_cdecl("bjs_roundTripExportedOptionalJSObject")
-public func _bjs_roundTripExportedOptionalJSObject(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripExportedOptionalJSObject")
+@_cdecl("bjs_TestModule_roundTripExportedOptionalJSObject")
+public func _bjs_TestModule_roundTripExportedOptionalJSObject(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripExportedOptionalJSObject(value: Optional<JSObject>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -31,9 +31,9 @@ public func _bjs_roundTripExportedOptionalJSObject(_ valueIsSome: Int32, _ value
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripExportedOptionalJSClass")
-@_cdecl("bjs_roundTripExportedOptionalJSClass")
-public func _bjs_roundTripExportedOptionalJSClass(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripExportedOptionalJSClass")
+@_cdecl("bjs_TestModule_roundTripExportedOptionalJSClass")
+public func _bjs_TestModule_roundTripExportedOptionalJSClass(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripExportedOptionalJSClass(value: Optional<WithOptionalJSClass>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -42,9 +42,9 @@ public func _bjs_roundTripExportedOptionalJSClass(_ valueIsSome: Int32, _ valueV
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripString")
-@_cdecl("bjs_roundTripString")
-public func _bjs_roundTripString(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripString")
+@_cdecl("bjs_TestModule_roundTripString")
+public func _bjs_TestModule_roundTripString(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripString(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -53,9 +53,9 @@ public func _bjs_roundTripString(_ nameIsSome: Int32, _ nameBytes: Int32, _ name
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripInt")
-@_cdecl("bjs_roundTripInt")
-public func _bjs_roundTripInt(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripInt")
+@_cdecl("bjs_TestModule_roundTripInt")
+public func _bjs_TestModule_roundTripInt(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripInt(value: Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -64,9 +64,9 @@ public func _bjs_roundTripInt(_ valueIsSome: Int32, _ valueValue: Int32) -> Void
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripInt8")
-@_cdecl("bjs_roundTripInt8")
-public func _bjs_roundTripInt8(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripInt8")
+@_cdecl("bjs_TestModule_roundTripInt8")
+public func _bjs_TestModule_roundTripInt8(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripInt8(value: Optional<Int8>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -75,9 +75,9 @@ public func _bjs_roundTripInt8(_ valueIsSome: Int32, _ valueValue: Int32) -> Voi
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUInt8")
-@_cdecl("bjs_roundTripUInt8")
-public func _bjs_roundTripUInt8(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripUInt8")
+@_cdecl("bjs_TestModule_roundTripUInt8")
+public func _bjs_TestModule_roundTripUInt8(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripUInt8(value: Optional<UInt8>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -86,9 +86,9 @@ public func _bjs_roundTripUInt8(_ valueIsSome: Int32, _ valueValue: Int32) -> Vo
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripInt16")
-@_cdecl("bjs_roundTripInt16")
-public func _bjs_roundTripInt16(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripInt16")
+@_cdecl("bjs_TestModule_roundTripInt16")
+public func _bjs_TestModule_roundTripInt16(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripInt16(value: Optional<Int16>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -97,9 +97,9 @@ public func _bjs_roundTripInt16(_ valueIsSome: Int32, _ valueValue: Int32) -> Vo
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUInt16")
-@_cdecl("bjs_roundTripUInt16")
-public func _bjs_roundTripUInt16(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripUInt16")
+@_cdecl("bjs_TestModule_roundTripUInt16")
+public func _bjs_TestModule_roundTripUInt16(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripUInt16(value: Optional<UInt16>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -108,9 +108,9 @@ public func _bjs_roundTripUInt16(_ valueIsSome: Int32, _ valueValue: Int32) -> V
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripInt32")
-@_cdecl("bjs_roundTripInt32")
-public func _bjs_roundTripInt32(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripInt32")
+@_cdecl("bjs_TestModule_roundTripInt32")
+public func _bjs_TestModule_roundTripInt32(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripInt32(value: Optional<Int32>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -119,9 +119,9 @@ public func _bjs_roundTripInt32(_ valueIsSome: Int32, _ valueValue: Int32) -> Vo
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUInt32")
-@_cdecl("bjs_roundTripUInt32")
-public func _bjs_roundTripUInt32(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripUInt32")
+@_cdecl("bjs_TestModule_roundTripUInt32")
+public func _bjs_TestModule_roundTripUInt32(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripUInt32(value: Optional<UInt32>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -130,9 +130,9 @@ public func _bjs_roundTripUInt32(_ valueIsSome: Int32, _ valueValue: Int32) -> V
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripBool")
-@_cdecl("bjs_roundTripBool")
-public func _bjs_roundTripBool(_ flagIsSome: Int32, _ flagValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripBool")
+@_cdecl("bjs_TestModule_roundTripBool")
+public func _bjs_TestModule_roundTripBool(_ flagIsSome: Int32, _ flagValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripBool(flag: Optional<Bool>.bridgeJSLiftParameter(flagIsSome, flagValue))
     return ret.bridgeJSLowerReturn()
@@ -141,9 +141,9 @@ public func _bjs_roundTripBool(_ flagIsSome: Int32, _ flagValue: Int32) -> Void 
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripFloat")
-@_cdecl("bjs_roundTripFloat")
-public func _bjs_roundTripFloat(_ numberIsSome: Int32, _ numberValue: Float32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripFloat")
+@_cdecl("bjs_TestModule_roundTripFloat")
+public func _bjs_TestModule_roundTripFloat(_ numberIsSome: Int32, _ numberValue: Float32) -> Void {
     #if arch(wasm32)
     let ret = roundTripFloat(number: Optional<Float>.bridgeJSLiftParameter(numberIsSome, numberValue))
     return ret.bridgeJSLowerReturn()
@@ -152,9 +152,9 @@ public func _bjs_roundTripFloat(_ numberIsSome: Int32, _ numberValue: Float32) -
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripDouble")
-@_cdecl("bjs_roundTripDouble")
-public func _bjs_roundTripDouble(_ precisionIsSome: Int32, _ precisionValue: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripDouble")
+@_cdecl("bjs_TestModule_roundTripDouble")
+public func _bjs_TestModule_roundTripDouble(_ precisionIsSome: Int32, _ precisionValue: Float64) -> Void {
     #if arch(wasm32)
     let ret = roundTripDouble(precision: Optional<Double>.bridgeJSLiftParameter(precisionIsSome, precisionValue))
     return ret.bridgeJSLowerReturn()
@@ -163,9 +163,9 @@ public func _bjs_roundTripDouble(_ precisionIsSome: Int32, _ precisionValue: Flo
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripSyntax")
-@_cdecl("bjs_roundTripSyntax")
-public func _bjs_roundTripSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripSyntax")
+@_cdecl("bjs_TestModule_roundTripSyntax")
+public func _bjs_TestModule_roundTripSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -174,9 +174,9 @@ public func _bjs_roundTripSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ name
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripMixSyntax")
-@_cdecl("bjs_roundTripMixSyntax")
-public func _bjs_roundTripMixSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripMixSyntax")
+@_cdecl("bjs_TestModule_roundTripMixSyntax")
+public func _bjs_TestModule_roundTripMixSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripMixSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -185,9 +185,9 @@ public func _bjs_roundTripMixSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ n
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripSwiftSyntax")
-@_cdecl("bjs_roundTripSwiftSyntax")
-public func _bjs_roundTripSwiftSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripSwiftSyntax")
+@_cdecl("bjs_TestModule_roundTripSwiftSyntax")
+public func _bjs_TestModule_roundTripSwiftSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripSwiftSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -196,9 +196,9 @@ public func _bjs_roundTripSwiftSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripMixedSwiftSyntax")
-@_cdecl("bjs_roundTripMixedSwiftSyntax")
-public func _bjs_roundTripMixedSwiftSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripMixedSwiftSyntax")
+@_cdecl("bjs_TestModule_roundTripMixedSwiftSyntax")
+public func _bjs_TestModule_roundTripMixedSwiftSyntax(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripMixedSwiftSyntax(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -207,9 +207,9 @@ public func _bjs_roundTripMixedSwiftSyntax(_ nameIsSome: Int32, _ nameBytes: Int
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripWithSpaces")
-@_cdecl("bjs_roundTripWithSpaces")
-public func _bjs_roundTripWithSpaces(_ valueIsSome: Int32, _ valueValue: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripWithSpaces")
+@_cdecl("bjs_TestModule_roundTripWithSpaces")
+public func _bjs_TestModule_roundTripWithSpaces(_ valueIsSome: Int32, _ valueValue: Float64) -> Void {
     #if arch(wasm32)
     let ret = roundTripWithSpaces(value: Optional<Double>.bridgeJSLiftParameter(valueIsSome, valueValue))
     return ret.bridgeJSLowerReturn()
@@ -218,9 +218,9 @@ public func _bjs_roundTripWithSpaces(_ valueIsSome: Int32, _ valueValue: Float64
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripAlias")
-@_cdecl("bjs_roundTripAlias")
-public func _bjs_roundTripAlias(_ ageIsSome: Int32, _ ageValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripAlias")
+@_cdecl("bjs_TestModule_roundTripAlias")
+public func _bjs_TestModule_roundTripAlias(_ ageIsSome: Int32, _ ageValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripAlias(age: Optional<Int>.bridgeJSLiftParameter(ageIsSome, ageValue))
     return ret.bridgeJSLowerReturn()
@@ -229,9 +229,9 @@ public func _bjs_roundTripAlias(_ ageIsSome: Int32, _ ageValue: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalAlias")
-@_cdecl("bjs_roundTripOptionalAlias")
-public func _bjs_roundTripOptionalAlias(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripOptionalAlias")
+@_cdecl("bjs_TestModule_roundTripOptionalAlias")
+public func _bjs_TestModule_roundTripOptionalAlias(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalAlias(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -240,9 +240,9 @@ public func _bjs_roundTripOptionalAlias(_ nameIsSome: Int32, _ nameBytes: Int32,
     #endif
 }
 
-@_expose(wasm, "bjs_testMixedOptionals")
-@_cdecl("bjs_testMixedOptionals")
-public func _bjs_testMixedOptionals(_ firstNameIsSome: Int32, _ firstNameBytes: Int32, _ firstNameLength: Int32, _ lastNameIsSome: Int32, _ lastNameBytes: Int32, _ lastNameLength: Int32, _ ageIsSome: Int32, _ ageValue: Int32, _ active: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_testMixedOptionals")
+@_cdecl("bjs_TestModule_testMixedOptionals")
+public func _bjs_TestModule_testMixedOptionals(_ firstNameIsSome: Int32, _ firstNameBytes: Int32, _ firstNameLength: Int32, _ lastNameIsSome: Int32, _ lastNameBytes: Int32, _ lastNameLength: Int32, _ ageIsSome: Int32, _ ageValue: Int32, _ active: Int32) -> Void {
     #if arch(wasm32)
     let ret = testMixedOptionals(firstName: Optional<String>.bridgeJSLiftParameter(firstNameIsSome, firstNameBytes, firstNameLength), lastName: Optional<String>.bridgeJSLiftParameter(lastNameIsSome, lastNameBytes, lastNameLength), age: Optional<Int>.bridgeJSLiftParameter(ageIsSome, ageValue), active: Bool.bridgeJSLiftParameter(active))
     return ret.bridgeJSLowerReturn()
@@ -251,193 +251,193 @@ public func _bjs_testMixedOptionals(_ firstNameIsSome: Int32, _ firstNameBytes: 
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_init")
-@_cdecl("bjs_Greeter_init")
-public func _bjs_Greeter_init(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Greeter_init")
+@_cdecl("bjs_TestModule_Greeter_init")
+public func _bjs_TestModule_Greeter_init(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
+    let ret = TestModule.Greeter(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greet")
-@_cdecl("bjs_Greeter_greet")
-public func _bjs_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_greet")
+@_cdecl("bjs_TestModule_Greeter_greet")
+public func _bjs_TestModule_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greet()
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_changeName")
-@_cdecl("bjs_Greeter_changeName")
-public func _bjs_Greeter_changeName(_ _self: UnsafeMutableRawPointer, _ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_changeName")
+@_cdecl("bjs_TestModule_Greeter_changeName")
+public func _bjs_TestModule_Greeter_changeName(_ _self: UnsafeMutableRawPointer, _ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
-    Greeter.bridgeJSLiftParameter(_self).changeName(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
+    TestModule.Greeter.bridgeJSLiftParameter(_self).changeName(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_get")
-@_cdecl("bjs_Greeter_name_get")
-public func _bjs_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_name_get")
+@_cdecl("bjs_TestModule_Greeter_name_get")
+public func _bjs_TestModule_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).name
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_set")
-@_cdecl("bjs_Greeter_name_set")
-public func _bjs_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_name_set")
+@_cdecl("bjs_TestModule_Greeter_name_set")
+public func _bjs_TestModule_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    Greeter.bridgeJSLiftParameter(_self).name = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    TestModule.Greeter.bridgeJSLiftParameter(_self).name = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_deinit")
-@_cdecl("bjs_Greeter_deinit")
-public func _bjs_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_deinit")
+@_cdecl("bjs_TestModule_Greeter_deinit")
+public func _bjs_TestModule_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Greeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Greeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Greeter_wrap")
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Greeter_wrap")
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Greeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Greeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_init")
-@_cdecl("bjs_OptionalPropertyHolder_init")
-public func _bjs_OptionalPropertyHolder_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_OptionalPropertyHolder_init")
+@_cdecl("bjs_TestModule_OptionalPropertyHolder_init")
+public func _bjs_TestModule_OptionalPropertyHolder_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = OptionalPropertyHolder()
+    let ret = TestModule.OptionalPropertyHolder()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalName_get")
-@_cdecl("bjs_OptionalPropertyHolder_optionalName_get")
-public func _bjs_OptionalPropertyHolder_optionalName_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_OptionalPropertyHolder_optionalName_get")
+@_cdecl("bjs_TestModule_OptionalPropertyHolder_optionalName_get")
+public func _bjs_TestModule_OptionalPropertyHolder_optionalName_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName
+    let ret = TestModule.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalName_set")
-@_cdecl("bjs_OptionalPropertyHolder_optionalName_set")
-public func _bjs_OptionalPropertyHolder_optionalName_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_OptionalPropertyHolder_optionalName_set")
+@_cdecl("bjs_TestModule_OptionalPropertyHolder_optionalName_set")
+public func _bjs_TestModule_OptionalPropertyHolder_optionalName_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    TestModule.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalAge_get")
-@_cdecl("bjs_OptionalPropertyHolder_optionalAge_get")
-public func _bjs_OptionalPropertyHolder_optionalAge_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_OptionalPropertyHolder_optionalAge_get")
+@_cdecl("bjs_TestModule_OptionalPropertyHolder_optionalAge_get")
+public func _bjs_TestModule_OptionalPropertyHolder_optionalAge_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge
+    let ret = TestModule.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalAge_set")
-@_cdecl("bjs_OptionalPropertyHolder_optionalAge_set")
-public func _bjs_OptionalPropertyHolder_optionalAge_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_OptionalPropertyHolder_optionalAge_set")
+@_cdecl("bjs_TestModule_OptionalPropertyHolder_optionalAge_set")
+public func _bjs_TestModule_OptionalPropertyHolder_optionalAge_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    TestModule.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_get")
-@_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_get")
-public func _bjs_OptionalPropertyHolder_optionalGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_OptionalPropertyHolder_optionalGreeter_get")
+@_cdecl("bjs_TestModule_OptionalPropertyHolder_optionalGreeter_get")
+public func _bjs_TestModule_OptionalPropertyHolder_optionalGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter
+    let ret = TestModule.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_set")
-@_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_set")
-public func _bjs_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_OptionalPropertyHolder_optionalGreeter_set")
+@_cdecl("bjs_TestModule_OptionalPropertyHolder_optionalGreeter_set")
+public func _bjs_TestModule_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    TestModule.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<TestModule.Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_deinit")
-@_cdecl("bjs_OptionalPropertyHolder_deinit")
-public func _bjs_OptionalPropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_OptionalPropertyHolder_deinit")
+@_cdecl("bjs_TestModule_OptionalPropertyHolder_deinit")
+public func _bjs_TestModule_OptionalPropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<OptionalPropertyHolder>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.OptionalPropertyHolder>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension OptionalPropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.OptionalPropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_OptionalPropertyHolder_wrap")
-fileprivate func _bjs_OptionalPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_OptionalPropertyHolder_wrap")
+fileprivate func _bjs_TestModule_OptionalPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_OptionalPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_OptionalPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_OptionalPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_OptionalPropertyHolder_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_OptionalPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_OptionalPropertyHolder_wrap_extern(pointer)
 }
 
 #if arch(wasm32)

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveParameters.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveParameters.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_check",
+        "abiName" : "bjs_TestModule_check",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveParameters.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveParameters.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_check")
-@_cdecl("bjs_check")
-public func _bjs_check(_ a: Int32, _ b: Int32, _ c: Float32, _ d: Float64, _ e: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_check")
+@_cdecl("bjs_TestModule_check")
+public func _bjs_TestModule_check(_ a: Int32, _ b: Int32, _ c: Float32, _ d: Float64, _ e: Int32) -> Void {
     #if arch(wasm32)
     check(a: Int.bridgeJSLiftParameter(a), b: UInt.bridgeJSLiftParameter(b), c: Float.bridgeJSLiftParameter(c), d: Double.bridgeJSLiftParameter(d), e: Bool.bridgeJSLiftParameter(e))
     #else

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveReturn.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_checkInt",
+        "abiName" : "bjs_TestModule_checkInt",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -32,7 +32,7 @@
         }
       },
       {
-        "abiName" : "bjs_checkUInt",
+        "abiName" : "bjs_TestModule_checkUInt",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -52,7 +52,7 @@
         }
       },
       {
-        "abiName" : "bjs_checkFloat",
+        "abiName" : "bjs_TestModule_checkFloat",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -69,7 +69,7 @@
         }
       },
       {
-        "abiName" : "bjs_checkDouble",
+        "abiName" : "bjs_TestModule_checkDouble",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -86,7 +86,7 @@
         }
       },
       {
-        "abiName" : "bjs_checkBool",
+        "abiName" : "bjs_TestModule_checkBool",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PrimitiveReturn.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_checkInt")
-@_cdecl("bjs_checkInt")
-public func _bjs_checkInt() -> Int32 {
+@_expose(wasm, "bjs_TestModule_checkInt")
+@_cdecl("bjs_TestModule_checkInt")
+public func _bjs_TestModule_checkInt() -> Int32 {
     #if arch(wasm32)
     let ret = checkInt()
     return ret.bridgeJSLowerReturn()
@@ -9,9 +9,9 @@ public func _bjs_checkInt() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_checkUInt")
-@_cdecl("bjs_checkUInt")
-public func _bjs_checkUInt() -> Int32 {
+@_expose(wasm, "bjs_TestModule_checkUInt")
+@_cdecl("bjs_TestModule_checkUInt")
+public func _bjs_TestModule_checkUInt() -> Int32 {
     #if arch(wasm32)
     let ret = checkUInt()
     return ret.bridgeJSLowerReturn()
@@ -20,9 +20,9 @@ public func _bjs_checkUInt() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_checkFloat")
-@_cdecl("bjs_checkFloat")
-public func _bjs_checkFloat() -> Float32 {
+@_expose(wasm, "bjs_TestModule_checkFloat")
+@_cdecl("bjs_TestModule_checkFloat")
+public func _bjs_TestModule_checkFloat() -> Float32 {
     #if arch(wasm32)
     let ret = checkFloat()
     return ret.bridgeJSLowerReturn()
@@ -31,9 +31,9 @@ public func _bjs_checkFloat() -> Float32 {
     #endif
 }
 
-@_expose(wasm, "bjs_checkDouble")
-@_cdecl("bjs_checkDouble")
-public func _bjs_checkDouble() -> Float64 {
+@_expose(wasm, "bjs_TestModule_checkDouble")
+@_cdecl("bjs_TestModule_checkDouble")
+public func _bjs_TestModule_checkDouble() -> Float64 {
     #if arch(wasm32)
     let ret = checkDouble()
     return ret.bridgeJSLowerReturn()
@@ -42,9 +42,9 @@ public func _bjs_checkDouble() -> Float64 {
     #endif
 }
 
-@_expose(wasm, "bjs_checkBool")
-@_cdecl("bjs_checkBool")
-public func _bjs_checkBool() -> Int32 {
+@_expose(wasm, "bjs_TestModule_checkBool")
+@_cdecl("bjs_TestModule_checkBool")
+public func _bjs_TestModule_checkBool() -> Int32 {
     #if arch(wasm32)
     let ret = checkBool()
     return ret.bridgeJSLowerReturn()

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PropertyTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PropertyTypes.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_PropertyHolder_init",
+          "abiName" : "bjs_TestModule_PropertyHolder_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -74,7 +74,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_PropertyHolder_getAllValues",
+            "abiName" : "bjs_TestModule_PropertyHolder_getAllValues",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -215,7 +215,7 @@
             "name" : "sibling",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "PropertyHolder"
+                "_0" : "TestModule.PropertyHolder"
               }
             }
           },
@@ -266,7 +266,7 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyHolder"
+        "swiftCallName" : "TestModule.PropertyHolder"
       }
     ],
     "enums" : [
@@ -275,7 +275,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_createPropertyHolder",
+        "abiName" : "bjs_TestModule_createPropertyHolder",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -343,12 +343,12 @@
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "PropertyHolder"
+            "_0" : "TestModule.PropertyHolder"
           }
         }
       },
       {
-        "abiName" : "bjs_testPropertyHolder",
+        "abiName" : "bjs_TestModule_testPropertyHolder",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -361,7 +361,7 @@
             "name" : "holder",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "PropertyHolder"
+                "_0" : "TestModule.PropertyHolder"
               }
             }
           }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PropertyTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/PropertyTypes.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_createPropertyHolder")
-@_cdecl("bjs_createPropertyHolder")
-public func _bjs_createPropertyHolder(_ intValue: Int32, _ floatValue: Float32, _ doubleValue: Float64, _ boolValue: Int32, _ stringValueBytes: Int32, _ stringValueLength: Int32, _ jsObject: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_createPropertyHolder")
+@_cdecl("bjs_TestModule_createPropertyHolder")
+public func _bjs_TestModule_createPropertyHolder(_ intValue: Int32, _ floatValue: Float32, _ doubleValue: Float64, _ boolValue: Int32, _ stringValueBytes: Int32, _ stringValueLength: Int32, _ jsObject: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = createPropertyHolder(intValue: Int.bridgeJSLiftParameter(intValue), floatValue: Float.bridgeJSLiftParameter(floatValue), doubleValue: Double.bridgeJSLiftParameter(doubleValue), boolValue: Bool.bridgeJSLiftParameter(boolValue), stringValue: String.bridgeJSLiftParameter(stringValueBytes, stringValueLength), jsObject: JSObject.bridgeJSLiftParameter(jsObject))
     return ret.bridgeJSLowerReturn()
@@ -9,342 +9,342 @@ public func _bjs_createPropertyHolder(_ intValue: Int32, _ floatValue: Float32, 
     #endif
 }
 
-@_expose(wasm, "bjs_testPropertyHolder")
-@_cdecl("bjs_testPropertyHolder")
-public func _bjs_testPropertyHolder(_ holder: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_testPropertyHolder")
+@_cdecl("bjs_TestModule_testPropertyHolder")
+public func _bjs_TestModule_testPropertyHolder(_ holder: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = testPropertyHolder(holder: PropertyHolder.bridgeJSLiftParameter(holder))
+    let ret = testPropertyHolder(holder: TestModule.PropertyHolder.bridgeJSLiftParameter(holder))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_init")
-@_cdecl("bjs_PropertyHolder_init")
-public func _bjs_PropertyHolder_init(_ intValue: Int32, _ floatValue: Float32, _ doubleValue: Float64, _ boolValue: Int32, _ stringValueBytes: Int32, _ stringValueLength: Int32, _ jsObject: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_init")
+@_cdecl("bjs_TestModule_PropertyHolder_init")
+public func _bjs_TestModule_PropertyHolder_init(_ intValue: Int32, _ floatValue: Float32, _ doubleValue: Float64, _ boolValue: Int32, _ stringValueBytes: Int32, _ stringValueLength: Int32, _ jsObject: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PropertyHolder(intValue: Int.bridgeJSLiftParameter(intValue), floatValue: Float.bridgeJSLiftParameter(floatValue), doubleValue: Double.bridgeJSLiftParameter(doubleValue), boolValue: Bool.bridgeJSLiftParameter(boolValue), stringValue: String.bridgeJSLiftParameter(stringValueBytes, stringValueLength), jsObject: JSObject.bridgeJSLiftParameter(jsObject))
+    let ret = TestModule.PropertyHolder(intValue: Int.bridgeJSLiftParameter(intValue), floatValue: Float.bridgeJSLiftParameter(floatValue), doubleValue: Double.bridgeJSLiftParameter(doubleValue), boolValue: Bool.bridgeJSLiftParameter(boolValue), stringValue: String.bridgeJSLiftParameter(stringValueBytes, stringValueLength), jsObject: JSObject.bridgeJSLiftParameter(jsObject))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_getAllValues")
-@_cdecl("bjs_PropertyHolder_getAllValues")
-public func _bjs_PropertyHolder_getAllValues(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_getAllValues")
+@_cdecl("bjs_TestModule_PropertyHolder_getAllValues")
+public func _bjs_TestModule_PropertyHolder_getAllValues(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).getAllValues()
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).getAllValues()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_intValue_get")
-@_cdecl("bjs_PropertyHolder_intValue_get")
-public func _bjs_PropertyHolder_intValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_intValue_get")
+@_cdecl("bjs_TestModule_PropertyHolder_intValue_get")
+public func _bjs_TestModule_PropertyHolder_intValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).intValue
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).intValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_intValue_set")
-@_cdecl("bjs_PropertyHolder_intValue_set")
-public func _bjs_PropertyHolder_intValue_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_intValue_set")
+@_cdecl("bjs_TestModule_PropertyHolder_intValue_set")
+public func _bjs_TestModule_PropertyHolder_intValue_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).intValue = Int.bridgeJSLiftParameter(value)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).intValue = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_floatValue_get")
-@_cdecl("bjs_PropertyHolder_floatValue_get")
-public func _bjs_PropertyHolder_floatValue_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_floatValue_get")
+@_cdecl("bjs_TestModule_PropertyHolder_floatValue_get")
+public func _bjs_TestModule_PropertyHolder_floatValue_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).floatValue
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).floatValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_floatValue_set")
-@_cdecl("bjs_PropertyHolder_floatValue_set")
-public func _bjs_PropertyHolder_floatValue_set(_ _self: UnsafeMutableRawPointer, _ value: Float32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_floatValue_set")
+@_cdecl("bjs_TestModule_PropertyHolder_floatValue_set")
+public func _bjs_TestModule_PropertyHolder_floatValue_set(_ _self: UnsafeMutableRawPointer, _ value: Float32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).floatValue = Float.bridgeJSLiftParameter(value)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).floatValue = Float.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_doubleValue_get")
-@_cdecl("bjs_PropertyHolder_doubleValue_get")
-public func _bjs_PropertyHolder_doubleValue_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_doubleValue_get")
+@_cdecl("bjs_TestModule_PropertyHolder_doubleValue_get")
+public func _bjs_TestModule_PropertyHolder_doubleValue_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).doubleValue
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).doubleValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_doubleValue_set")
-@_cdecl("bjs_PropertyHolder_doubleValue_set")
-public func _bjs_PropertyHolder_doubleValue_set(_ _self: UnsafeMutableRawPointer, _ value: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_doubleValue_set")
+@_cdecl("bjs_TestModule_PropertyHolder_doubleValue_set")
+public func _bjs_TestModule_PropertyHolder_doubleValue_set(_ _self: UnsafeMutableRawPointer, _ value: Float64) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).doubleValue = Double.bridgeJSLiftParameter(value)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).doubleValue = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_boolValue_get")
-@_cdecl("bjs_PropertyHolder_boolValue_get")
-public func _bjs_PropertyHolder_boolValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_boolValue_get")
+@_cdecl("bjs_TestModule_PropertyHolder_boolValue_get")
+public func _bjs_TestModule_PropertyHolder_boolValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).boolValue
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).boolValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_boolValue_set")
-@_cdecl("bjs_PropertyHolder_boolValue_set")
-public func _bjs_PropertyHolder_boolValue_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_boolValue_set")
+@_cdecl("bjs_TestModule_PropertyHolder_boolValue_set")
+public func _bjs_TestModule_PropertyHolder_boolValue_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).boolValue = Bool.bridgeJSLiftParameter(value)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).boolValue = Bool.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_stringValue_get")
-@_cdecl("bjs_PropertyHolder_stringValue_get")
-public func _bjs_PropertyHolder_stringValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_stringValue_get")
+@_cdecl("bjs_TestModule_PropertyHolder_stringValue_get")
+public func _bjs_TestModule_PropertyHolder_stringValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).stringValue
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).stringValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_stringValue_set")
-@_cdecl("bjs_PropertyHolder_stringValue_set")
-public func _bjs_PropertyHolder_stringValue_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_stringValue_set")
+@_cdecl("bjs_TestModule_PropertyHolder_stringValue_set")
+public func _bjs_TestModule_PropertyHolder_stringValue_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).stringValue = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).stringValue = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyInt_get")
-@_cdecl("bjs_PropertyHolder_readonlyInt_get")
-public func _bjs_PropertyHolder_readonlyInt_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_readonlyInt_get")
+@_cdecl("bjs_TestModule_PropertyHolder_readonlyInt_get")
+public func _bjs_TestModule_PropertyHolder_readonlyInt_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyInt
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).readonlyInt
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyFloat_get")
-@_cdecl("bjs_PropertyHolder_readonlyFloat_get")
-public func _bjs_PropertyHolder_readonlyFloat_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_readonlyFloat_get")
+@_cdecl("bjs_TestModule_PropertyHolder_readonlyFloat_get")
+public func _bjs_TestModule_PropertyHolder_readonlyFloat_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyFloat
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).readonlyFloat
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyDouble_get")
-@_cdecl("bjs_PropertyHolder_readonlyDouble_get")
-public func _bjs_PropertyHolder_readonlyDouble_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_readonlyDouble_get")
+@_cdecl("bjs_TestModule_PropertyHolder_readonlyDouble_get")
+public func _bjs_TestModule_PropertyHolder_readonlyDouble_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyDouble
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).readonlyDouble
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyBool_get")
-@_cdecl("bjs_PropertyHolder_readonlyBool_get")
-public func _bjs_PropertyHolder_readonlyBool_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_readonlyBool_get")
+@_cdecl("bjs_TestModule_PropertyHolder_readonlyBool_get")
+public func _bjs_TestModule_PropertyHolder_readonlyBool_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyBool
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).readonlyBool
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyString_get")
-@_cdecl("bjs_PropertyHolder_readonlyString_get")
-public func _bjs_PropertyHolder_readonlyString_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_readonlyString_get")
+@_cdecl("bjs_TestModule_PropertyHolder_readonlyString_get")
+public func _bjs_TestModule_PropertyHolder_readonlyString_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyString
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).readonlyString
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_jsObject_get")
-@_cdecl("bjs_PropertyHolder_jsObject_get")
-public func _bjs_PropertyHolder_jsObject_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_jsObject_get")
+@_cdecl("bjs_TestModule_PropertyHolder_jsObject_get")
+public func _bjs_TestModule_PropertyHolder_jsObject_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).jsObject
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).jsObject
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_jsObject_set")
-@_cdecl("bjs_PropertyHolder_jsObject_set")
-public func _bjs_PropertyHolder_jsObject_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_jsObject_set")
+@_cdecl("bjs_TestModule_PropertyHolder_jsObject_set")
+public func _bjs_TestModule_PropertyHolder_jsObject_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).jsObject = JSObject.bridgeJSLiftParameter(value)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).jsObject = JSObject.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_sibling_get")
-@_cdecl("bjs_PropertyHolder_sibling_get")
-public func _bjs_PropertyHolder_sibling_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_sibling_get")
+@_cdecl("bjs_TestModule_PropertyHolder_sibling_get")
+public func _bjs_TestModule_PropertyHolder_sibling_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).sibling
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).sibling
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_sibling_set")
-@_cdecl("bjs_PropertyHolder_sibling_set")
-public func _bjs_PropertyHolder_sibling_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_sibling_set")
+@_cdecl("bjs_TestModule_PropertyHolder_sibling_set")
+public func _bjs_TestModule_PropertyHolder_sibling_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).sibling = PropertyHolder.bridgeJSLiftParameter(value)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).sibling = TestModule.PropertyHolder.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_lazyValue_get")
-@_cdecl("bjs_PropertyHolder_lazyValue_get")
-public func _bjs_PropertyHolder_lazyValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_lazyValue_get")
+@_cdecl("bjs_TestModule_PropertyHolder_lazyValue_get")
+public func _bjs_TestModule_PropertyHolder_lazyValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).lazyValue
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).lazyValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_lazyValue_set")
-@_cdecl("bjs_PropertyHolder_lazyValue_set")
-public func _bjs_PropertyHolder_lazyValue_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_lazyValue_set")
+@_cdecl("bjs_TestModule_PropertyHolder_lazyValue_set")
+public func _bjs_TestModule_PropertyHolder_lazyValue_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).lazyValue = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).lazyValue = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_computedReadonly_get")
-@_cdecl("bjs_PropertyHolder_computedReadonly_get")
-public func _bjs_PropertyHolder_computedReadonly_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_computedReadonly_get")
+@_cdecl("bjs_TestModule_PropertyHolder_computedReadonly_get")
+public func _bjs_TestModule_PropertyHolder_computedReadonly_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).computedReadonly
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).computedReadonly
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_computedReadWrite_get")
-@_cdecl("bjs_PropertyHolder_computedReadWrite_get")
-public func _bjs_PropertyHolder_computedReadWrite_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_computedReadWrite_get")
+@_cdecl("bjs_TestModule_PropertyHolder_computedReadWrite_get")
+public func _bjs_TestModule_PropertyHolder_computedReadWrite_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).computedReadWrite
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).computedReadWrite
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_computedReadWrite_set")
-@_cdecl("bjs_PropertyHolder_computedReadWrite_set")
-public func _bjs_PropertyHolder_computedReadWrite_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_computedReadWrite_set")
+@_cdecl("bjs_TestModule_PropertyHolder_computedReadWrite_set")
+public func _bjs_TestModule_PropertyHolder_computedReadWrite_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).computedReadWrite = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).computedReadWrite = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_observedProperty_get")
-@_cdecl("bjs_PropertyHolder_observedProperty_get")
-public func _bjs_PropertyHolder_observedProperty_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_observedProperty_get")
+@_cdecl("bjs_TestModule_PropertyHolder_observedProperty_get")
+public func _bjs_TestModule_PropertyHolder_observedProperty_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).observedProperty
+    let ret = TestModule.PropertyHolder.bridgeJSLiftParameter(_self).observedProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_observedProperty_set")
-@_cdecl("bjs_PropertyHolder_observedProperty_set")
-public func _bjs_PropertyHolder_observedProperty_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_observedProperty_set")
+@_cdecl("bjs_TestModule_PropertyHolder_observedProperty_set")
+public func _bjs_TestModule_PropertyHolder_observedProperty_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).observedProperty = Int.bridgeJSLiftParameter(value)
+    TestModule.PropertyHolder.bridgeJSLiftParameter(_self).observedProperty = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_deinit")
-@_cdecl("bjs_PropertyHolder_deinit")
-public func _bjs_PropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyHolder_deinit")
+@_cdecl("bjs_TestModule_PropertyHolder_deinit")
+public func _bjs_TestModule_PropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PropertyHolder>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.PropertyHolder>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.PropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_PropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_PropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_PropertyHolder_wrap")
-fileprivate func _bjs_PropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_PropertyHolder_wrap")
+fileprivate func _bjs_TestModule_PropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_PropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PropertyHolder_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_PropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_PropertyHolder_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Helper_init",
+          "abiName" : "bjs_TestModule_Helper_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -29,7 +29,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Helper_increment",
+            "abiName" : "bjs_TestModule_Helper_increment",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -62,11 +62,11 @@
             }
           }
         ],
-        "swiftCallName" : "Helper"
+        "swiftCallName" : "TestModule.Helper"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_MyViewController_init",
+          "abiName" : "bjs_TestModule_MyViewController_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -78,7 +78,7 @@
               "name" : "delegate",
               "type" : {
                 "swiftProtocol" : {
-                  "_0" : "MyViewControllerDelegate"
+                  "_0" : "TestModule.MyViewControllerDelegate"
                 }
               }
             }
@@ -86,7 +86,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_MyViewController_triggerEvent",
+            "abiName" : "bjs_TestModule_MyViewController_triggerEvent",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -103,7 +103,7 @@
             }
           },
           {
-            "abiName" : "bjs_MyViewController_updateValue",
+            "abiName" : "bjs_TestModule_MyViewController_updateValue",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -128,7 +128,7 @@
             }
           },
           {
-            "abiName" : "bjs_MyViewController_updateCount",
+            "abiName" : "bjs_TestModule_MyViewController_updateCount",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -156,7 +156,7 @@
             }
           },
           {
-            "abiName" : "bjs_MyViewController_updateLabel",
+            "abiName" : "bjs_TestModule_MyViewController_updateLabel",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -190,7 +190,7 @@
             }
           },
           {
-            "abiName" : "bjs_MyViewController_checkEvenCount",
+            "abiName" : "bjs_TestModule_MyViewController_checkEvenCount",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -207,7 +207,7 @@
             }
           },
           {
-            "abiName" : "bjs_MyViewController_sendHelper",
+            "abiName" : "bjs_TestModule_MyViewController_sendHelper",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -220,7 +220,7 @@
                 "name" : "helper",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Helper"
+                    "_0" : "TestModule.Helper"
                   }
                 }
               }
@@ -240,7 +240,7 @@
             "name" : "delegate",
             "type" : {
               "swiftProtocol" : {
-                "_0" : "MyViewControllerDelegate"
+                "_0" : "TestModule.MyViewControllerDelegate"
               }
             }
           },
@@ -252,7 +252,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "MyViewControllerDelegate"
+                    "_0" : "TestModule.MyViewControllerDelegate"
                   }
                 },
                 "_1" : "null"
@@ -260,11 +260,11 @@
             }
           }
         ],
-        "swiftCallName" : "MyViewController"
+        "swiftCallName" : "TestModule.MyViewController"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_DelegateManager_init",
+          "abiName" : "bjs_TestModule_DelegateManager_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -278,7 +278,7 @@
                 "array" : {
                   "_0" : {
                     "swiftProtocol" : {
-                      "_0" : "MyViewControllerDelegate"
+                      "_0" : "TestModule.MyViewControllerDelegate"
                     }
                   }
                 }
@@ -288,7 +288,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_DelegateManager_notifyAll",
+            "abiName" : "bjs_TestModule_DelegateManager_notifyAll",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -315,7 +315,7 @@
               "array" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "MyViewControllerDelegate"
+                    "_0" : "TestModule.MyViewControllerDelegate"
                   }
                 }
               }
@@ -329,14 +329,14 @@
               "dictionary" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "MyViewControllerDelegate"
+                    "_0" : "TestModule.MyViewControllerDelegate"
                   }
                 }
               }
             }
           }
         ],
-        "swiftCallName" : "DelegateManager"
+        "swiftCallName" : "TestModule.DelegateManager"
       }
     ],
     "enums" : [
@@ -375,7 +375,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Direction",
+        "swiftCallName" : "TestModule.Direction",
         "tsFullPath" : "Direction"
       },
       {
@@ -404,7 +404,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "ExampleEnum",
+        "swiftCallName" : "TestModule.ExampleEnum",
         "tsFullPath" : "ExampleEnum"
       },
       {
@@ -445,7 +445,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Result",
+        "swiftCallName" : "TestModule.Result",
         "tsFullPath" : "Result"
       },
       {
@@ -481,14 +481,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Priority",
+        "swiftCallName" : "TestModule.Priority",
         "tsFullPath" : "Priority"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_processDelegates",
+        "abiName" : "bjs_TestModule_processDelegates",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -503,7 +503,7 @@
               "array" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "MyViewControllerDelegate"
+                    "_0" : "TestModule.MyViewControllerDelegate"
                   }
                 }
               }
@@ -514,14 +514,14 @@
           "array" : {
             "_0" : {
               "swiftProtocol" : {
-                "_0" : "MyViewControllerDelegate"
+                "_0" : "TestModule.MyViewControllerDelegate"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_processDelegatesByName",
+        "abiName" : "bjs_TestModule_processDelegatesByName",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -536,7 +536,7 @@
               "dictionary" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "MyViewControllerDelegate"
+                    "_0" : "TestModule.MyViewControllerDelegate"
                   }
                 }
               }
@@ -547,7 +547,7 @@
           "dictionary" : {
             "_0" : {
               "swiftProtocol" : {
-                "_0" : "MyViewControllerDelegate"
+                "_0" : "TestModule.MyViewControllerDelegate"
               }
             }
           }
@@ -692,7 +692,7 @@
                 "name" : "helper",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Helper"
+                    "_0" : "TestModule.Helper"
                   }
                 }
               }
@@ -716,7 +716,7 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "Helper"
+                "_0" : "TestModule.Helper"
               }
             }
           },
@@ -736,7 +736,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Helper"
+                        "_0" : "TestModule.Helper"
                       }
                     },
                     "_1" : "null"
@@ -765,7 +765,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Helper"
+                    "_0" : "TestModule.Helper"
                   }
                 },
                 "_1" : "null"
@@ -785,7 +785,7 @@
             ],
             "returnType" : {
               "rawValueEnum" : {
-                "_0" : "ExampleEnum",
+                "_0" : "TestModule.ExampleEnum",
                 "_1" : "String"
               }
             }
@@ -804,7 +804,7 @@
                 "name" : "result",
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "Result"
+                    "_0" : "TestModule.Result"
                   }
                 }
               }
@@ -828,7 +828,7 @@
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "Result"
+                "_0" : "TestModule.Result"
               }
             }
           }
@@ -877,7 +877,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "ExampleEnum",
+                    "_0" : "TestModule.ExampleEnum",
                     "_1" : "String"
                   }
                 },
@@ -890,7 +890,7 @@
             "name" : "rawStringEnum",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "ExampleEnum",
+                "_0" : "TestModule.ExampleEnum",
                 "_1" : "String"
               }
             }
@@ -900,7 +900,7 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "Result"
+                "_0" : "TestModule.Result"
               }
             }
           },
@@ -911,7 +911,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "Result"
+                    "_0" : "TestModule.Result"
                   }
                 },
                 "_1" : "null"
@@ -923,7 +923,7 @@
             "name" : "direction",
             "type" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "TestModule.Direction"
               }
             }
           },
@@ -934,7 +934,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "TestModule.Direction"
                   }
                 },
                 "_1" : "null"
@@ -946,7 +946,7 @@
             "name" : "priority",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Priority",
+                "_0" : "TestModule.Priority",
                 "_1" : "Int"
               }
             }
@@ -958,7 +958,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Priority",
+                    "_0" : "TestModule.Priority",
                     "_1" : "Int"
                   }
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Protocol.swift
@@ -35,46 +35,46 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         return Bool.bridgeJSLiftReturn(ret)
     }
 
-    func onHelperUpdated(_ helper: Helper) -> Void {
+    func onHelperUpdated(_ helper: TestModule.Helper) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let helperPointer = helper.bridgeJSLowerParameter()
         _extern_onHelperUpdated(jsObjectValue, helperPointer)
     }
 
-    func createHelper() -> Helper {
+    func createHelper() -> TestModule.Helper {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createHelper(jsObjectValue)
-        return Helper.bridgeJSLiftReturn(ret)
+        return TestModule.Helper.bridgeJSLiftReturn(ret)
     }
 
-    func onOptionalHelperUpdated(_ helper: Optional<Helper>) -> Void {
+    func onOptionalHelperUpdated(_ helper: Optional<TestModule.Helper>) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let (helperIsSome, helperPointer) = helper.bridgeJSLowerParameter()
         _extern_onOptionalHelperUpdated(jsObjectValue, helperIsSome, helperPointer)
     }
 
-    func createOptionalHelper() -> Optional<Helper> {
+    func createOptionalHelper() -> Optional<TestModule.Helper> {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createOptionalHelper(jsObjectValue)
-        return Optional<Helper>.bridgeJSLiftReturn(ret)
+        return Optional<TestModule.Helper>.bridgeJSLiftReturn(ret)
     }
 
-    func createEnum() -> ExampleEnum {
+    func createEnum() -> TestModule.ExampleEnum {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createEnum(jsObjectValue)
-        return ExampleEnum.bridgeJSLiftReturn(ret)
+        return TestModule.ExampleEnum.bridgeJSLiftReturn(ret)
     }
 
-    func handleResult(_ result: Result) -> Void {
+    func handleResult(_ result: TestModule.Result) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let resultCaseId = result.bridgeJSLowerParameter()
         _extern_handleResult(jsObjectValue, resultCaseId)
     }
 
-    func getResult() -> Result {
+    func getResult() -> TestModule.Result {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_getResult(jsObjectValue)
-        return Result.bridgeJSLiftReturn(ret)
+        return TestModule.Result.bridgeJSLiftReturn(ret)
     }
 
     var eventCount: Int {
@@ -112,11 +112,11 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         }
     }
 
-    var optionalRawEnum: Optional<ExampleEnum> {
+    var optionalRawEnum: Optional<TestModule.ExampleEnum> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_optionalRawEnum_get(jsObjectValue)
-            return Optional<ExampleEnum>.bridgeJSLiftReturnFromSideChannel()
+            return Optional<TestModule.ExampleEnum>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -126,11 +126,11 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         }
     }
 
-    var rawStringEnum: ExampleEnum {
+    var rawStringEnum: TestModule.ExampleEnum {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_rawStringEnum_get(jsObjectValue)
-            return ExampleEnum.bridgeJSLiftReturn(ret)
+            return TestModule.ExampleEnum.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -140,11 +140,11 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         }
     }
 
-    var result: Result {
+    var result: TestModule.Result {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_result_get(jsObjectValue)
-            return Result.bridgeJSLiftReturn(ret)
+            return TestModule.Result.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -153,11 +153,11 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         }
     }
 
-    var optionalResult: Optional<Result> {
+    var optionalResult: Optional<TestModule.Result> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_optionalResult_get(jsObjectValue)
-            return Optional<Result>.bridgeJSLiftReturn(ret)
+            return Optional<TestModule.Result>.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -166,11 +166,11 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         }
     }
 
-    var direction: Direction {
+    var direction: TestModule.Direction {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_direction_get(jsObjectValue)
-            return Direction.bridgeJSLiftReturn(ret)
+            return TestModule.Direction.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -179,11 +179,11 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         }
     }
 
-    var directionOptional: Optional<Direction> {
+    var directionOptional: Optional<TestModule.Direction> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_directionOptional_get(jsObjectValue)
-            return Optional<Direction>.bridgeJSLiftReturn(ret)
+            return Optional<TestModule.Direction>.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -192,11 +192,11 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         }
     }
 
-    var priority: Priority {
+    var priority: TestModule.Priority {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_MyViewControllerDelegate_priority_get(jsObjectValue)
-            return Priority.bridgeJSLiftReturn(ret)
+            return TestModule.Priority.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -205,11 +205,11 @@ struct AnyMyViewControllerDelegate: MyViewControllerDelegate, _BridgedSwiftProto
         }
     }
 
-    var priorityOptional: Optional<Priority> {
+    var priorityOptional: Optional<TestModule.Priority> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_MyViewControllerDelegate_priorityOptional_get(jsObjectValue)
-            return Optional<Priority>.bridgeJSLiftReturnFromSideChannel()
+            return Optional<TestModule.Priority>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -619,15 +619,15 @@ fileprivate func bjs_MyViewControllerDelegate_priorityOptional_set_extern(_ jsOb
     return bjs_MyViewControllerDelegate_priorityOptional_set_extern(jsObject, newValueIsSome, newValueValue)
 }
 
-extension Direction: _BridgedSwiftCaseEnum {
+extension TestModule.Direction: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Direction {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Direction {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Direction {
-        return Direction(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Direction {
+        return TestModule.Direction(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -662,18 +662,18 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
-extension ExampleEnum: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.ExampleEnum: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Result: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Result {
+extension TestModule.Result: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.Result {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
         case 1:
             return .failure(Int.bridgeJSStackPop())
         default:
-            fatalError("Unknown Result case ID: \(caseId)")
+            fatalError("Unknown TestModule.Result case ID: \(caseId)")
         }
     }
 
@@ -689,12 +689,12 @@ extension Result: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension Priority: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Priority: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-@_expose(wasm, "bjs_processDelegates")
-@_cdecl("bjs_processDelegates")
-public func _bjs_processDelegates() -> Void {
+@_expose(wasm, "bjs_TestModule_processDelegates")
+@_cdecl("bjs_TestModule_processDelegates")
+public func _bjs_TestModule_processDelegates() -> Void {
     #if arch(wasm32)
     let ret = processDelegates(_: [AnyMyViewControllerDelegate].bridgeJSStackPop())
     for __bjs_elem_ret in ret {
@@ -706,9 +706,9 @@ public func _bjs_processDelegates() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_processDelegatesByName")
-@_cdecl("bjs_processDelegatesByName")
-public func _bjs_processDelegatesByName() -> Void {
+@_expose(wasm, "bjs_TestModule_processDelegatesByName")
+@_cdecl("bjs_TestModule_processDelegatesByName")
+public func _bjs_TestModule_processDelegatesByName() -> Void {
     #if arch(wasm32)
     let ret = processDelegatesByName(_: [String: AnyMyViewControllerDelegate].bridgeJSLiftParameter())
     for __bjs_kv_ret in ret {
@@ -721,178 +721,178 @@ public func _bjs_processDelegatesByName() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_Helper_init")
-@_cdecl("bjs_Helper_init")
-public func _bjs_Helper_init(_ value: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Helper_init")
+@_cdecl("bjs_TestModule_Helper_init")
+public func _bjs_TestModule_Helper_init(_ value: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Helper(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Helper(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Helper_increment")
-@_cdecl("bjs_Helper_increment")
-public func _bjs_Helper_increment(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Helper_increment")
+@_cdecl("bjs_TestModule_Helper_increment")
+public func _bjs_TestModule_Helper_increment(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Helper.bridgeJSLiftParameter(_self).increment()
+    TestModule.Helper.bridgeJSLiftParameter(_self).increment()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Helper_value_get")
-@_cdecl("bjs_Helper_value_get")
-public func _bjs_Helper_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_Helper_value_get")
+@_cdecl("bjs_TestModule_Helper_value_get")
+public func _bjs_TestModule_Helper_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = Helper.bridgeJSLiftParameter(_self).value
+    let ret = TestModule.Helper.bridgeJSLiftParameter(_self).value
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Helper_value_set")
-@_cdecl("bjs_Helper_value_set")
-public func _bjs_Helper_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Helper_value_set")
+@_cdecl("bjs_TestModule_Helper_value_set")
+public func _bjs_TestModule_Helper_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    Helper.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
+    TestModule.Helper.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Helper_deinit")
-@_cdecl("bjs_Helper_deinit")
-public func _bjs_Helper_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Helper_deinit")
+@_cdecl("bjs_TestModule_Helper_deinit")
+public func _bjs_TestModule_Helper_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Helper>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Helper>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Helper: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Helper: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Helper_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Helper_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Helper_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Helper_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Helper_wrap")
-fileprivate func _bjs_Helper_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Helper_wrap")
+fileprivate func _bjs_TestModule_Helper_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Helper_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Helper_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Helper_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Helper_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Helper_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Helper_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_MyViewController_init")
-@_cdecl("bjs_MyViewController_init")
-public func _bjs_MyViewController_init(_ delegate: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_MyViewController_init")
+@_cdecl("bjs_TestModule_MyViewController_init")
+public func _bjs_TestModule_MyViewController_init(_ delegate: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = MyViewController(delegate: AnyMyViewControllerDelegate.bridgeJSLiftParameter(delegate))
+    let ret = TestModule.MyViewController(delegate: AnyMyViewControllerDelegate.bridgeJSLiftParameter(delegate))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_triggerEvent")
-@_cdecl("bjs_MyViewController_triggerEvent")
-public func _bjs_MyViewController_triggerEvent(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_MyViewController_triggerEvent")
+@_cdecl("bjs_TestModule_MyViewController_triggerEvent")
+public func _bjs_TestModule_MyViewController_triggerEvent(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    MyViewController.bridgeJSLiftParameter(_self).triggerEvent()
+    TestModule.MyViewController.bridgeJSLiftParameter(_self).triggerEvent()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_updateValue")
-@_cdecl("bjs_MyViewController_updateValue")
-public func _bjs_MyViewController_updateValue(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_MyViewController_updateValue")
+@_cdecl("bjs_TestModule_MyViewController_updateValue")
+public func _bjs_TestModule_MyViewController_updateValue(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    MyViewController.bridgeJSLiftParameter(_self).updateValue(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    TestModule.MyViewController.bridgeJSLiftParameter(_self).updateValue(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_updateCount")
-@_cdecl("bjs_MyViewController_updateCount")
-public func _bjs_MyViewController_updateCount(_ _self: UnsafeMutableRawPointer, _ count: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MyViewController_updateCount")
+@_cdecl("bjs_TestModule_MyViewController_updateCount")
+public func _bjs_TestModule_MyViewController_updateCount(_ _self: UnsafeMutableRawPointer, _ count: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MyViewController.bridgeJSLiftParameter(_self).updateCount(_: Int.bridgeJSLiftParameter(count))
+    let ret = TestModule.MyViewController.bridgeJSLiftParameter(_self).updateCount(_: Int.bridgeJSLiftParameter(count))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_updateLabel")
-@_cdecl("bjs_MyViewController_updateLabel")
-public func _bjs_MyViewController_updateLabel(_ _self: UnsafeMutableRawPointer, _ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_MyViewController_updateLabel")
+@_cdecl("bjs_TestModule_MyViewController_updateLabel")
+public func _bjs_TestModule_MyViewController_updateLabel(_ _self: UnsafeMutableRawPointer, _ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
     #if arch(wasm32)
-    MyViewController.bridgeJSLiftParameter(_self).updateLabel(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength), _: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    TestModule.MyViewController.bridgeJSLiftParameter(_self).updateLabel(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength), _: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_checkEvenCount")
-@_cdecl("bjs_MyViewController_checkEvenCount")
-public func _bjs_MyViewController_checkEvenCount(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MyViewController_checkEvenCount")
+@_cdecl("bjs_TestModule_MyViewController_checkEvenCount")
+public func _bjs_TestModule_MyViewController_checkEvenCount(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = MyViewController.bridgeJSLiftParameter(_self).checkEvenCount()
+    let ret = TestModule.MyViewController.bridgeJSLiftParameter(_self).checkEvenCount()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_sendHelper")
-@_cdecl("bjs_MyViewController_sendHelper")
-public func _bjs_MyViewController_sendHelper(_ _self: UnsafeMutableRawPointer, _ helper: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_MyViewController_sendHelper")
+@_cdecl("bjs_TestModule_MyViewController_sendHelper")
+public func _bjs_TestModule_MyViewController_sendHelper(_ _self: UnsafeMutableRawPointer, _ helper: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    MyViewController.bridgeJSLiftParameter(_self).sendHelper(_: Helper.bridgeJSLiftParameter(helper))
+    TestModule.MyViewController.bridgeJSLiftParameter(_self).sendHelper(_: TestModule.Helper.bridgeJSLiftParameter(helper))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_delegate_get")
-@_cdecl("bjs_MyViewController_delegate_get")
-public func _bjs_MyViewController_delegate_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MyViewController_delegate_get")
+@_cdecl("bjs_TestModule_MyViewController_delegate_get")
+public func _bjs_TestModule_MyViewController_delegate_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = MyViewController.bridgeJSLiftParameter(_self).delegate as! _BridgedSwiftProtocolExportable
+    let ret = TestModule.MyViewController.bridgeJSLiftParameter(_self).delegate as! _BridgedSwiftProtocolExportable
     return ret.bridgeJSLowerAsProtocolReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_delegate_set")
-@_cdecl("bjs_MyViewController_delegate_set")
-public func _bjs_MyViewController_delegate_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_MyViewController_delegate_set")
+@_cdecl("bjs_TestModule_MyViewController_delegate_set")
+public func _bjs_TestModule_MyViewController_delegate_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    MyViewController.bridgeJSLiftParameter(_self).delegate = AnyMyViewControllerDelegate.bridgeJSLiftParameter(value)
+    TestModule.MyViewController.bridgeJSLiftParameter(_self).delegate = AnyMyViewControllerDelegate.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_secondDelegate_get")
-@_cdecl("bjs_MyViewController_secondDelegate_get")
-public func _bjs_MyViewController_secondDelegate_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_MyViewController_secondDelegate_get")
+@_cdecl("bjs_TestModule_MyViewController_secondDelegate_get")
+public func _bjs_TestModule_MyViewController_secondDelegate_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = MyViewController.bridgeJSLiftParameter(_self).secondDelegate
+    let ret = TestModule.MyViewController.bridgeJSLiftParameter(_self).secondDelegate
     if let ret {
         _swift_js_return_optional_object(1, (ret as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
     } else {
@@ -903,73 +903,73 @@ public func _bjs_MyViewController_secondDelegate_get(_ _self: UnsafeMutableRawPo
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_secondDelegate_set")
-@_cdecl("bjs_MyViewController_secondDelegate_set")
-public func _bjs_MyViewController_secondDelegate_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_MyViewController_secondDelegate_set")
+@_cdecl("bjs_TestModule_MyViewController_secondDelegate_set")
+public func _bjs_TestModule_MyViewController_secondDelegate_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
-    MyViewController.bridgeJSLiftParameter(_self).secondDelegate = Optional<AnyMyViewControllerDelegate>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    TestModule.MyViewController.bridgeJSLiftParameter(_self).secondDelegate = Optional<AnyMyViewControllerDelegate>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MyViewController_deinit")
-@_cdecl("bjs_MyViewController_deinit")
-public func _bjs_MyViewController_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_MyViewController_deinit")
+@_cdecl("bjs_TestModule_MyViewController_deinit")
+public func _bjs_TestModule_MyViewController_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<MyViewController>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.MyViewController>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension MyViewController: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.MyViewController: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_MyViewController_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_MyViewController_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_MyViewController_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_MyViewController_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_MyViewController_wrap")
-fileprivate func _bjs_MyViewController_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_MyViewController_wrap")
+fileprivate func _bjs_TestModule_MyViewController_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_MyViewController_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_MyViewController_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_MyViewController_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_MyViewController_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_MyViewController_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_MyViewController_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_DelegateManager_init")
-@_cdecl("bjs_DelegateManager_init")
-public func _bjs_DelegateManager_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_DelegateManager_init")
+@_cdecl("bjs_TestModule_DelegateManager_init")
+public func _bjs_TestModule_DelegateManager_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = DelegateManager(delegates: [AnyMyViewControllerDelegate].bridgeJSStackPop())
+    let ret = TestModule.DelegateManager(delegates: [AnyMyViewControllerDelegate].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DelegateManager_notifyAll")
-@_cdecl("bjs_DelegateManager_notifyAll")
-public func _bjs_DelegateManager_notifyAll(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_DelegateManager_notifyAll")
+@_cdecl("bjs_TestModule_DelegateManager_notifyAll")
+public func _bjs_TestModule_DelegateManager_notifyAll(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    DelegateManager.bridgeJSLiftParameter(_self).notifyAll()
+    TestModule.DelegateManager.bridgeJSLiftParameter(_self).notifyAll()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DelegateManager_delegates_get")
-@_cdecl("bjs_DelegateManager_delegates_get")
-public func _bjs_DelegateManager_delegates_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_DelegateManager_delegates_get")
+@_cdecl("bjs_TestModule_DelegateManager_delegates_get")
+public func _bjs_TestModule_DelegateManager_delegates_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DelegateManager.bridgeJSLiftParameter(_self).delegates
+    let ret = TestModule.DelegateManager.bridgeJSLiftParameter(_self).delegates
     for __bjs_elem_ret in ret {
         _swift_js_push_i32((__bjs_elem_ret as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
     }
@@ -979,21 +979,21 @@ public func _bjs_DelegateManager_delegates_get(_ _self: UnsafeMutableRawPointer)
     #endif
 }
 
-@_expose(wasm, "bjs_DelegateManager_delegates_set")
-@_cdecl("bjs_DelegateManager_delegates_set")
-public func _bjs_DelegateManager_delegates_set(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_DelegateManager_delegates_set")
+@_cdecl("bjs_TestModule_DelegateManager_delegates_set")
+public func _bjs_TestModule_DelegateManager_delegates_set(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    DelegateManager.bridgeJSLiftParameter(_self).delegates = [AnyMyViewControllerDelegate].bridgeJSStackPop()
+    TestModule.DelegateManager.bridgeJSLiftParameter(_self).delegates = [AnyMyViewControllerDelegate].bridgeJSStackPop()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DelegateManager_delegatesByName_get")
-@_cdecl("bjs_DelegateManager_delegatesByName_get")
-public func _bjs_DelegateManager_delegatesByName_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_DelegateManager_delegatesByName_get")
+@_cdecl("bjs_TestModule_DelegateManager_delegatesByName_get")
+public func _bjs_TestModule_DelegateManager_delegatesByName_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DelegateManager.bridgeJSLiftParameter(_self).delegatesByName
+    let ret = TestModule.DelegateManager.bridgeJSLiftParameter(_self).delegatesByName
     for __bjs_kv_ret in ret {
         __bjs_kv_ret.key.bridgeJSStackPush()
         _swift_js_push_i32((__bjs_kv_ret.value as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
@@ -1004,43 +1004,43 @@ public func _bjs_DelegateManager_delegatesByName_get(_ _self: UnsafeMutableRawPo
     #endif
 }
 
-@_expose(wasm, "bjs_DelegateManager_delegatesByName_set")
-@_cdecl("bjs_DelegateManager_delegatesByName_set")
-public func _bjs_DelegateManager_delegatesByName_set(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_DelegateManager_delegatesByName_set")
+@_cdecl("bjs_TestModule_DelegateManager_delegatesByName_set")
+public func _bjs_TestModule_DelegateManager_delegatesByName_set(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    DelegateManager.bridgeJSLiftParameter(_self).delegatesByName = [String: AnyMyViewControllerDelegate].bridgeJSLiftParameter()
+    TestModule.DelegateManager.bridgeJSLiftParameter(_self).delegatesByName = [String: AnyMyViewControllerDelegate].bridgeJSLiftParameter()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DelegateManager_deinit")
-@_cdecl("bjs_DelegateManager_deinit")
-public func _bjs_DelegateManager_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_DelegateManager_deinit")
+@_cdecl("bjs_TestModule_DelegateManager_deinit")
+public func _bjs_TestModule_DelegateManager_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<DelegateManager>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.DelegateManager>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension DelegateManager: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.DelegateManager: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_DelegateManager_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_DelegateManager_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_DelegateManager_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_DelegateManager_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_DelegateManager_wrap")
-fileprivate func _bjs_DelegateManager_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_DelegateManager_wrap")
+fileprivate func _bjs_TestModule_DelegateManager_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_DelegateManager_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_DelegateManager_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_DelegateManager_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_DelegateManager_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_DelegateManager_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_DelegateManager_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ProtocolInClosure.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ProtocolInClosure.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Widget_init",
+          "abiName" : "bjs_TestModule_Widget_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -40,7 +40,7 @@
             }
           }
         ],
-        "swiftCallName" : "Widget"
+        "swiftCallName" : "TestModule.Widget"
       }
     ],
     "enums" : [
@@ -49,7 +49,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_processRenderable",
+        "abiName" : "bjs_TestModule_processRenderable",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -62,7 +62,7 @@
             "name" : "item",
             "type" : {
               "swiftProtocol" : {
-                "_0" : "Renderable"
+                "_0" : "TestModule.Renderable"
               }
             }
           },
@@ -74,12 +74,12 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModule10RenderableP_SS",
+                  "mangleName" : "10TestModule21TestModule_RenderableP_SS",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "swiftProtocol" : {
-                        "_0" : "Renderable"
+                        "_0" : "TestModule.Renderable"
                       }
                     }
                   ],
@@ -102,7 +102,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeRenderableFactory",
+        "abiName" : "bjs_TestModule_makeRenderableFactory",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -125,14 +125,14 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuley_10RenderableP",
+              "mangleName" : "10TestModuley_21TestModule_RenderableP",
               "moduleName" : "TestModule",
               "parameters" : [
 
               ],
               "returnType" : {
                 "swiftProtocol" : {
-                  "_0" : "Renderable"
+                  "_0" : "TestModule.Renderable"
                 }
               },
               "sendingParameters" : false
@@ -142,7 +142,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripRenderable",
+        "abiName" : "bjs_TestModule_roundtripRenderable",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -158,18 +158,18 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModule10RenderableP_10RenderableP",
+                  "mangleName" : "10TestModule21TestModule_RenderableP_21TestModule_RenderableP",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "swiftProtocol" : {
-                        "_0" : "Renderable"
+                        "_0" : "TestModule.Renderable"
                       }
                     }
                   ],
                   "returnType" : {
                     "swiftProtocol" : {
-                      "_0" : "Renderable"
+                      "_0" : "TestModule.Renderable"
                     }
                   },
                   "sendingParameters" : false
@@ -184,18 +184,18 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModule10RenderableP_10RenderableP",
+              "mangleName" : "10TestModule21TestModule_RenderableP_21TestModule_RenderableP",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "swiftProtocol" : {
-                    "_0" : "Renderable"
+                    "_0" : "TestModule.Renderable"
                   }
                 }
               ],
               "returnType" : {
                 "swiftProtocol" : {
-                  "_0" : "Renderable"
+                  "_0" : "TestModule.Renderable"
                 }
               },
               "sendingParameters" : false
@@ -205,7 +205,7 @@
         }
       },
       {
-        "abiName" : "bjs_processOptionalRenderable",
+        "abiName" : "bjs_TestModule_processOptionalRenderable",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -221,14 +221,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModuleSq10RenderableP_SS",
+                  "mangleName" : "10TestModuleSq21TestModule_RenderableP_SS",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "nullable" : {
                         "_0" : {
                           "swiftProtocol" : {
-                            "_0" : "Renderable"
+                            "_0" : "TestModule.Renderable"
                           }
                         },
                         "_1" : "null"

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ProtocolInClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/ProtocolInClosure.swift
@@ -1,35 +1,35 @@
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule10RenderableP_10RenderableP")
-fileprivate func invoke_js_callback_TestModule_10TestModule10RenderableP_10RenderableP_extern(_ callback: Int32, _ param0: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP")
+fileprivate func invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP_extern(_ callback: Int32, _ param0: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModule10RenderableP_10RenderableP_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule10RenderableP_10RenderableP(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModule10RenderableP_10RenderableP_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP")
-fileprivate func make_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP")
+fileprivate func make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModule10RenderableP_10RenderableP {
-    static func bridgeJSLift(_ callbackId: Int32) -> (any Renderable) -> any Renderable {
+private enum _BJS_Closure_10TestModule21TestModule_RenderableP_21TestModule_RenderableP {
+    static func bridgeJSLift(_ callbackId: Int32) -> (any TestModule.Renderable) -> any TestModule.Renderable {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
-            let ret = invoke_js_callback_TestModule_10TestModule10RenderableP_10RenderableP(callbackValue, param0ObjectId)
+            let ret = invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP(callbackValue, param0ObjectId)
             return AnyRenderable.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -38,10 +38,10 @@ private enum _BJS_Closure_10TestModule10RenderableP_10RenderableP {
     }
 }
 
-extension JSTypedClosure where Signature == (any Renderable) -> any Renderable {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (any Renderable) -> any Renderable) {
+extension JSTypedClosure where Signature == (any TestModule.Renderable) -> any TestModule.Renderable {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (any TestModule.Renderable) -> any TestModule.Renderable) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP,
+            makeClosure: make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP,
             body: body,
             fileID: fileID,
             line: line
@@ -49,11 +49,11 @@ extension JSTypedClosure where Signature == (any Renderable) -> any Renderable {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP")
-@_cdecl("invoke_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP")
-public func _invoke_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP")
+@_cdecl("invoke_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP")
+public func _invoke_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(any Renderable) -> any Renderable>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(any TestModule.Renderable) -> any TestModule.Renderable>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure(AnyRenderable.bridgeJSLiftParameter(param0))
     return (result as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
     #else
@@ -62,37 +62,37 @@ public func _invoke_swift_closure_TestModule_10TestModule10RenderableP_10Rendera
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule10RenderableP_SS")
-fileprivate func invoke_js_callback_TestModule_10TestModule10RenderableP_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_SS")
+fileprivate func invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModule10RenderableP_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule10RenderableP_SS(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModule10RenderableP_SS_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_SS(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_SS_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule10RenderableP_SS")
-fileprivate func make_swift_closure_TestModule_10TestModule10RenderableP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS")
+fileprivate func make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModule10RenderableP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule10RenderableP_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModule10RenderableP_SS_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModule10RenderableP_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (any Renderable) -> String {
+private enum _BJS_Closure_10TestModule21TestModule_RenderableP_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (any TestModule.Renderable) -> String {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
-            let ret = invoke_js_callback_TestModule_10TestModule10RenderableP_SS(callbackValue, param0ObjectId)
+            let ret = invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_SS(callbackValue, param0ObjectId)
             return String.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -101,10 +101,10 @@ private enum _BJS_Closure_10TestModule10RenderableP_SS {
     }
 }
 
-extension JSTypedClosure where Signature == (any Renderable) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (any Renderable) -> String) {
+extension JSTypedClosure where Signature == (any TestModule.Renderable) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (any TestModule.Renderable) -> String) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModule10RenderableP_SS,
+            makeClosure: make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS,
             body: body,
             fileID: fileID,
             line: line
@@ -112,11 +112,11 @@ extension JSTypedClosure where Signature == (any Renderable) -> String {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule10RenderableP_SS")
-@_cdecl("invoke_swift_closure_TestModule_10TestModule10RenderableP_SS")
-public func _invoke_swift_closure_TestModule_10TestModule10RenderableP_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS")
+@_cdecl("invoke_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS")
+public func _invoke_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(any Renderable) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(any TestModule.Renderable) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure(AnyRenderable.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
@@ -125,31 +125,31 @@ public func _invoke_swift_closure_TestModule_10TestModule10RenderableP_SS(_ boxP
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq10RenderableP_SS")
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq10RenderableP_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq21TestModule_RenderableP_SS")
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq21TestModule_RenderableP_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq10RenderableP_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq21TestModule_RenderableP_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq10RenderableP_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModuleSq10RenderableP_SS_extern(callback, param0IsSome, param0ObjectId)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq21TestModule_RenderableP_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModuleSq21TestModule_RenderableP_SS_extern(callback, param0IsSome, param0ObjectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq10RenderableP_SS")
-fileprivate func make_swift_closure_TestModule_10TestModuleSq10RenderableP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS")
+fileprivate func make_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuleSq10RenderableP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq10RenderableP_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleSq10RenderableP_SS_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuleSq10RenderableP_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<any Renderable>) -> String {
+private enum _BJS_Closure_10TestModuleSq21TestModule_RenderableP_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<any TestModule.Renderable>) -> String {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
@@ -160,7 +160,7 @@ private enum _BJS_Closure_10TestModuleSq10RenderableP_SS {
             } else {
                 (param0IsSome, param0ObjectId) = (0, 0)
             }
-            let ret = invoke_js_callback_TestModule_10TestModuleSq10RenderableP_SS(callbackValue, param0IsSome, param0ObjectId)
+            let ret = invoke_js_callback_TestModule_10TestModuleSq21TestModule_RenderableP_SS(callbackValue, param0IsSome, param0ObjectId)
             return String.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -169,10 +169,10 @@ private enum _BJS_Closure_10TestModuleSq10RenderableP_SS {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<any Renderable>) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<any Renderable>) -> String) {
+extension JSTypedClosure where Signature == (Optional<any TestModule.Renderable>) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<any TestModule.Renderable>) -> String) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleSq10RenderableP_SS,
+            makeClosure: make_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS,
             body: body,
             fileID: fileID,
             line: line
@@ -180,11 +180,11 @@ extension JSTypedClosure where Signature == (Optional<any Renderable>) -> String
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq10RenderableP_SS")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq10RenderableP_SS")
-public func _invoke_swift_closure_TestModule_10TestModuleSq10RenderableP_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS")
+public func _invoke_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<any Renderable>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<any TestModule.Renderable>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure(Optional<AnyRenderable>.bridgeJSLiftParameter(param0IsSome, param0Value))
     return result.bridgeJSLowerReturn()
     #else
@@ -193,36 +193,36 @@ public func _invoke_swift_closure_TestModule_10TestModuleSq10RenderableP_SS(_ bo
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuley_10RenderableP")
-fileprivate func invoke_js_callback_TestModule_10TestModuley_10RenderableP_extern(_ callback: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuley_21TestModule_RenderableP")
+fileprivate func invoke_js_callback_TestModule_10TestModuley_21TestModule_RenderableP_extern(_ callback: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuley_10RenderableP_extern(_ callback: Int32) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModuley_21TestModule_RenderableP_extern(_ callback: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuley_10RenderableP(_ callback: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModuley_10RenderableP_extern(callback)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuley_21TestModule_RenderableP(_ callback: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModuley_21TestModule_RenderableP_extern(callback)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuley_10RenderableP")
-fileprivate func make_swift_closure_TestModule_10TestModuley_10RenderableP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP")
+fileprivate func make_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuley_10RenderableP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuley_10RenderableP(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuley_10RenderableP_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuley_10RenderableP {
-    static func bridgeJSLift(_ callbackId: Int32) -> () -> any Renderable {
+private enum _BJS_Closure_10TestModuley_21TestModule_RenderableP {
+    static func bridgeJSLift(_ callbackId: Int32) -> () -> any TestModule.Renderable {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModuley_10RenderableP(callbackValue)
+            let ret = invoke_js_callback_TestModule_10TestModuley_21TestModule_RenderableP(callbackValue)
             return AnyRenderable.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -231,10 +231,10 @@ private enum _BJS_Closure_10TestModuley_10RenderableP {
     }
 }
 
-extension JSTypedClosure where Signature == () -> any Renderable {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping () -> any Renderable) {
+extension JSTypedClosure where Signature == () -> any TestModule.Renderable {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping () -> any TestModule.Renderable) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuley_10RenderableP,
+            makeClosure: make_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP,
             body: body,
             fileID: fileID,
             line: line
@@ -242,11 +242,11 @@ extension JSTypedClosure where Signature == () -> any Renderable {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuley_10RenderableP")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuley_10RenderableP")
-public func _invoke_swift_closure_TestModule_10TestModuley_10RenderableP(_ boxPtr: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP")
+public func _invoke_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP(_ boxPtr: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> any Renderable>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> any TestModule.Renderable>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure()
     return (result as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
     #else
@@ -280,20 +280,20 @@ fileprivate func _extern_render_extern(_ jsObject: Int32) -> Int32 {
     return _extern_render_extern(jsObject)
 }
 
-@_expose(wasm, "bjs_processRenderable")
-@_cdecl("bjs_processRenderable")
-public func _bjs_processRenderable(_ item: Int32, _ transform: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_processRenderable")
+@_cdecl("bjs_TestModule_processRenderable")
+public func _bjs_TestModule_processRenderable(_ item: Int32, _ transform: Int32) -> Void {
     #if arch(wasm32)
-    let ret = processRenderable(_: AnyRenderable.bridgeJSLiftParameter(item), transform: _BJS_Closure_10TestModule10RenderableP_SS.bridgeJSLift(transform))
+    let ret = processRenderable(_: AnyRenderable.bridgeJSLiftParameter(item), transform: _BJS_Closure_10TestModule21TestModule_RenderableP_SS.bridgeJSLift(transform))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeRenderableFactory")
-@_cdecl("bjs_makeRenderableFactory")
-public func _bjs_makeRenderableFactory(_ defaultNameBytes: Int32, _ defaultNameLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_makeRenderableFactory")
+@_cdecl("bjs_TestModule_makeRenderableFactory")
+public func _bjs_TestModule_makeRenderableFactory(_ defaultNameBytes: Int32, _ defaultNameLength: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = makeRenderableFactory(defaultName: String.bridgeJSLiftParameter(defaultNameBytes, defaultNameLength))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -302,87 +302,87 @@ public func _bjs_makeRenderableFactory(_ defaultNameBytes: Int32, _ defaultNameL
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripRenderable")
-@_cdecl("bjs_roundtripRenderable")
-public func _bjs_roundtripRenderable(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripRenderable")
+@_cdecl("bjs_TestModule_roundtripRenderable")
+public func _bjs_TestModule_roundtripRenderable(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripRenderable(_: _BJS_Closure_10TestModule10RenderableP_10RenderableP.bridgeJSLift(callback))
+    let ret = roundtripRenderable(_: _BJS_Closure_10TestModule21TestModule_RenderableP_21TestModule_RenderableP.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processOptionalRenderable")
-@_cdecl("bjs_processOptionalRenderable")
-public func _bjs_processOptionalRenderable(_ callback: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_processOptionalRenderable")
+@_cdecl("bjs_TestModule_processOptionalRenderable")
+public func _bjs_TestModule_processOptionalRenderable(_ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = processOptionalRenderable(_: _BJS_Closure_10TestModuleSq10RenderableP_SS.bridgeJSLift(callback))
+    let ret = processOptionalRenderable(_: _BJS_Closure_10TestModuleSq21TestModule_RenderableP_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Widget_init")
-@_cdecl("bjs_Widget_init")
-public func _bjs_Widget_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Widget_init")
+@_cdecl("bjs_TestModule_Widget_init")
+public func _bjs_TestModule_Widget_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Widget(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Widget(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Widget_name_get")
-@_cdecl("bjs_Widget_name_get")
-public func _bjs_Widget_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Widget_name_get")
+@_cdecl("bjs_TestModule_Widget_name_get")
+public func _bjs_TestModule_Widget_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Widget.bridgeJSLiftParameter(_self).name
+    let ret = TestModule.Widget.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Widget_name_set")
-@_cdecl("bjs_Widget_name_set")
-public func _bjs_Widget_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Widget_name_set")
+@_cdecl("bjs_TestModule_Widget_name_set")
+public func _bjs_TestModule_Widget_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    Widget.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.Widget.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Widget_deinit")
-@_cdecl("bjs_Widget_deinit")
-public func _bjs_Widget_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Widget_deinit")
+@_cdecl("bjs_TestModule_Widget_deinit")
+public func _bjs_TestModule_Widget_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Widget>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Widget>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Widget: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Widget: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Widget_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Widget_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Widget_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Widget_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Widget_wrap")
-fileprivate func _bjs_Widget_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Widget_wrap")
+fileprivate func _bjs_TestModule_Widget_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Widget_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Widget_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Widget_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Widget_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Widget_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Widget_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_MathUtils_init",
+          "abiName" : "bjs_TestModule_MathUtils_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_MathUtils_static_subtract",
+            "abiName" : "bjs_TestModule_MathUtils_static_subtract",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -61,12 +61,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "TestModule_MathUtils"
               }
             }
           },
           {
-            "abiName" : "bjs_MathUtils_static_add",
+            "abiName" : "bjs_TestModule_MathUtils_static_add",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -109,12 +109,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "TestModule_MathUtils"
               }
             }
           },
           {
-            "abiName" : "bjs_MathUtils_multiply",
+            "abiName" : "bjs_TestModule_MathUtils_multiply",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -157,7 +157,7 @@
             }
           },
           {
-            "abiName" : "bjs_MathUtils_static_divide",
+            "abiName" : "bjs_TestModule_MathUtils_static_divide",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -200,7 +200,7 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "TestModule_MathUtils"
               }
             }
           }
@@ -213,7 +213,7 @@
             "name" : "pi",
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "TestModule_MathUtils"
               }
             },
             "type" : {
@@ -223,7 +223,7 @@
             }
           }
         ],
-        "swiftCallName" : "MathUtils"
+        "swiftCallName" : "TestModule.MathUtils"
       }
     ],
     "enums" : [
@@ -246,7 +246,7 @@
         "name" : "Calculator",
         "staticMethods" : [
           {
-            "abiName" : "bjs_Calculator_static_square",
+            "abiName" : "bjs_TestModule_Calculator_static_square",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -277,12 +277,12 @@
             },
             "staticContext" : {
               "enumName" : {
-                "_0" : "Calculator"
+                "_0" : "TestModule.Calculator"
               }
             }
           },
           {
-            "abiName" : "bjs_Calculator_static_cube",
+            "abiName" : "bjs_TestModule_Calculator_static_cube",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -313,7 +313,7 @@
             },
             "staticContext" : {
               "enumName" : {
-                "_0" : "Calculator"
+                "_0" : "TestModule.Calculator"
               }
             }
           }
@@ -325,7 +325,7 @@
             "name" : "version",
             "staticContext" : {
               "enumName" : {
-                "_0" : "Calculator"
+                "_0" : "TestModule.Calculator"
               }
             },
             "type" : {
@@ -335,7 +335,7 @@
             }
           }
         ],
-        "swiftCallName" : "Calculator",
+        "swiftCallName" : "TestModule.Calculator",
         "tsFullPath" : "Calculator"
       },
       {
@@ -372,7 +372,7 @@
         "name" : "APIResult",
         "staticMethods" : [
           {
-            "abiName" : "bjs_APIResult_static_roundtrip",
+            "abiName" : "bjs_TestModule_APIResult_static_roundtrip",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -385,19 +385,19 @@
                 "name" : "value",
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "TestModule.APIResult"
                   }
                 }
               }
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "TestModule.APIResult"
               }
             },
             "staticContext" : {
               "enumName" : {
-                "_0" : "APIResult"
+                "_0" : "TestModule.APIResult"
               }
             }
           }
@@ -405,7 +405,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "APIResult",
+        "swiftCallName" : "TestModule.APIResult",
         "tsFullPath" : "APIResult"
       },
       {
@@ -420,7 +420,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utils",
+        "swiftCallName" : "TestModule.Utils",
         "tsFullPath" : "Utils"
       },
       {
@@ -434,7 +434,7 @@
         ],
         "staticMethods" : [
           {
-            "abiName" : "bjs_Utils_String_static_uppercase",
+            "abiName" : "bjs_TestModule_Utils_String_static_uppercase",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -463,7 +463,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "Utils.String"
+                "_0" : "TestModule.Utils.String"
               }
             }
           }
@@ -471,7 +471,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utils.String",
+        "swiftCallName" : "TestModule.Utils.String",
         "tsFullPath" : "Utils.String"
       }
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.Global.swift
@@ -1,12 +1,12 @@
-extension Calculator: _BridgedSwiftCaseEnum {
+extension TestModule.Calculator: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Calculator {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Calculator {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Calculator {
-        return Calculator(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Calculator {
+        return TestModule.Calculator(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -33,48 +33,48 @@ extension Calculator: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_Calculator_static_square")
-@_cdecl("bjs_Calculator_static_square")
-public func _bjs_Calculator_static_square(_ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_Calculator_static_square")
+@_cdecl("bjs_TestModule_Calculator_static_square")
+public func _bjs_TestModule_Calculator_static_square(_ value: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = Calculator.square(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Calculator.square(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Calculator_static_cube")
-@_cdecl("bjs_Calculator_static_cube")
-public func _bjs_Calculator_static_cube(_ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_Calculator_static_cube")
+@_cdecl("bjs_TestModule_Calculator_static_cube")
+public func _bjs_TestModule_Calculator_static_cube(_ value: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = Calculator.cube(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Calculator.cube(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Calculator_static_version_get")
-@_cdecl("bjs_Calculator_static_version_get")
-public func _bjs_Calculator_static_version_get() -> Void {
+@_expose(wasm, "bjs_TestModule_Calculator_static_version_get")
+@_cdecl("bjs_TestModule_Calculator_static_version_get")
+public func _bjs_TestModule_Calculator_static_version_get() -> Void {
     #if arch(wasm32)
-    let ret = Calculator.version
+    let ret = TestModule.Calculator.version
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension APIResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
+extension TestModule.APIResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.APIResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
         case 1:
             return .failure(Int.bridgeJSStackPop())
         default:
-            fatalError("Unknown APIResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.APIResult case ID: \(caseId)")
         }
     }
 
@@ -90,121 +90,121 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-@_expose(wasm, "bjs_APIResult_static_roundtrip")
-@_cdecl("bjs_APIResult_static_roundtrip")
-public func _bjs_APIResult_static_roundtrip(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_APIResult_static_roundtrip")
+@_cdecl("bjs_TestModule_APIResult_static_roundtrip")
+public func _bjs_TestModule_APIResult_static_roundtrip(_ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = APIResult.roundtrip(value: APIResult.bridgeJSLiftParameter(value))
+    let ret = TestModule.APIResult.roundtrip(value: TestModule.APIResult.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_String_static_uppercase")
-@_cdecl("bjs_Utils_String_static_uppercase")
-public func _bjs_Utils_String_static_uppercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Utils_String_static_uppercase")
+@_cdecl("bjs_TestModule_Utils_String_static_uppercase")
+public func _bjs_TestModule_Utils_String_static_uppercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Utils.String.uppercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
+    let ret = TestModule.Utils.String.uppercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_init")
-@_cdecl("bjs_MathUtils_init")
-public func _bjs_MathUtils_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_MathUtils_init")
+@_cdecl("bjs_TestModule_MathUtils_init")
+public func _bjs_TestModule_MathUtils_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = MathUtils()
+    let ret = TestModule.MathUtils()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_static_subtract")
-@_cdecl("bjs_MathUtils_static_subtract")
-public func _bjs_MathUtils_static_subtract(_ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MathUtils_static_subtract")
+@_cdecl("bjs_TestModule_MathUtils_static_subtract")
+public func _bjs_TestModule_MathUtils_static_subtract(_ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.subtract(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
+    let ret = TestModule.MathUtils.subtract(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_static_add")
-@_cdecl("bjs_MathUtils_static_add")
-public func _bjs_MathUtils_static_add(_ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MathUtils_static_add")
+@_cdecl("bjs_TestModule_MathUtils_static_add")
+public func _bjs_TestModule_MathUtils_static_add(_ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
+    let ret = TestModule.MathUtils.add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_multiply")
-@_cdecl("bjs_MathUtils_multiply")
-public func _bjs_MathUtils_multiply(_ _self: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MathUtils_multiply")
+@_cdecl("bjs_TestModule_MathUtils_multiply")
+public func _bjs_TestModule_MathUtils_multiply(_ _self: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.bridgeJSLiftParameter(_self).multiply(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
+    let ret = TestModule.MathUtils.bridgeJSLiftParameter(_self).multiply(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_static_divide")
-@_cdecl("bjs_MathUtils_static_divide")
-public func _bjs_MathUtils_static_divide(_ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MathUtils_static_divide")
+@_cdecl("bjs_TestModule_MathUtils_static_divide")
+public func _bjs_TestModule_MathUtils_static_divide(_ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.divide(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
+    let ret = TestModule.MathUtils.divide(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_static_pi_get")
-@_cdecl("bjs_MathUtils_static_pi_get")
-public func _bjs_MathUtils_static_pi_get() -> Float64 {
+@_expose(wasm, "bjs_TestModule_MathUtils_static_pi_get")
+@_cdecl("bjs_TestModule_MathUtils_static_pi_get")
+public func _bjs_TestModule_MathUtils_static_pi_get() -> Float64 {
     #if arch(wasm32)
-    let ret = MathUtils.pi
+    let ret = TestModule.MathUtils.pi
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_deinit")
-@_cdecl("bjs_MathUtils_deinit")
-public func _bjs_MathUtils_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_MathUtils_deinit")
+@_cdecl("bjs_TestModule_MathUtils_deinit")
+public func _bjs_TestModule_MathUtils_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<MathUtils>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.MathUtils>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension MathUtils: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.MathUtils: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_MathUtils_wrap")
-fileprivate func _bjs_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_MathUtils_wrap")
+fileprivate func _bjs_TestModule_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_MathUtils_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_MathUtils_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_MathUtils_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_MathUtils_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_MathUtils_init",
+          "abiName" : "bjs_TestModule_MathUtils_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_MathUtils_static_subtract",
+            "abiName" : "bjs_TestModule_MathUtils_static_subtract",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -61,12 +61,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "TestModule_MathUtils"
               }
             }
           },
           {
-            "abiName" : "bjs_MathUtils_static_add",
+            "abiName" : "bjs_TestModule_MathUtils_static_add",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -109,12 +109,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "TestModule_MathUtils"
               }
             }
           },
           {
-            "abiName" : "bjs_MathUtils_multiply",
+            "abiName" : "bjs_TestModule_MathUtils_multiply",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -157,7 +157,7 @@
             }
           },
           {
-            "abiName" : "bjs_MathUtils_static_divide",
+            "abiName" : "bjs_TestModule_MathUtils_static_divide",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -200,7 +200,7 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "TestModule_MathUtils"
               }
             }
           }
@@ -213,7 +213,7 @@
             "name" : "pi",
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "TestModule_MathUtils"
               }
             },
             "type" : {
@@ -223,7 +223,7 @@
             }
           }
         ],
-        "swiftCallName" : "MathUtils"
+        "swiftCallName" : "TestModule.MathUtils"
       }
     ],
     "enums" : [
@@ -246,7 +246,7 @@
         "name" : "Calculator",
         "staticMethods" : [
           {
-            "abiName" : "bjs_Calculator_static_square",
+            "abiName" : "bjs_TestModule_Calculator_static_square",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -277,12 +277,12 @@
             },
             "staticContext" : {
               "enumName" : {
-                "_0" : "Calculator"
+                "_0" : "TestModule.Calculator"
               }
             }
           },
           {
-            "abiName" : "bjs_Calculator_static_cube",
+            "abiName" : "bjs_TestModule_Calculator_static_cube",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -313,7 +313,7 @@
             },
             "staticContext" : {
               "enumName" : {
-                "_0" : "Calculator"
+                "_0" : "TestModule.Calculator"
               }
             }
           }
@@ -325,7 +325,7 @@
             "name" : "version",
             "staticContext" : {
               "enumName" : {
-                "_0" : "Calculator"
+                "_0" : "TestModule.Calculator"
               }
             },
             "type" : {
@@ -335,7 +335,7 @@
             }
           }
         ],
-        "swiftCallName" : "Calculator",
+        "swiftCallName" : "TestModule.Calculator",
         "tsFullPath" : "Calculator"
       },
       {
@@ -372,7 +372,7 @@
         "name" : "APIResult",
         "staticMethods" : [
           {
-            "abiName" : "bjs_APIResult_static_roundtrip",
+            "abiName" : "bjs_TestModule_APIResult_static_roundtrip",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -385,19 +385,19 @@
                 "name" : "value",
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "TestModule.APIResult"
                   }
                 }
               }
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "TestModule.APIResult"
               }
             },
             "staticContext" : {
               "enumName" : {
-                "_0" : "APIResult"
+                "_0" : "TestModule.APIResult"
               }
             }
           }
@@ -405,7 +405,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "APIResult",
+        "swiftCallName" : "TestModule.APIResult",
         "tsFullPath" : "APIResult"
       },
       {
@@ -420,7 +420,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utils",
+        "swiftCallName" : "TestModule.Utils",
         "tsFullPath" : "Utils"
       },
       {
@@ -434,7 +434,7 @@
         ],
         "staticMethods" : [
           {
-            "abiName" : "bjs_Utils_String_static_uppercase",
+            "abiName" : "bjs_TestModule_Utils_String_static_uppercase",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -463,7 +463,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "Utils.String"
+                "_0" : "TestModule.Utils.String"
               }
             }
           }
@@ -471,7 +471,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utils.String",
+        "swiftCallName" : "TestModule.Utils.String",
         "tsFullPath" : "Utils.String"
       }
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticFunctions.swift
@@ -1,12 +1,12 @@
-extension Calculator: _BridgedSwiftCaseEnum {
+extension TestModule.Calculator: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Calculator {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Calculator {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Calculator {
-        return Calculator(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Calculator {
+        return TestModule.Calculator(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -33,48 +33,48 @@ extension Calculator: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_Calculator_static_square")
-@_cdecl("bjs_Calculator_static_square")
-public func _bjs_Calculator_static_square(_ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_Calculator_static_square")
+@_cdecl("bjs_TestModule_Calculator_static_square")
+public func _bjs_TestModule_Calculator_static_square(_ value: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = Calculator.square(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Calculator.square(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Calculator_static_cube")
-@_cdecl("bjs_Calculator_static_cube")
-public func _bjs_Calculator_static_cube(_ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_Calculator_static_cube")
+@_cdecl("bjs_TestModule_Calculator_static_cube")
+public func _bjs_TestModule_Calculator_static_cube(_ value: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = Calculator.cube(value: Int.bridgeJSLiftParameter(value))
+    let ret = TestModule.Calculator.cube(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Calculator_static_version_get")
-@_cdecl("bjs_Calculator_static_version_get")
-public func _bjs_Calculator_static_version_get() -> Void {
+@_expose(wasm, "bjs_TestModule_Calculator_static_version_get")
+@_cdecl("bjs_TestModule_Calculator_static_version_get")
+public func _bjs_TestModule_Calculator_static_version_get() -> Void {
     #if arch(wasm32)
-    let ret = Calculator.version
+    let ret = TestModule.Calculator.version
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension APIResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
+extension TestModule.APIResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.APIResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
         case 1:
             return .failure(Int.bridgeJSStackPop())
         default:
-            fatalError("Unknown APIResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.APIResult case ID: \(caseId)")
         }
     }
 
@@ -90,121 +90,121 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-@_expose(wasm, "bjs_APIResult_static_roundtrip")
-@_cdecl("bjs_APIResult_static_roundtrip")
-public func _bjs_APIResult_static_roundtrip(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_APIResult_static_roundtrip")
+@_cdecl("bjs_TestModule_APIResult_static_roundtrip")
+public func _bjs_TestModule_APIResult_static_roundtrip(_ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = APIResult.roundtrip(value: APIResult.bridgeJSLiftParameter(value))
+    let ret = TestModule.APIResult.roundtrip(value: TestModule.APIResult.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_String_static_uppercase")
-@_cdecl("bjs_Utils_String_static_uppercase")
-public func _bjs_Utils_String_static_uppercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Utils_String_static_uppercase")
+@_cdecl("bjs_TestModule_Utils_String_static_uppercase")
+public func _bjs_TestModule_Utils_String_static_uppercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Utils.String.uppercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
+    let ret = TestModule.Utils.String.uppercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_init")
-@_cdecl("bjs_MathUtils_init")
-public func _bjs_MathUtils_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_MathUtils_init")
+@_cdecl("bjs_TestModule_MathUtils_init")
+public func _bjs_TestModule_MathUtils_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = MathUtils()
+    let ret = TestModule.MathUtils()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_static_subtract")
-@_cdecl("bjs_MathUtils_static_subtract")
-public func _bjs_MathUtils_static_subtract(_ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MathUtils_static_subtract")
+@_cdecl("bjs_TestModule_MathUtils_static_subtract")
+public func _bjs_TestModule_MathUtils_static_subtract(_ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.subtract(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
+    let ret = TestModule.MathUtils.subtract(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_static_add")
-@_cdecl("bjs_MathUtils_static_add")
-public func _bjs_MathUtils_static_add(_ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MathUtils_static_add")
+@_cdecl("bjs_TestModule_MathUtils_static_add")
+public func _bjs_TestModule_MathUtils_static_add(_ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
+    let ret = TestModule.MathUtils.add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_multiply")
-@_cdecl("bjs_MathUtils_multiply")
-public func _bjs_MathUtils_multiply(_ _self: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MathUtils_multiply")
+@_cdecl("bjs_TestModule_MathUtils_multiply")
+public func _bjs_TestModule_MathUtils_multiply(_ _self: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.bridgeJSLiftParameter(_self).multiply(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
+    let ret = TestModule.MathUtils.bridgeJSLiftParameter(_self).multiply(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_static_divide")
-@_cdecl("bjs_MathUtils_static_divide")
-public func _bjs_MathUtils_static_divide(_ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_MathUtils_static_divide")
+@_cdecl("bjs_TestModule_MathUtils_static_divide")
+public func _bjs_TestModule_MathUtils_static_divide(_ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.divide(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
+    let ret = TestModule.MathUtils.divide(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_static_pi_get")
-@_cdecl("bjs_MathUtils_static_pi_get")
-public func _bjs_MathUtils_static_pi_get() -> Float64 {
+@_expose(wasm, "bjs_TestModule_MathUtils_static_pi_get")
+@_cdecl("bjs_TestModule_MathUtils_static_pi_get")
+public func _bjs_TestModule_MathUtils_static_pi_get() -> Float64 {
     #if arch(wasm32)
-    let ret = MathUtils.pi
+    let ret = TestModule.MathUtils.pi
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_deinit")
-@_cdecl("bjs_MathUtils_deinit")
-public func _bjs_MathUtils_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_MathUtils_deinit")
+@_cdecl("bjs_TestModule_MathUtils_deinit")
+public func _bjs_TestModule_MathUtils_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<MathUtils>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.MathUtils>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension MathUtils: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.MathUtils: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_MathUtils_wrap")
-fileprivate func _bjs_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_MathUtils_wrap")
+fileprivate func _bjs_TestModule_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_MathUtils_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_MathUtils_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_MathUtils_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_MathUtils_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.Global.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.Global.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_PropertyClass_init",
+          "abiName" : "bjs_TestModule_PropertyClass_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -27,7 +27,7 @@
             "name" : "staticConstant",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -42,7 +42,7 @@
             "name" : "staticVariable",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -60,7 +60,7 @@
             "name" : "jsObjectProperty",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -75,7 +75,7 @@
             "name" : "classVariable",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -90,7 +90,7 @@
             "name" : "computedProperty",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -105,7 +105,7 @@
             "name" : "readOnlyComputed",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -123,7 +123,7 @@
             "name" : "optionalProperty",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -138,7 +138,7 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyClass"
+        "swiftCallName" : "TestModule.PropertyClass"
       }
     ],
     "enums" : [
@@ -169,7 +169,7 @@
             "name" : "enumProperty",
             "staticContext" : {
               "enumName" : {
-                "_0" : "PropertyEnum"
+                "_0" : "TestModule.PropertyEnum"
               }
             },
             "type" : {
@@ -184,7 +184,7 @@
             "name" : "enumConstant",
             "staticContext" : {
               "enumName" : {
-                "_0" : "PropertyEnum"
+                "_0" : "TestModule.PropertyEnum"
               }
             },
             "type" : {
@@ -202,7 +202,7 @@
             "name" : "computedEnum",
             "staticContext" : {
               "enumName" : {
-                "_0" : "PropertyEnum"
+                "_0" : "TestModule.PropertyEnum"
               }
             },
             "type" : {
@@ -212,7 +212,7 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyEnum",
+        "swiftCallName" : "TestModule.PropertyEnum",
         "tsFullPath" : "PropertyEnum"
       },
       {
@@ -234,7 +234,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace"
+                "_0" : "TestModule.PropertyNamespace"
               }
             },
             "type" : {
@@ -252,7 +252,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace"
+                "_0" : "TestModule.PropertyNamespace"
               }
             },
             "type" : {
@@ -262,7 +262,7 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyNamespace",
+        "swiftCallName" : "TestModule.PropertyNamespace",
         "tsFullPath" : "PropertyNamespace"
       },
       {
@@ -288,7 +288,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace.Nested"
+                "_0" : "TestModule.PropertyNamespace.Nested"
               }
             },
             "type" : {
@@ -310,7 +310,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace.Nested"
+                "_0" : "TestModule.PropertyNamespace.Nested"
               }
             },
             "type" : {
@@ -329,7 +329,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace.Nested"
+                "_0" : "TestModule.PropertyNamespace.Nested"
               }
             },
             "type" : {
@@ -339,7 +339,7 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyNamespace.Nested",
+        "swiftCallName" : "TestModule.PropertyNamespace.Nested",
         "tsFullPath" : "PropertyNamespace.Nested"
       }
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.Global.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.Global.swift
@@ -1,12 +1,12 @@
-extension PropertyEnum: _BridgedSwiftCaseEnum {
+extension TestModule.PropertyEnum: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> PropertyEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.PropertyEnum {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> PropertyEnum {
-        return PropertyEnum(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.PropertyEnum {
+        return TestModule.PropertyEnum(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -33,309 +33,309 @@ extension PropertyEnum: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_enumProperty_get")
-@_cdecl("bjs_PropertyEnum_static_enumProperty_get")
-public func _bjs_PropertyEnum_static_enumProperty_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_enumProperty_get")
+@_cdecl("bjs_TestModule_PropertyEnum_static_enumProperty_get")
+public func _bjs_TestModule_PropertyEnum_static_enumProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyEnum.enumProperty
+    let ret = TestModule.PropertyEnum.enumProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_enumProperty_set")
-@_cdecl("bjs_PropertyEnum_static_enumProperty_set")
-public func _bjs_PropertyEnum_static_enumProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_enumProperty_set")
+@_cdecl("bjs_TestModule_PropertyEnum_static_enumProperty_set")
+public func _bjs_TestModule_PropertyEnum_static_enumProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyEnum.enumProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyEnum.enumProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_enumConstant_get")
-@_cdecl("bjs_PropertyEnum_static_enumConstant_get")
-public func _bjs_PropertyEnum_static_enumConstant_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_enumConstant_get")
+@_cdecl("bjs_TestModule_PropertyEnum_static_enumConstant_get")
+public func _bjs_TestModule_PropertyEnum_static_enumConstant_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyEnum.enumConstant
+    let ret = TestModule.PropertyEnum.enumConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_computedEnum_get")
-@_cdecl("bjs_PropertyEnum_static_computedEnum_get")
-public func _bjs_PropertyEnum_static_computedEnum_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_computedEnum_get")
+@_cdecl("bjs_TestModule_PropertyEnum_static_computedEnum_get")
+public func _bjs_TestModule_PropertyEnum_static_computedEnum_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyEnum.computedEnum
+    let ret = TestModule.PropertyEnum.computedEnum
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_computedEnum_set")
-@_cdecl("bjs_PropertyEnum_static_computedEnum_set")
-public func _bjs_PropertyEnum_static_computedEnum_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_computedEnum_set")
+@_cdecl("bjs_TestModule_PropertyEnum_static_computedEnum_set")
+public func _bjs_TestModule_PropertyEnum_static_computedEnum_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyEnum.computedEnum = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyEnum.computedEnum = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_static_namespaceProperty_get")
-@_cdecl("bjs_PropertyNamespace_static_namespaceProperty_get")
-public func _bjs_PropertyNamespace_static_namespaceProperty_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_static_namespaceProperty_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_static_namespaceProperty_get")
+public func _bjs_TestModule_PropertyNamespace_static_namespaceProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyNamespace.namespaceProperty
+    let ret = TestModule.PropertyNamespace.namespaceProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_static_namespaceProperty_set")
-@_cdecl("bjs_PropertyNamespace_static_namespaceProperty_set")
-public func _bjs_PropertyNamespace_static_namespaceProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_static_namespaceProperty_set")
+@_cdecl("bjs_TestModule_PropertyNamespace_static_namespaceProperty_set")
+public func _bjs_TestModule_PropertyNamespace_static_namespaceProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyNamespace.namespaceProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyNamespace.namespaceProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_static_namespaceConstant_get")
-@_cdecl("bjs_PropertyNamespace_static_namespaceConstant_get")
-public func _bjs_PropertyNamespace_static_namespaceConstant_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_static_namespaceConstant_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_static_namespaceConstant_get")
+public func _bjs_TestModule_PropertyNamespace_static_namespaceConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyNamespace.namespaceConstant
+    let ret = TestModule.PropertyNamespace.namespaceConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedProperty_get")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedProperty_get")
-public func _bjs_PropertyNamespace_Nested_static_nestedProperty_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_get")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyNamespace.Nested.nestedProperty
+    let ret = TestModule.PropertyNamespace.Nested.nestedProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedProperty_set")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedProperty_set")
-public func _bjs_PropertyNamespace_Nested_static_nestedProperty_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_set")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_set")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyNamespace.Nested.nestedProperty = Int.bridgeJSLiftParameter(value)
+    TestModule.PropertyNamespace.Nested.nestedProperty = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedConstant_get")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedConstant_get")
-public func _bjs_PropertyNamespace_Nested_static_nestedConstant_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedConstant_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedConstant_get")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyNamespace.Nested.nestedConstant
+    let ret = TestModule.PropertyNamespace.Nested.nestedConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedDouble_get")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedDouble_get")
-public func _bjs_PropertyNamespace_Nested_static_nestedDouble_get() -> Float64 {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_get")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_get() -> Float64 {
     #if arch(wasm32)
-    let ret = PropertyNamespace.Nested.nestedDouble
+    let ret = TestModule.PropertyNamespace.Nested.nestedDouble
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedDouble_set")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedDouble_set")
-public func _bjs_PropertyNamespace_Nested_static_nestedDouble_set(_ value: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_set")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_set")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_set(_ value: Float64) -> Void {
     #if arch(wasm32)
-    PropertyNamespace.Nested.nestedDouble = Double.bridgeJSLiftParameter(value)
+    TestModule.PropertyNamespace.Nested.nestedDouble = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_init")
-@_cdecl("bjs_PropertyClass_init")
-public func _bjs_PropertyClass_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PropertyClass_init")
+@_cdecl("bjs_TestModule_PropertyClass_init")
+public func _bjs_TestModule_PropertyClass_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PropertyClass()
+    let ret = TestModule.PropertyClass()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_staticConstant_get")
-@_cdecl("bjs_PropertyClass_static_staticConstant_get")
-public func _bjs_PropertyClass_static_staticConstant_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_staticConstant_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_staticConstant_get")
+public func _bjs_TestModule_PropertyClass_static_staticConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyClass.staticConstant
+    let ret = TestModule.PropertyClass.staticConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_staticVariable_get")
-@_cdecl("bjs_PropertyClass_static_staticVariable_get")
-public func _bjs_PropertyClass_static_staticVariable_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_staticVariable_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_staticVariable_get")
+public func _bjs_TestModule_PropertyClass_static_staticVariable_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyClass.staticVariable
+    let ret = TestModule.PropertyClass.staticVariable
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_staticVariable_set")
-@_cdecl("bjs_PropertyClass_static_staticVariable_set")
-public func _bjs_PropertyClass_static_staticVariable_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_staticVariable_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_staticVariable_set")
+public func _bjs_TestModule_PropertyClass_static_staticVariable_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.staticVariable = Int.bridgeJSLiftParameter(value)
+    TestModule.PropertyClass.staticVariable = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_jsObjectProperty_get")
-@_cdecl("bjs_PropertyClass_static_jsObjectProperty_get")
-public func _bjs_PropertyClass_static_jsObjectProperty_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_jsObjectProperty_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_jsObjectProperty_get")
+public func _bjs_TestModule_PropertyClass_static_jsObjectProperty_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyClass.jsObjectProperty
+    let ret = TestModule.PropertyClass.jsObjectProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_jsObjectProperty_set")
-@_cdecl("bjs_PropertyClass_static_jsObjectProperty_set")
-public func _bjs_PropertyClass_static_jsObjectProperty_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_jsObjectProperty_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_jsObjectProperty_set")
+public func _bjs_TestModule_PropertyClass_static_jsObjectProperty_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.jsObjectProperty = JSObject.bridgeJSLiftParameter(value)
+    TestModule.PropertyClass.jsObjectProperty = JSObject.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_classVariable_get")
-@_cdecl("bjs_PropertyClass_static_classVariable_get")
-public func _bjs_PropertyClass_static_classVariable_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_classVariable_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_classVariable_get")
+public func _bjs_TestModule_PropertyClass_static_classVariable_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyClass.classVariable
+    let ret = TestModule.PropertyClass.classVariable
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_classVariable_set")
-@_cdecl("bjs_PropertyClass_static_classVariable_set")
-public func _bjs_PropertyClass_static_classVariable_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_classVariable_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_classVariable_set")
+public func _bjs_TestModule_PropertyClass_static_classVariable_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.classVariable = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyClass.classVariable = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_computedProperty_get")
-@_cdecl("bjs_PropertyClass_static_computedProperty_get")
-public func _bjs_PropertyClass_static_computedProperty_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_computedProperty_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_computedProperty_get")
+public func _bjs_TestModule_PropertyClass_static_computedProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyClass.computedProperty
+    let ret = TestModule.PropertyClass.computedProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_computedProperty_set")
-@_cdecl("bjs_PropertyClass_static_computedProperty_set")
-public func _bjs_PropertyClass_static_computedProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_computedProperty_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_computedProperty_set")
+public func _bjs_TestModule_PropertyClass_static_computedProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.computedProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyClass.computedProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_readOnlyComputed_get")
-@_cdecl("bjs_PropertyClass_static_readOnlyComputed_get")
-public func _bjs_PropertyClass_static_readOnlyComputed_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_readOnlyComputed_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_readOnlyComputed_get")
+public func _bjs_TestModule_PropertyClass_static_readOnlyComputed_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyClass.readOnlyComputed
+    let ret = TestModule.PropertyClass.readOnlyComputed
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_optionalProperty_get")
-@_cdecl("bjs_PropertyClass_static_optionalProperty_get")
-public func _bjs_PropertyClass_static_optionalProperty_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_optionalProperty_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_optionalProperty_get")
+public func _bjs_TestModule_PropertyClass_static_optionalProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyClass.optionalProperty
+    let ret = TestModule.PropertyClass.optionalProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_optionalProperty_set")
-@_cdecl("bjs_PropertyClass_static_optionalProperty_set")
-public func _bjs_PropertyClass_static_optionalProperty_set(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_optionalProperty_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_optionalProperty_set")
+public func _bjs_TestModule_PropertyClass_static_optionalProperty_set(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.optionalProperty = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    TestModule.PropertyClass.optionalProperty = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_deinit")
-@_cdecl("bjs_PropertyClass_deinit")
-public func _bjs_PropertyClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_deinit")
+@_cdecl("bjs_TestModule_PropertyClass_deinit")
+public func _bjs_TestModule_PropertyClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PropertyClass>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.PropertyClass>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PropertyClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.PropertyClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PropertyClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_PropertyClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PropertyClass_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_PropertyClass_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_PropertyClass_wrap")
-fileprivate func _bjs_PropertyClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_PropertyClass_wrap")
+fileprivate func _bjs_TestModule_PropertyClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PropertyClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_PropertyClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PropertyClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PropertyClass_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_PropertyClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_PropertyClass_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_PropertyClass_init",
+          "abiName" : "bjs_TestModule_PropertyClass_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -27,7 +27,7 @@
             "name" : "staticConstant",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -42,7 +42,7 @@
             "name" : "staticVariable",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -60,7 +60,7 @@
             "name" : "jsObjectProperty",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -75,7 +75,7 @@
             "name" : "classVariable",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -90,7 +90,7 @@
             "name" : "computedProperty",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -105,7 +105,7 @@
             "name" : "readOnlyComputed",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -123,7 +123,7 @@
             "name" : "optionalProperty",
             "staticContext" : {
               "className" : {
-                "_0" : "PropertyClass"
+                "_0" : "TestModule_PropertyClass"
               }
             },
             "type" : {
@@ -138,7 +138,7 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyClass"
+        "swiftCallName" : "TestModule.PropertyClass"
       }
     ],
     "enums" : [
@@ -169,7 +169,7 @@
             "name" : "enumProperty",
             "staticContext" : {
               "enumName" : {
-                "_0" : "PropertyEnum"
+                "_0" : "TestModule.PropertyEnum"
               }
             },
             "type" : {
@@ -184,7 +184,7 @@
             "name" : "enumConstant",
             "staticContext" : {
               "enumName" : {
-                "_0" : "PropertyEnum"
+                "_0" : "TestModule.PropertyEnum"
               }
             },
             "type" : {
@@ -202,7 +202,7 @@
             "name" : "computedEnum",
             "staticContext" : {
               "enumName" : {
-                "_0" : "PropertyEnum"
+                "_0" : "TestModule.PropertyEnum"
               }
             },
             "type" : {
@@ -212,7 +212,7 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyEnum",
+        "swiftCallName" : "TestModule.PropertyEnum",
         "tsFullPath" : "PropertyEnum"
       },
       {
@@ -234,7 +234,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace"
+                "_0" : "TestModule.PropertyNamespace"
               }
             },
             "type" : {
@@ -252,7 +252,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace"
+                "_0" : "TestModule.PropertyNamespace"
               }
             },
             "type" : {
@@ -262,7 +262,7 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyNamespace",
+        "swiftCallName" : "TestModule.PropertyNamespace",
         "tsFullPath" : "PropertyNamespace"
       },
       {
@@ -288,7 +288,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace.Nested"
+                "_0" : "TestModule.PropertyNamespace.Nested"
               }
             },
             "type" : {
@@ -310,7 +310,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace.Nested"
+                "_0" : "TestModule.PropertyNamespace.Nested"
               }
             },
             "type" : {
@@ -329,7 +329,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "PropertyNamespace.Nested"
+                "_0" : "TestModule.PropertyNamespace.Nested"
               }
             },
             "type" : {
@@ -339,7 +339,7 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyNamespace.Nested",
+        "swiftCallName" : "TestModule.PropertyNamespace.Nested",
         "tsFullPath" : "PropertyNamespace.Nested"
       }
     ],

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StaticProperties.swift
@@ -1,12 +1,12 @@
-extension PropertyEnum: _BridgedSwiftCaseEnum {
+extension TestModule.PropertyEnum: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> PropertyEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.PropertyEnum {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> PropertyEnum {
-        return PropertyEnum(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.PropertyEnum {
+        return TestModule.PropertyEnum(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -33,309 +33,309 @@ extension PropertyEnum: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_enumProperty_get")
-@_cdecl("bjs_PropertyEnum_static_enumProperty_get")
-public func _bjs_PropertyEnum_static_enumProperty_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_enumProperty_get")
+@_cdecl("bjs_TestModule_PropertyEnum_static_enumProperty_get")
+public func _bjs_TestModule_PropertyEnum_static_enumProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyEnum.enumProperty
+    let ret = TestModule.PropertyEnum.enumProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_enumProperty_set")
-@_cdecl("bjs_PropertyEnum_static_enumProperty_set")
-public func _bjs_PropertyEnum_static_enumProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_enumProperty_set")
+@_cdecl("bjs_TestModule_PropertyEnum_static_enumProperty_set")
+public func _bjs_TestModule_PropertyEnum_static_enumProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyEnum.enumProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyEnum.enumProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_enumConstant_get")
-@_cdecl("bjs_PropertyEnum_static_enumConstant_get")
-public func _bjs_PropertyEnum_static_enumConstant_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_enumConstant_get")
+@_cdecl("bjs_TestModule_PropertyEnum_static_enumConstant_get")
+public func _bjs_TestModule_PropertyEnum_static_enumConstant_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyEnum.enumConstant
+    let ret = TestModule.PropertyEnum.enumConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_computedEnum_get")
-@_cdecl("bjs_PropertyEnum_static_computedEnum_get")
-public func _bjs_PropertyEnum_static_computedEnum_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_computedEnum_get")
+@_cdecl("bjs_TestModule_PropertyEnum_static_computedEnum_get")
+public func _bjs_TestModule_PropertyEnum_static_computedEnum_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyEnum.computedEnum
+    let ret = TestModule.PropertyEnum.computedEnum
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyEnum_static_computedEnum_set")
-@_cdecl("bjs_PropertyEnum_static_computedEnum_set")
-public func _bjs_PropertyEnum_static_computedEnum_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyEnum_static_computedEnum_set")
+@_cdecl("bjs_TestModule_PropertyEnum_static_computedEnum_set")
+public func _bjs_TestModule_PropertyEnum_static_computedEnum_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyEnum.computedEnum = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyEnum.computedEnum = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_static_namespaceProperty_get")
-@_cdecl("bjs_PropertyNamespace_static_namespaceProperty_get")
-public func _bjs_PropertyNamespace_static_namespaceProperty_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_static_namespaceProperty_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_static_namespaceProperty_get")
+public func _bjs_TestModule_PropertyNamespace_static_namespaceProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyNamespace.namespaceProperty
+    let ret = TestModule.PropertyNamespace.namespaceProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_static_namespaceProperty_set")
-@_cdecl("bjs_PropertyNamespace_static_namespaceProperty_set")
-public func _bjs_PropertyNamespace_static_namespaceProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_static_namespaceProperty_set")
+@_cdecl("bjs_TestModule_PropertyNamespace_static_namespaceProperty_set")
+public func _bjs_TestModule_PropertyNamespace_static_namespaceProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyNamespace.namespaceProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyNamespace.namespaceProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_static_namespaceConstant_get")
-@_cdecl("bjs_PropertyNamespace_static_namespaceConstant_get")
-public func _bjs_PropertyNamespace_static_namespaceConstant_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_static_namespaceConstant_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_static_namespaceConstant_get")
+public func _bjs_TestModule_PropertyNamespace_static_namespaceConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyNamespace.namespaceConstant
+    let ret = TestModule.PropertyNamespace.namespaceConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedProperty_get")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedProperty_get")
-public func _bjs_PropertyNamespace_Nested_static_nestedProperty_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_get")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyNamespace.Nested.nestedProperty
+    let ret = TestModule.PropertyNamespace.Nested.nestedProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedProperty_set")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedProperty_set")
-public func _bjs_PropertyNamespace_Nested_static_nestedProperty_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_set")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_set")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyNamespace.Nested.nestedProperty = Int.bridgeJSLiftParameter(value)
+    TestModule.PropertyNamespace.Nested.nestedProperty = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedConstant_get")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedConstant_get")
-public func _bjs_PropertyNamespace_Nested_static_nestedConstant_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedConstant_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedConstant_get")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyNamespace.Nested.nestedConstant
+    let ret = TestModule.PropertyNamespace.Nested.nestedConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedDouble_get")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedDouble_get")
-public func _bjs_PropertyNamespace_Nested_static_nestedDouble_get() -> Float64 {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_get")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_get")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_get() -> Float64 {
     #if arch(wasm32)
-    let ret = PropertyNamespace.Nested.nestedDouble
+    let ret = TestModule.PropertyNamespace.Nested.nestedDouble
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyNamespace_Nested_static_nestedDouble_set")
-@_cdecl("bjs_PropertyNamespace_Nested_static_nestedDouble_set")
-public func _bjs_PropertyNamespace_Nested_static_nestedDouble_set(_ value: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_set")
+@_cdecl("bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_set")
+public func _bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_set(_ value: Float64) -> Void {
     #if arch(wasm32)
-    PropertyNamespace.Nested.nestedDouble = Double.bridgeJSLiftParameter(value)
+    TestModule.PropertyNamespace.Nested.nestedDouble = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_init")
-@_cdecl("bjs_PropertyClass_init")
-public func _bjs_PropertyClass_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_PropertyClass_init")
+@_cdecl("bjs_TestModule_PropertyClass_init")
+public func _bjs_TestModule_PropertyClass_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PropertyClass()
+    let ret = TestModule.PropertyClass()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_staticConstant_get")
-@_cdecl("bjs_PropertyClass_static_staticConstant_get")
-public func _bjs_PropertyClass_static_staticConstant_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_staticConstant_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_staticConstant_get")
+public func _bjs_TestModule_PropertyClass_static_staticConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyClass.staticConstant
+    let ret = TestModule.PropertyClass.staticConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_staticVariable_get")
-@_cdecl("bjs_PropertyClass_static_staticVariable_get")
-public func _bjs_PropertyClass_static_staticVariable_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_staticVariable_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_staticVariable_get")
+public func _bjs_TestModule_PropertyClass_static_staticVariable_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyClass.staticVariable
+    let ret = TestModule.PropertyClass.staticVariable
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_staticVariable_set")
-@_cdecl("bjs_PropertyClass_static_staticVariable_set")
-public func _bjs_PropertyClass_static_staticVariable_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_staticVariable_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_staticVariable_set")
+public func _bjs_TestModule_PropertyClass_static_staticVariable_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.staticVariable = Int.bridgeJSLiftParameter(value)
+    TestModule.PropertyClass.staticVariable = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_jsObjectProperty_get")
-@_cdecl("bjs_PropertyClass_static_jsObjectProperty_get")
-public func _bjs_PropertyClass_static_jsObjectProperty_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_jsObjectProperty_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_jsObjectProperty_get")
+public func _bjs_TestModule_PropertyClass_static_jsObjectProperty_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyClass.jsObjectProperty
+    let ret = TestModule.PropertyClass.jsObjectProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_jsObjectProperty_set")
-@_cdecl("bjs_PropertyClass_static_jsObjectProperty_set")
-public func _bjs_PropertyClass_static_jsObjectProperty_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_jsObjectProperty_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_jsObjectProperty_set")
+public func _bjs_TestModule_PropertyClass_static_jsObjectProperty_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.jsObjectProperty = JSObject.bridgeJSLiftParameter(value)
+    TestModule.PropertyClass.jsObjectProperty = JSObject.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_classVariable_get")
-@_cdecl("bjs_PropertyClass_static_classVariable_get")
-public func _bjs_PropertyClass_static_classVariable_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_classVariable_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_classVariable_get")
+public func _bjs_TestModule_PropertyClass_static_classVariable_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyClass.classVariable
+    let ret = TestModule.PropertyClass.classVariable
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_classVariable_set")
-@_cdecl("bjs_PropertyClass_static_classVariable_set")
-public func _bjs_PropertyClass_static_classVariable_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_classVariable_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_classVariable_set")
+public func _bjs_TestModule_PropertyClass_static_classVariable_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.classVariable = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyClass.classVariable = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_computedProperty_get")
-@_cdecl("bjs_PropertyClass_static_computedProperty_get")
-public func _bjs_PropertyClass_static_computedProperty_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_computedProperty_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_computedProperty_get")
+public func _bjs_TestModule_PropertyClass_static_computedProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyClass.computedProperty
+    let ret = TestModule.PropertyClass.computedProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_computedProperty_set")
-@_cdecl("bjs_PropertyClass_static_computedProperty_set")
-public func _bjs_PropertyClass_static_computedProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_computedProperty_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_computedProperty_set")
+public func _bjs_TestModule_PropertyClass_static_computedProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.computedProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.PropertyClass.computedProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_readOnlyComputed_get")
-@_cdecl("bjs_PropertyClass_static_readOnlyComputed_get")
-public func _bjs_PropertyClass_static_readOnlyComputed_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_readOnlyComputed_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_readOnlyComputed_get")
+public func _bjs_TestModule_PropertyClass_static_readOnlyComputed_get() -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyClass.readOnlyComputed
+    let ret = TestModule.PropertyClass.readOnlyComputed
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_optionalProperty_get")
-@_cdecl("bjs_PropertyClass_static_optionalProperty_get")
-public func _bjs_PropertyClass_static_optionalProperty_get() -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_optionalProperty_get")
+@_cdecl("bjs_TestModule_PropertyClass_static_optionalProperty_get")
+public func _bjs_TestModule_PropertyClass_static_optionalProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = PropertyClass.optionalProperty
+    let ret = TestModule.PropertyClass.optionalProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_static_optionalProperty_set")
-@_cdecl("bjs_PropertyClass_static_optionalProperty_set")
-public func _bjs_PropertyClass_static_optionalProperty_set(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_static_optionalProperty_set")
+@_cdecl("bjs_TestModule_PropertyClass_static_optionalProperty_set")
+public func _bjs_TestModule_PropertyClass_static_optionalProperty_set(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyClass.optionalProperty = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    TestModule.PropertyClass.optionalProperty = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyClass_deinit")
-@_cdecl("bjs_PropertyClass_deinit")
-public func _bjs_PropertyClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PropertyClass_deinit")
+@_cdecl("bjs_TestModule_PropertyClass_deinit")
+public func _bjs_TestModule_PropertyClass_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PropertyClass>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.PropertyClass>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PropertyClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.PropertyClass: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PropertyClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_PropertyClass_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PropertyClass_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_PropertyClass_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_PropertyClass_wrap")
-fileprivate func _bjs_PropertyClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_PropertyClass_wrap")
+fileprivate func _bjs_TestModule_PropertyClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PropertyClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_PropertyClass_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PropertyClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PropertyClass_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_PropertyClass_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_PropertyClass_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringParameter.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringParameter.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_checkString",
+        "abiName" : "bjs_TestModule_checkString",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -37,7 +37,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripString",
+        "abiName" : "bjs_TestModule_roundtripString",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringParameter.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringParameter.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_checkString")
-@_cdecl("bjs_checkString")
-public func _bjs_checkString(_ aBytes: Int32, _ aLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_checkString")
+@_cdecl("bjs_TestModule_checkString")
+public func _bjs_TestModule_checkString(_ aBytes: Int32, _ aLength: Int32) -> Void {
     #if arch(wasm32)
     checkString(a: String.bridgeJSLiftParameter(aBytes, aLength))
     #else
@@ -8,9 +8,9 @@ public func _bjs_checkString(_ aBytes: Int32, _ aLength: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripString")
-@_cdecl("bjs_roundtripString")
-public func _bjs_roundtripString(_ aBytes: Int32, _ aLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_roundtripString")
+@_cdecl("bjs_TestModule_roundtripString")
+public func _bjs_TestModule_roundtripString(_ aBytes: Int32, _ aLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundtripString(a: String.bridgeJSLiftParameter(aBytes, aLength))
     return ret.bridgeJSLowerReturn()

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringReturn.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_checkString",
+        "abiName" : "bjs_TestModule_checkString",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StringReturn.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_checkString")
-@_cdecl("bjs_checkString")
-public func _bjs_checkString() -> Void {
+@_expose(wasm, "bjs_TestModule_checkString")
+@_cdecl("bjs_TestModule_checkString")
+public func _bjs_TestModule_checkString() -> Void {
     #if arch(wasm32)
     let ret = checkString()
     return ret.bridgeJSLowerReturn()

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StructWithNestedTypes.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StructWithNestedTypes.json
@@ -34,7 +34,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Shape.Kind",
+        "swiftCallName" : "TestModule.Shape.Kind",
         "tsFullPath" : "Shape.Kind"
       },
       {
@@ -64,7 +64,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Widget.Variant",
+        "swiftCallName" : "TestModule.Widget.Variant",
         "tsFullPath" : "Widget.Variant"
       },
       {
@@ -95,7 +95,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Widget.Layout.Alignment",
+        "swiftCallName" : "TestModule.Widget.Layout.Alignment",
         "tsFullPath" : "Widget.Layout.Alignment"
       }
     ],
@@ -109,7 +109,7 @@
     "structs" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Shape_init",
+          "abiName" : "bjs_TestModule_Shape_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -143,11 +143,11 @@
             }
           }
         ],
-        "swiftCallName" : "Shape"
+        "swiftCallName" : "TestModule.Shape"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Widget_init",
+          "abiName" : "bjs_TestModule_Widget_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -181,7 +181,7 @@
             }
           }
         ],
-        "swiftCallName" : "Widget"
+        "swiftCallName" : "TestModule.Widget"
       },
       {
         "methods" : [
@@ -209,11 +209,11 @@
             }
           }
         ],
-        "swiftCallName" : "Widget.Layout"
+        "swiftCallName" : "TestModule.Widget.Layout"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Widget_Bounds_init",
+          "abiName" : "bjs_TestModule_Widget_Bounds_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -248,7 +248,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Widget_Bounds_static_zero",
+            "abiName" : "bjs_TestModule_Widget_Bounds_static_zero",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -260,12 +260,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Widget.Bounds"
+                "_0" : "TestModule.Widget.Bounds"
               }
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "Widget_Bounds"
+                "_0" : "TestModule_Widget_Bounds"
               }
             }
           }
@@ -313,7 +313,7 @@
             "name" : "dimensions",
             "staticContext" : {
               "structName" : {
-                "_0" : "Widget_Bounds"
+                "_0" : "TestModule_Widget_Bounds"
               }
             },
             "type" : {
@@ -326,7 +326,7 @@
             }
           }
         ],
-        "swiftCallName" : "Widget.Bounds"
+        "swiftCallName" : "TestModule.Widget.Bounds"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StructWithNestedTypes.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/StructWithNestedTypes.swift
@@ -1,16 +1,16 @@
-extension Shape.Kind: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Shape.Kind: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Widget.Variant: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Widget.Variant: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Widget.Layout.Alignment: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Widget.Layout.Alignment: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Shape: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Shape {
+extension TestModule.Shape: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Shape {
         let label = String.bridgeJSStackPop()
-        return Shape(label: label)
+        return TestModule.Shape(label: label)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -18,56 +18,56 @@ extension Shape: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Shape(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Shape(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Shape()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Shape()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Shape")
-fileprivate func _bjs_struct_lower_Shape_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Shape")
+fileprivate func _bjs_struct_lower_TestModule_Shape_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Shape_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Shape_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Shape(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Shape_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Shape(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Shape_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Shape")
-fileprivate func _bjs_struct_lift_Shape_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Shape")
+fileprivate func _bjs_struct_lift_TestModule_Shape_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Shape_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Shape_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Shape() -> Int32 {
-    return _bjs_struct_lift_Shape_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Shape() -> Int32 {
+    return _bjs_struct_lift_TestModule_Shape_extern()
 }
 
-@_expose(wasm, "bjs_Shape_init")
-@_cdecl("bjs_Shape_init")
-public func _bjs_Shape_init(_ labelBytes: Int32, _ labelLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Shape_init")
+@_cdecl("bjs_TestModule_Shape_init")
+public func _bjs_TestModule_Shape_init(_ labelBytes: Int32, _ labelLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Shape(label: String.bridgeJSLiftParameter(labelBytes, labelLength))
+    let ret = TestModule.Shape(label: String.bridgeJSLiftParameter(labelBytes, labelLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Widget: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Widget {
+extension TestModule.Widget: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Widget {
         let name = String.bridgeJSStackPop()
-        return Widget(name: name)
+        return TestModule.Widget(name: name)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -75,56 +75,56 @@ extension Widget: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Widget(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Widget(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Widget()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Widget()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Widget")
-fileprivate func _bjs_struct_lower_Widget_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Widget")
+fileprivate func _bjs_struct_lower_TestModule_Widget_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Widget_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Widget_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Widget(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Widget_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Widget(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Widget_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Widget")
-fileprivate func _bjs_struct_lift_Widget_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Widget")
+fileprivate func _bjs_struct_lift_TestModule_Widget_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Widget_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Widget_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Widget() -> Int32 {
-    return _bjs_struct_lift_Widget_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Widget() -> Int32 {
+    return _bjs_struct_lift_TestModule_Widget_extern()
 }
 
-@_expose(wasm, "bjs_Widget_init")
-@_cdecl("bjs_Widget_init")
-public func _bjs_Widget_init(_ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Widget_init")
+@_cdecl("bjs_TestModule_Widget_init")
+public func _bjs_TestModule_Widget_init(_ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Widget(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Widget(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Widget.Layout: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Widget.Layout {
+extension TestModule.Widget.Layout: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Widget.Layout {
         let padding = Int.bridgeJSStackPop()
-        return Widget.Layout(padding: padding)
+        return TestModule.Widget.Layout(padding: padding)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -132,46 +132,46 @@ extension Widget.Layout: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Widget_Layout(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Widget_Layout(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Widget_Layout()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Widget_Layout()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Widget_Layout")
-fileprivate func _bjs_struct_lower_Widget_Layout_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Widget_Layout")
+fileprivate func _bjs_struct_lower_TestModule_Widget_Layout_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Widget_Layout_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Widget_Layout_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Widget_Layout(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Widget_Layout_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Widget_Layout(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Widget_Layout_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Widget_Layout")
-fileprivate func _bjs_struct_lift_Widget_Layout_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Widget_Layout")
+fileprivate func _bjs_struct_lift_TestModule_Widget_Layout_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Widget_Layout_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Widget_Layout_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Widget_Layout() -> Int32 {
-    return _bjs_struct_lift_Widget_Layout_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Widget_Layout() -> Int32 {
+    return _bjs_struct_lift_TestModule_Widget_Layout_extern()
 }
 
-extension Widget.Bounds: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Widget.Bounds {
+extension TestModule.Widget.Bounds: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Widget.Bounds {
         let height = Int.bridgeJSStackPop()
         let width = Int.bridgeJSStackPop()
-        return Widget.Bounds(width: width, height: height)
+        return TestModule.Widget.Bounds(width: width, height: height)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -180,68 +180,68 @@ extension Widget.Bounds: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Widget_Bounds(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Widget_Bounds(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Widget_Bounds()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Widget_Bounds()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Widget_Bounds")
-fileprivate func _bjs_struct_lower_Widget_Bounds_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Widget_Bounds")
+fileprivate func _bjs_struct_lower_TestModule_Widget_Bounds_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Widget_Bounds_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Widget_Bounds_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Widget_Bounds(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Widget_Bounds_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Widget_Bounds(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Widget_Bounds_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Widget_Bounds")
-fileprivate func _bjs_struct_lift_Widget_Bounds_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Widget_Bounds")
+fileprivate func _bjs_struct_lift_TestModule_Widget_Bounds_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Widget_Bounds_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Widget_Bounds_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Widget_Bounds() -> Int32 {
-    return _bjs_struct_lift_Widget_Bounds_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Widget_Bounds() -> Int32 {
+    return _bjs_struct_lift_TestModule_Widget_Bounds_extern()
 }
 
-@_expose(wasm, "bjs_Widget_Bounds_init")
-@_cdecl("bjs_Widget_Bounds_init")
-public func _bjs_Widget_Bounds_init(_ width: Int32, _ height: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Widget_Bounds_init")
+@_cdecl("bjs_TestModule_Widget_Bounds_init")
+public func _bjs_TestModule_Widget_Bounds_init(_ width: Int32, _ height: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Widget.Bounds(width: Int.bridgeJSLiftParameter(width), height: Int.bridgeJSLiftParameter(height))
+    let ret = TestModule.Widget.Bounds(width: Int.bridgeJSLiftParameter(width), height: Int.bridgeJSLiftParameter(height))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Widget_Bounds_static_dimensions_get")
-@_cdecl("bjs_Widget_Bounds_static_dimensions_get")
-public func _bjs_Widget_Bounds_static_dimensions_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_Widget_Bounds_static_dimensions_get")
+@_cdecl("bjs_TestModule_Widget_Bounds_static_dimensions_get")
+public func _bjs_TestModule_Widget_Bounds_static_dimensions_get() -> Int32 {
     #if arch(wasm32)
-    let ret = Widget.Bounds.dimensions
+    let ret = TestModule.Widget.Bounds.dimensions
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Widget_Bounds_static_zero")
-@_cdecl("bjs_Widget_Bounds_static_zero")
-public func _bjs_Widget_Bounds_static_zero() -> Void {
+@_expose(wasm, "bjs_TestModule_Widget_Bounds_static_zero")
+@_cdecl("bjs_TestModule_Widget_Bounds_static_zero")
+public func _bjs_TestModule_Widget_Bounds_static_zero() -> Void {
     #if arch(wasm32)
-    let ret = Widget.Bounds.zero()
+    let ret = TestModule.Widget.Bounds.zero()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClass.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClass.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Greeter_init",
+          "abiName" : "bjs_TestModule_Greeter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -26,7 +26,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Greeter_greet",
+            "abiName" : "bjs_TestModule_Greeter_greet",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -43,7 +43,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_changeName",
+            "abiName" : "bjs_TestModule_Greeter_changeName",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -68,7 +68,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_greetEnthusiastically",
+            "abiName" : "bjs_TestModule_Greeter_greetEnthusiastically",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -85,7 +85,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_static_greetAnonymously",
+            "abiName" : "bjs_TestModule_Greeter_static_greetAnonymously",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -102,7 +102,7 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "Greeter"
+                "_0" : "TestModule_Greeter"
               }
             }
           }
@@ -138,7 +138,7 @@
             "name" : "defaultGreeting",
             "staticContext" : {
               "className" : {
-                "_0" : "Greeter"
+                "_0" : "TestModule_Greeter"
               }
             },
             "type" : {
@@ -148,7 +148,7 @@
             }
           }
         ],
-        "swiftCallName" : "Greeter"
+        "swiftCallName" : "TestModule.Greeter"
       },
       {
         "explicitAccessControl" : "public",
@@ -159,7 +159,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PublicGreeter"
+        "swiftCallName" : "TestModule.PublicGreeter"
       },
       {
         "explicitAccessControl" : "package",
@@ -170,7 +170,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PackageGreeter"
+        "swiftCallName" : "TestModule.PackageGreeter"
       }
     ],
     "enums" : [
@@ -179,7 +179,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_takeGreeter",
+        "abiName" : "bjs_TestModule_takeGreeter",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -192,7 +192,7 @@
             "name" : "greeter",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "TestModule.Greeter"
               }
             }
           }
@@ -228,14 +228,14 @@
                 "name" : "greeter",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "TestModule.Greeter"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "TestModule.Greeter"
               }
             }
           },
@@ -254,7 +254,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "TestModule.Greeter"
                       }
                     },
                     "_1" : "null"
@@ -266,7 +266,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "TestModule.Greeter"
                   }
                 },
                 "_1" : "null"

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClass.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClass.swift
@@ -1,201 +1,201 @@
-@_expose(wasm, "bjs_takeGreeter")
-@_cdecl("bjs_takeGreeter")
-public func _bjs_takeGreeter(_ greeter: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_takeGreeter")
+@_cdecl("bjs_TestModule_takeGreeter")
+public func _bjs_TestModule_takeGreeter(_ greeter: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    takeGreeter(greeter: Greeter.bridgeJSLiftParameter(greeter))
+    takeGreeter(greeter: TestModule.Greeter.bridgeJSLiftParameter(greeter))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_init")
-@_cdecl("bjs_Greeter_init")
-public func _bjs_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Greeter_init")
+@_cdecl("bjs_TestModule_Greeter_init")
+public func _bjs_TestModule_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greet")
-@_cdecl("bjs_Greeter_greet")
-public func _bjs_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_greet")
+@_cdecl("bjs_TestModule_Greeter_greet")
+public func _bjs_TestModule_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greet()
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_changeName")
-@_cdecl("bjs_Greeter_changeName")
-public func _bjs_Greeter_changeName(_ _self: UnsafeMutableRawPointer, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_changeName")
+@_cdecl("bjs_TestModule_Greeter_changeName")
+public func _bjs_TestModule_Greeter_changeName(_ _self: UnsafeMutableRawPointer, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
-    Greeter.bridgeJSLiftParameter(_self).changeName(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    TestModule.Greeter.bridgeJSLiftParameter(_self).changeName(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greetEnthusiastically")
-@_cdecl("bjs_Greeter_greetEnthusiastically")
-public func _bjs_Greeter_greetEnthusiastically(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_greetEnthusiastically")
+@_cdecl("bjs_TestModule_Greeter_greetEnthusiastically")
+public func _bjs_TestModule_Greeter_greetEnthusiastically(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greetEnthusiastically()
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).greetEnthusiastically()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_static_greetAnonymously")
-@_cdecl("bjs_Greeter_static_greetAnonymously")
-public func _bjs_Greeter_static_greetAnonymously() -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_static_greetAnonymously")
+@_cdecl("bjs_TestModule_Greeter_static_greetAnonymously")
+public func _bjs_TestModule_Greeter_static_greetAnonymously() -> Void {
     #if arch(wasm32)
-    let ret = Greeter.greetAnonymously()
+    let ret = TestModule.Greeter.greetAnonymously()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_get")
-@_cdecl("bjs_Greeter_name_get")
-public func _bjs_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_name_get")
+@_cdecl("bjs_TestModule_Greeter_name_get")
+public func _bjs_TestModule_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).name
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_set")
-@_cdecl("bjs_Greeter_name_set")
-public func _bjs_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_name_set")
+@_cdecl("bjs_TestModule_Greeter_name_set")
+public func _bjs_TestModule_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    Greeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.Greeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_nameCount_get")
-@_cdecl("bjs_Greeter_nameCount_get")
-public func _bjs_Greeter_nameCount_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_TestModule_Greeter_nameCount_get")
+@_cdecl("bjs_TestModule_Greeter_nameCount_get")
+public func _bjs_TestModule_Greeter_nameCount_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).nameCount
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).nameCount
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_static_defaultGreeting_get")
-@_cdecl("bjs_Greeter_static_defaultGreeting_get")
-public func _bjs_Greeter_static_defaultGreeting_get() -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_static_defaultGreeting_get")
+@_cdecl("bjs_TestModule_Greeter_static_defaultGreeting_get")
+public func _bjs_TestModule_Greeter_static_defaultGreeting_get() -> Void {
     #if arch(wasm32)
-    let ret = Greeter.defaultGreeting
+    let ret = TestModule.Greeter.defaultGreeting
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_deinit")
-@_cdecl("bjs_Greeter_deinit")
-public func _bjs_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_deinit")
+@_cdecl("bjs_TestModule_Greeter_deinit")
+public func _bjs_TestModule_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Greeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Greeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Greeter_wrap")
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Greeter_wrap")
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Greeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Greeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_PublicGreeter_deinit")
-@_cdecl("bjs_PublicGreeter_deinit")
-public func _bjs_PublicGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PublicGreeter_deinit")
+@_cdecl("bjs_TestModule_PublicGreeter_deinit")
+public func _bjs_TestModule_PublicGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PublicGreeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.PublicGreeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PublicGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.PublicGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     public var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PublicGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_PublicGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     public consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PublicGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_PublicGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_PublicGreeter_wrap")
-fileprivate func _bjs_PublicGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_PublicGreeter_wrap")
+fileprivate func _bjs_TestModule_PublicGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PublicGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_PublicGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PublicGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PublicGreeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_PublicGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_PublicGreeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_PackageGreeter_deinit")
-@_cdecl("bjs_PackageGreeter_deinit")
-public func _bjs_PackageGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PackageGreeter_deinit")
+@_cdecl("bjs_TestModule_PackageGreeter_deinit")
+public func _bjs_TestModule_PackageGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PackageGreeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.PackageGreeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PackageGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.PackageGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     package var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PackageGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_PackageGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     package consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PackageGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_PackageGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_PackageGreeter_wrap")
-fileprivate func _bjs_PackageGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_PackageGreeter_wrap")
+fileprivate func _bjs_TestModule_PackageGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PackageGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_PackageGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PackageGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PackageGreeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_PackageGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_PackageGreeter_wrap_extern(pointer)
 }
 
 #if arch(wasm32)
@@ -210,13 +210,13 @@ fileprivate func bjs_jsRoundTripGreeter_extern(_ greeter: UnsafeMutableRawPointe
     return bjs_jsRoundTripGreeter_extern(greeter)
 }
 
-func _$jsRoundTripGreeter(_ greeter: Greeter) throws(JSException) -> Greeter {
+func _$jsRoundTripGreeter(_ greeter: TestModule.Greeter) throws(JSException) -> TestModule.Greeter {
     let greeterPointer = greeter.bridgeJSLowerParameter()
     let ret = bjs_jsRoundTripGreeter(greeterPointer)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Greeter.bridgeJSLiftReturn(ret)
+    return TestModule.Greeter.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)
@@ -231,11 +231,11 @@ fileprivate func bjs_jsRoundTripOptionalGreeter_extern(_ greeterIsSome: Int32, _
     return bjs_jsRoundTripOptionalGreeter_extern(greeterIsSome, greeterPointer)
 }
 
-func _$jsRoundTripOptionalGreeter(_ greeter: Optional<Greeter>) throws(JSException) -> Optional<Greeter> {
+func _$jsRoundTripOptionalGreeter(_ greeter: Optional<TestModule.Greeter>) throws(JSException) -> Optional<TestModule.Greeter> {
     let (greeterIsSome, greeterPointer) = greeter.bridgeJSLowerParameter()
     let ret = bjs_jsRoundTripOptionalGreeter(greeterIsSome, greeterPointer)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<Greeter>.bridgeJSLiftReturn(ret)
+    return Optional<TestModule.Greeter>.bridgeJSLiftReturn(ret)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Person_init",
+          "abiName" : "bjs_TestModule_Person_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -32,11 +32,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Person"
+        "swiftCallName" : "TestModule.Person"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_TestProcessor_init",
+          "abiName" : "bjs_TestModule_TestProcessor_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -80,7 +80,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "TestProcessor"
+        "swiftCallName" : "TestModule.TestProcessor"
       }
     ],
     "enums" : [
@@ -119,7 +119,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Direction",
+        "swiftCallName" : "TestModule.Direction",
         "tsFullPath" : "Direction"
       },
       {
@@ -155,7 +155,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Theme",
+        "swiftCallName" : "TestModule.Theme",
         "tsFullPath" : "Theme"
       },
       {
@@ -198,7 +198,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "HttpStatus",
+        "swiftCallName" : "TestModule.HttpStatus",
         "tsFullPath" : "HttpStatus"
       },
       {
@@ -281,14 +281,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "APIResult",
+        "swiftCallName" : "TestModule.APIResult",
         "tsFullPath" : "APIResult"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_roundtripAnimal",
+        "abiName" : "bjs_TestModule_roundtripAnimal",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -304,18 +304,18 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModule6AnimalV_6AnimalV",
+                  "mangleName" : "10TestModule17TestModule_AnimalV_17TestModule_AnimalV",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "swiftStruct" : {
-                        "_0" : "Animal"
+                        "_0" : "TestModule.Animal"
                       }
                     }
                   ],
                   "returnType" : {
                     "swiftStruct" : {
-                      "_0" : "Animal"
+                      "_0" : "TestModule.Animal"
                     }
                   },
                   "sendingParameters" : false
@@ -330,18 +330,18 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModule6AnimalV_6AnimalV",
+              "mangleName" : "10TestModule17TestModule_AnimalV_17TestModule_AnimalV",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "swiftStruct" : {
-                    "_0" : "Animal"
+                    "_0" : "TestModule.Animal"
                   }
                 }
               ],
               "returnType" : {
                 "swiftStruct" : {
-                  "_0" : "Animal"
+                  "_0" : "TestModule.Animal"
                 }
               },
               "sendingParameters" : false
@@ -351,7 +351,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalAnimal",
+        "abiName" : "bjs_TestModule_roundtripOptionalAnimal",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -367,14 +367,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModuleSq6AnimalV_Sq6AnimalV",
+                  "mangleName" : "10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "nullable" : {
                         "_0" : {
                           "swiftStruct" : {
-                            "_0" : "Animal"
+                            "_0" : "TestModule.Animal"
                           }
                         },
                         "_1" : "null"
@@ -385,7 +385,7 @@
                     "nullable" : {
                       "_0" : {
                         "swiftStruct" : {
-                          "_0" : "Animal"
+                          "_0" : "TestModule.Animal"
                         }
                       },
                       "_1" : "null"
@@ -403,14 +403,14 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuleSq6AnimalV_Sq6AnimalV",
+              "mangleName" : "10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "nullable" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Animal"
+                        "_0" : "TestModule.Animal"
                       }
                     },
                     "_1" : "null"
@@ -421,7 +421,7 @@
                 "nullable" : {
                   "_0" : {
                     "swiftStruct" : {
-                      "_0" : "Animal"
+                      "_0" : "TestModule.Animal"
                     }
                   },
                   "_1" : "null"
@@ -434,7 +434,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripString",
+        "abiName" : "bjs_TestModule_roundtripString",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -497,7 +497,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripInt",
+        "abiName" : "bjs_TestModule_roundtripInt",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -572,7 +572,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripBool",
+        "abiName" : "bjs_TestModule_roundtripBool",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -635,7 +635,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripFloat",
+        "abiName" : "bjs_TestModule_roundtripFloat",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -698,7 +698,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripDouble",
+        "abiName" : "bjs_TestModule_roundtripDouble",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -761,7 +761,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalString",
+        "abiName" : "bjs_TestModule_roundtripOptionalString",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -844,7 +844,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalInt",
+        "abiName" : "bjs_TestModule_roundtripOptionalInt",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -939,7 +939,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalBool",
+        "abiName" : "bjs_TestModule_roundtripOptionalBool",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1022,7 +1022,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalFloat",
+        "abiName" : "bjs_TestModule_roundtripOptionalFloat",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1105,7 +1105,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalDouble",
+        "abiName" : "bjs_TestModule_roundtripOptionalDouble",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1188,7 +1188,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripPerson",
+        "abiName" : "bjs_TestModule_roundtripPerson",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1204,18 +1204,18 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModule6PersonC_6PersonC",
+                  "mangleName" : "10TestModule17TestModule_PersonC_17TestModule_PersonC",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "swiftHeapObject" : {
-                        "_0" : "Person"
+                        "_0" : "TestModule.Person"
                       }
                     }
                   ],
                   "returnType" : {
                     "swiftHeapObject" : {
-                      "_0" : "Person"
+                      "_0" : "TestModule.Person"
                     }
                   },
                   "sendingParameters" : false
@@ -1230,18 +1230,18 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModule6PersonC_6PersonC",
+              "mangleName" : "10TestModule17TestModule_PersonC_17TestModule_PersonC",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "swiftHeapObject" : {
-                    "_0" : "Person"
+                    "_0" : "TestModule.Person"
                   }
                 }
               ],
               "returnType" : {
                 "swiftHeapObject" : {
-                  "_0" : "Person"
+                  "_0" : "TestModule.Person"
                 }
               },
               "sendingParameters" : false
@@ -1251,7 +1251,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalPerson",
+        "abiName" : "bjs_TestModule_roundtripOptionalPerson",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1267,14 +1267,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModuleSq6PersonC_Sq6PersonC",
+                  "mangleName" : "10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "nullable" : {
                         "_0" : {
                           "swiftHeapObject" : {
-                            "_0" : "Person"
+                            "_0" : "TestModule.Person"
                           }
                         },
                         "_1" : "null"
@@ -1285,7 +1285,7 @@
                     "nullable" : {
                       "_0" : {
                         "swiftHeapObject" : {
-                          "_0" : "Person"
+                          "_0" : "TestModule.Person"
                         }
                       },
                       "_1" : "null"
@@ -1303,14 +1303,14 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuleSq6PersonC_Sq6PersonC",
+              "mangleName" : "10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Person"
+                        "_0" : "TestModule.Person"
                       }
                     },
                     "_1" : "null"
@@ -1321,7 +1321,7 @@
                 "nullable" : {
                   "_0" : {
                     "swiftHeapObject" : {
-                      "_0" : "Person"
+                      "_0" : "TestModule.Person"
                     }
                   },
                   "_1" : "null"
@@ -1334,7 +1334,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeThrowingParser",
+        "abiName" : "bjs_TestModule_makeThrowingParser",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1373,7 +1373,7 @@
         }
       },
       {
-        "abiName" : "bjs_validateWith",
+        "abiName" : "bjs_TestModule_validateWith",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1417,7 +1417,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeFetcher",
+        "abiName" : "bjs_TestModule_makeFetcher",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1453,7 +1453,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeAsyncEcho",
+        "abiName" : "bjs_TestModule_makeAsyncEcho",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1489,7 +1489,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeAnimalLoader",
+        "abiName" : "bjs_TestModule_makeAnimalLoader",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1504,7 +1504,7 @@
             "_0" : {
               "isAsync" : true,
               "isThrows" : false,
-              "mangleName" : "10TestModuleYaSS_6AnimalV",
+              "mangleName" : "10TestModuleYaSS_17TestModule_AnimalV",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
@@ -1515,7 +1515,7 @@
               ],
               "returnType" : {
                 "swiftStruct" : {
-                  "_0" : "Animal"
+                  "_0" : "TestModule.Animal"
                 }
               },
               "sendingParameters" : false
@@ -1525,7 +1525,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeResultLoader",
+        "abiName" : "bjs_TestModule_makeResultLoader",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1540,7 +1540,7 @@
             "_0" : {
               "isAsync" : true,
               "isThrows" : true,
-              "mangleName" : "10TestModuleYaKSb_9APIResultO",
+              "mangleName" : "10TestModuleYaKSb_20TestModule_APIResultO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
@@ -1551,7 +1551,7 @@
               ],
               "returnType" : {
                 "associatedValueEnum" : {
-                  "_0" : "APIResult"
+                  "_0" : "TestModule.APIResult"
                 }
               },
               "sendingParameters" : false
@@ -1561,7 +1561,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripDirection",
+        "abiName" : "bjs_TestModule_roundtripDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1577,18 +1577,18 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModule9DirectionO_9DirectionO",
+                  "mangleName" : "10TestModule20TestModule_DirectionO_20TestModule_DirectionO",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "TestModule.Direction"
                       }
                     }
                   ],
                   "returnType" : {
                     "caseEnum" : {
-                      "_0" : "Direction"
+                      "_0" : "TestModule.Direction"
                     }
                   },
                   "sendingParameters" : false
@@ -1603,18 +1603,18 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModule9DirectionO_9DirectionO",
+              "mangleName" : "10TestModule20TestModule_DirectionO_20TestModule_DirectionO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "TestModule.Direction"
                   }
                 }
               ],
               "returnType" : {
                 "caseEnum" : {
-                  "_0" : "Direction"
+                  "_0" : "TestModule.Direction"
                 }
               },
               "sendingParameters" : false
@@ -1624,7 +1624,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripTheme",
+        "abiName" : "bjs_TestModule_roundtripTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1640,19 +1640,19 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModule5ThemeO_5ThemeO",
+                  "mangleName" : "10TestModule16TestModule_ThemeO_16TestModule_ThemeO",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "rawValueEnum" : {
-                        "_0" : "Theme",
+                        "_0" : "TestModule.Theme",
                         "_1" : "String"
                       }
                     }
                   ],
                   "returnType" : {
                     "rawValueEnum" : {
-                      "_0" : "Theme",
+                      "_0" : "TestModule.Theme",
                       "_1" : "String"
                     }
                   },
@@ -1668,19 +1668,19 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModule5ThemeO_5ThemeO",
+              "mangleName" : "10TestModule16TestModule_ThemeO_16TestModule_ThemeO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "TestModule.Theme",
                     "_1" : "String"
                   }
                 }
               ],
               "returnType" : {
                 "rawValueEnum" : {
-                  "_0" : "Theme",
+                  "_0" : "TestModule.Theme",
                   "_1" : "String"
                 }
               },
@@ -1691,7 +1691,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripHttpStatus",
+        "abiName" : "bjs_TestModule_roundtripHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1707,19 +1707,19 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModule10HttpStatusO_10HttpStatusO",
+                  "mangleName" : "10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "rawValueEnum" : {
-                        "_0" : "HttpStatus",
+                        "_0" : "TestModule.HttpStatus",
                         "_1" : "Int"
                       }
                     }
                   ],
                   "returnType" : {
                     "rawValueEnum" : {
-                      "_0" : "HttpStatus",
+                      "_0" : "TestModule.HttpStatus",
                       "_1" : "Int"
                     }
                   },
@@ -1735,19 +1735,19 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModule10HttpStatusO_10HttpStatusO",
+              "mangleName" : "10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "rawValueEnum" : {
-                    "_0" : "HttpStatus",
+                    "_0" : "TestModule.HttpStatus",
                     "_1" : "Int"
                   }
                 }
               ],
               "returnType" : {
                 "rawValueEnum" : {
-                  "_0" : "HttpStatus",
+                  "_0" : "TestModule.HttpStatus",
                   "_1" : "Int"
                 }
               },
@@ -1758,7 +1758,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripAPIResult",
+        "abiName" : "bjs_TestModule_roundtripAPIResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1774,18 +1774,18 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModule9APIResultO_9APIResultO",
+                  "mangleName" : "10TestModule20TestModule_APIResultO_20TestModule_APIResultO",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "TestModule.APIResult"
                       }
                     }
                   ],
                   "returnType" : {
                     "associatedValueEnum" : {
-                      "_0" : "APIResult"
+                      "_0" : "TestModule.APIResult"
                     }
                   },
                   "sendingParameters" : false
@@ -1800,18 +1800,18 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModule9APIResultO_9APIResultO",
+              "mangleName" : "10TestModule20TestModule_APIResultO_20TestModule_APIResultO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "TestModule.APIResult"
                   }
                 }
               ],
               "returnType" : {
                 "associatedValueEnum" : {
-                  "_0" : "APIResult"
+                  "_0" : "TestModule.APIResult"
                 }
               },
               "sendingParameters" : false
@@ -1821,7 +1821,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalDirection",
+        "abiName" : "bjs_TestModule_roundtripOptionalDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1837,14 +1837,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModuleSq9DirectionO_Sq9DirectionO",
+                  "mangleName" : "10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "nullable" : {
                         "_0" : {
                           "caseEnum" : {
-                            "_0" : "Direction"
+                            "_0" : "TestModule.Direction"
                           }
                         },
                         "_1" : "null"
@@ -1855,7 +1855,7 @@
                     "nullable" : {
                       "_0" : {
                         "caseEnum" : {
-                          "_0" : "Direction"
+                          "_0" : "TestModule.Direction"
                         }
                       },
                       "_1" : "null"
@@ -1873,14 +1873,14 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuleSq9DirectionO_Sq9DirectionO",
+              "mangleName" : "10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "TestModule.Direction"
                       }
                     },
                     "_1" : "null"
@@ -1891,7 +1891,7 @@
                 "nullable" : {
                   "_0" : {
                     "caseEnum" : {
-                      "_0" : "Direction"
+                      "_0" : "TestModule.Direction"
                     }
                   },
                   "_1" : "null"
@@ -1904,7 +1904,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalTheme",
+        "abiName" : "bjs_TestModule_roundtripOptionalTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -1920,14 +1920,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModuleSq5ThemeO_Sq5ThemeO",
+                  "mangleName" : "10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "nullable" : {
                         "_0" : {
                           "rawValueEnum" : {
-                            "_0" : "Theme",
+                            "_0" : "TestModule.Theme",
                             "_1" : "String"
                           }
                         },
@@ -1939,7 +1939,7 @@
                     "nullable" : {
                       "_0" : {
                         "rawValueEnum" : {
-                          "_0" : "Theme",
+                          "_0" : "TestModule.Theme",
                           "_1" : "String"
                         }
                       },
@@ -1958,14 +1958,14 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuleSq5ThemeO_Sq5ThemeO",
+              "mangleName" : "10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "Theme",
+                        "_0" : "TestModule.Theme",
                         "_1" : "String"
                       }
                     },
@@ -1977,7 +1977,7 @@
                 "nullable" : {
                   "_0" : {
                     "rawValueEnum" : {
-                      "_0" : "Theme",
+                      "_0" : "TestModule.Theme",
                       "_1" : "String"
                     }
                   },
@@ -1991,7 +1991,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalHttpStatus",
+        "abiName" : "bjs_TestModule_roundtripOptionalHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -2007,14 +2007,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModuleSq10HttpStatusO_Sq10HttpStatusO",
+                  "mangleName" : "10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "nullable" : {
                         "_0" : {
                           "rawValueEnum" : {
-                            "_0" : "HttpStatus",
+                            "_0" : "TestModule.HttpStatus",
                             "_1" : "Int"
                           }
                         },
@@ -2026,7 +2026,7 @@
                     "nullable" : {
                       "_0" : {
                         "rawValueEnum" : {
-                          "_0" : "HttpStatus",
+                          "_0" : "TestModule.HttpStatus",
                           "_1" : "Int"
                         }
                       },
@@ -2045,14 +2045,14 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuleSq10HttpStatusO_Sq10HttpStatusO",
+              "mangleName" : "10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "HttpStatus",
+                        "_0" : "TestModule.HttpStatus",
                         "_1" : "Int"
                       }
                     },
@@ -2064,7 +2064,7 @@
                 "nullable" : {
                   "_0" : {
                     "rawValueEnum" : {
-                      "_0" : "HttpStatus",
+                      "_0" : "TestModule.HttpStatus",
                       "_1" : "Int"
                     }
                   },
@@ -2078,7 +2078,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalAPIResult",
+        "abiName" : "bjs_TestModule_roundtripOptionalAPIResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -2094,14 +2094,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModuleSq9APIResultO_Sq9APIResultO",
+                  "mangleName" : "10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "nullable" : {
                         "_0" : {
                           "associatedValueEnum" : {
-                            "_0" : "APIResult"
+                            "_0" : "TestModule.APIResult"
                           }
                         },
                         "_1" : "null"
@@ -2112,7 +2112,7 @@
                     "nullable" : {
                       "_0" : {
                         "associatedValueEnum" : {
-                          "_0" : "APIResult"
+                          "_0" : "TestModule.APIResult"
                         }
                       },
                       "_1" : "null"
@@ -2130,14 +2130,14 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuleSq9APIResultO_Sq9APIResultO",
+              "mangleName" : "10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "TestModule.APIResult"
                       }
                     },
                     "_1" : "null"
@@ -2148,7 +2148,7 @@
                 "nullable" : {
                   "_0" : {
                     "associatedValueEnum" : {
-                      "_0" : "APIResult"
+                      "_0" : "TestModule.APIResult"
                     }
                   },
                   "_1" : "null"
@@ -2161,7 +2161,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundtripOptionalDirection",
+        "abiName" : "bjs_TestModule_roundtripOptionalDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -2177,14 +2177,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "10TestModuleSq9DirectionO_Sq9DirectionO",
+                  "mangleName" : "10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO",
                   "moduleName" : "TestModule",
                   "parameters" : [
                     {
                       "nullable" : {
                         "_0" : {
                           "caseEnum" : {
-                            "_0" : "Direction"
+                            "_0" : "TestModule.Direction"
                           }
                         },
                         "_1" : "null"
@@ -2195,7 +2195,7 @@
                     "nullable" : {
                       "_0" : {
                         "caseEnum" : {
-                          "_0" : "Direction"
+                          "_0" : "TestModule.Direction"
                         }
                       },
                       "_1" : "null"
@@ -2213,14 +2213,14 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "10TestModuleSq9DirectionO_Sq9DirectionO",
+              "mangleName" : "10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO",
               "moduleName" : "TestModule",
               "parameters" : [
                 {
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "TestModule.Direction"
                       }
                     },
                     "_1" : "null"
@@ -2231,7 +2231,7 @@
                 "nullable" : {
                   "_0" : {
                     "caseEnum" : {
-                      "_0" : "Direction"
+                      "_0" : "TestModule.Direction"
                     }
                   },
                   "_1" : "null"
@@ -2250,7 +2250,7 @@
     "structs" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Animal_init",
+          "abiName" : "bjs_TestModule_Animal_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -2285,7 +2285,7 @@
             }
           }
         ],
-        "swiftCallName" : "Animal"
+        "swiftCallName" : "TestModule.Animal"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosure.swift
@@ -1,102 +1,39 @@
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule10HttpStatusO_10HttpStatusO")
-fileprivate func invoke_js_callback_TestModule_10TestModule10HttpStatusO_10HttpStatusO_extern(_ callback: Int32, _ param0: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO")
+fileprivate func invoke_js_callback_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModule10HttpStatusO_10HttpStatusO_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule10HttpStatusO_10HttpStatusO(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModule10HttpStatusO_10HttpStatusO_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO_extern(callback, param0Bytes, param0Length)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO")
-fileprivate func make_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO")
+fileprivate func make_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModule10HttpStatusO_10HttpStatusO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (HttpStatus) -> HttpStatus {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0Value = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModule10HttpStatusO_10HttpStatusO(callbackValue, param0Value)
-            return HttpStatus.bridgeJSLiftReturn(ret)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (HttpStatus) -> HttpStatus {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (HttpStatus) -> HttpStatus) {
-        self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO")
-@_cdecl("invoke_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO")
-public func _invoke_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(HttpStatus) -> HttpStatus>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(HttpStatus.bridgeJSLiftParameter(param0))
-    return result.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule5ThemeO_5ThemeO")
-fileprivate func invoke_js_callback_TestModule_10TestModule5ThemeO_5ThemeO_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
-#else
-fileprivate func invoke_js_callback_TestModule_10TestModule5ThemeO_5ThemeO_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule5ThemeO_5ThemeO(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModule5ThemeO_5ThemeO_extern(callback, param0Bytes, param0Length)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO")
-fileprivate func make_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_10TestModule5ThemeO_5ThemeO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Theme) -> Theme {
+private enum _BJS_Closure_10TestModule16TestModule_ThemeO_16TestModule_ThemeO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (TestModule.Theme) -> TestModule.Theme {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                let ret = invoke_js_callback_TestModule_10TestModule5ThemeO_5ThemeO(callbackValue, param0Bytes, param0Length)
+                let ret = invoke_js_callback_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO(callbackValue, param0Bytes, param0Length)
                 return ret
             }
             let ret = ret0
-            return Theme.bridgeJSLiftReturn(ret)
+            return TestModule.Theme.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -104,10 +41,10 @@ private enum _BJS_Closure_10TestModule5ThemeO_5ThemeO {
     }
 }
 
-extension JSTypedClosure where Signature == (Theme) -> Theme {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Theme) -> Theme) {
+extension JSTypedClosure where Signature == (TestModule.Theme) -> TestModule.Theme {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (TestModule.Theme) -> TestModule.Theme) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO,
+            makeClosure: make_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO,
             body: body,
             fileID: fileID,
             line: line
@@ -115,12 +52,12 @@ extension JSTypedClosure where Signature == (Theme) -> Theme {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO")
-@_cdecl("invoke_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO")
-public func _invoke_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO")
+public func _invoke_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Theme) -> Theme>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Theme.bridgeJSLiftParameter(param0Bytes, param0Length))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(TestModule.Theme) -> TestModule.Theme>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(TestModule.Theme.bridgeJSLiftParameter(param0Bytes, param0Length))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -128,38 +65,38 @@ public func _invoke_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO(_ boxPt
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV")
-fileprivate func invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV_extern(_ callback: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV")
+fileprivate func invoke_js_callback_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV_extern(_ callback: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV_extern(_ callback: Int32) -> Void {
+fileprivate func invoke_js_callback_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV_extern(_ callback: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV(_ callback: Int32) -> Void {
-    return invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV_extern(callback)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV(_ callback: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV_extern(callback)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV")
-fileprivate func make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV")
+fileprivate func make_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModule6AnimalV_6AnimalV {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Animal) -> Animal {
+private enum _BJS_Closure_10TestModule17TestModule_AnimalV_17TestModule_AnimalV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (TestModule.Animal) -> TestModule.Animal {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let _ = param0.bridgeJSLowerParameter()
-            invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV(callbackValue)
-            return Animal.bridgeJSLiftReturn()
+            invoke_js_callback_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV(callbackValue)
+            return TestModule.Animal.bridgeJSLiftReturn()
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -167,10 +104,10 @@ private enum _BJS_Closure_10TestModule6AnimalV_6AnimalV {
     }
 }
 
-extension JSTypedClosure where Signature == (Animal) -> Animal {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Animal) -> Animal) {
+extension JSTypedClosure where Signature == (TestModule.Animal) -> TestModule.Animal {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (TestModule.Animal) -> TestModule.Animal) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV,
+            makeClosure: make_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV,
             body: body,
             fileID: fileID,
             line: line
@@ -178,12 +115,12 @@ extension JSTypedClosure where Signature == (Animal) -> Animal {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV")
-@_cdecl("invoke_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV")
-public func _invoke_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV(_ boxPtr: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV")
+@_cdecl("invoke_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV")
+public func _invoke_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV(_ boxPtr: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Animal) -> Animal>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Animal.bridgeJSLiftParameter())
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(TestModule.Animal) -> TestModule.Animal>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(TestModule.Animal.bridgeJSLiftParameter())
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -191,38 +128,38 @@ public func _invoke_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV(_ box
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC")
-fileprivate func invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC")
+fileprivate func invoke_js_callback_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+fileprivate func invoke_js_callback_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    return invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    return invoke_js_callback_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule6PersonC_6PersonC")
-fileprivate func make_swift_closure_TestModule_10TestModule6PersonC_6PersonC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC")
+fileprivate func make_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModule6PersonC_6PersonC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule6PersonC_6PersonC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModule6PersonC_6PersonC_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModule6PersonC_6PersonC {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Person) -> Person {
+private enum _BJS_Closure_10TestModule17TestModule_PersonC_17TestModule_PersonC {
+    static func bridgeJSLift(_ callbackId: Int32) -> (TestModule.Person) -> TestModule.Person {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0Pointer = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC(callbackValue, param0Pointer)
-            return Person.bridgeJSLiftReturn(ret)
+            let ret = invoke_js_callback_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC(callbackValue, param0Pointer)
+            return TestModule.Person.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -230,10 +167,10 @@ private enum _BJS_Closure_10TestModule6PersonC_6PersonC {
     }
 }
 
-extension JSTypedClosure where Signature == (Person) -> Person {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Person) -> Person) {
+extension JSTypedClosure where Signature == (TestModule.Person) -> TestModule.Person {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (TestModule.Person) -> TestModule.Person) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModule6PersonC_6PersonC,
+            makeClosure: make_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC,
             body: body,
             fileID: fileID,
             line: line
@@ -241,12 +178,12 @@ extension JSTypedClosure where Signature == (Person) -> Person {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule6PersonC_6PersonC")
-@_cdecl("invoke_swift_closure_TestModule_10TestModule6PersonC_6PersonC")
-public func _invoke_swift_closure_TestModule_10TestModule6PersonC_6PersonC(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC")
+@_cdecl("invoke_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC")
+public func _invoke_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Person) -> Person>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Person.bridgeJSLiftParameter(param0))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(TestModule.Person) -> TestModule.Person>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(TestModule.Person.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -254,38 +191,38 @@ public func _invoke_swift_closure_TestModule_10TestModule6PersonC_6PersonC(_ box
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule9APIResultO_9APIResultO")
-fileprivate func invoke_js_callback_TestModule_10TestModule9APIResultO_9APIResultO_extern(_ callback: Int32, _ param0: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO")
+fileprivate func invoke_js_callback_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO_extern(_ callback: Int32, _ param0: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModule9APIResultO_9APIResultO_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule9APIResultO_9APIResultO(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModule9APIResultO_9APIResultO_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO")
-fileprivate func make_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO")
+fileprivate func make_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModule9APIResultO_9APIResultO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (APIResult) -> APIResult {
+private enum _BJS_Closure_10TestModule20TestModule_APIResultO_20TestModule_APIResultO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (TestModule.APIResult) -> TestModule.APIResult {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0CaseId = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModule9APIResultO_9APIResultO(callbackValue, param0CaseId)
-            return APIResult.bridgeJSLiftReturn(ret)
+            let ret = invoke_js_callback_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO(callbackValue, param0CaseId)
+            return TestModule.APIResult.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -293,10 +230,10 @@ private enum _BJS_Closure_10TestModule9APIResultO_9APIResultO {
     }
 }
 
-extension JSTypedClosure where Signature == (APIResult) -> APIResult {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (APIResult) -> APIResult) {
+extension JSTypedClosure where Signature == (TestModule.APIResult) -> TestModule.APIResult {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (TestModule.APIResult) -> TestModule.APIResult) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO,
+            makeClosure: make_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO,
             body: body,
             fileID: fileID,
             line: line
@@ -304,12 +241,12 @@ extension JSTypedClosure where Signature == (APIResult) -> APIResult {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO")
-@_cdecl("invoke_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO")
-public func _invoke_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO")
+public func _invoke_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(APIResult) -> APIResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(APIResult.bridgeJSLiftParameter(param0))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(TestModule.APIResult) -> TestModule.APIResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(TestModule.APIResult.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -317,38 +254,38 @@ public func _invoke_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule9DirectionO_9DirectionO")
-fileprivate func invoke_js_callback_TestModule_10TestModule9DirectionO_9DirectionO_extern(_ callback: Int32, _ param0: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO")
+fileprivate func invoke_js_callback_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO_extern(_ callback: Int32, _ param0: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModule9DirectionO_9DirectionO_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule9DirectionO_9DirectionO(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModule9DirectionO_9DirectionO_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO")
-fileprivate func make_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO")
+fileprivate func make_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModule9DirectionO_9DirectionO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Direction) -> Direction {
+private enum _BJS_Closure_10TestModule20TestModule_DirectionO_20TestModule_DirectionO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (TestModule.Direction) -> TestModule.Direction {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModule9DirectionO_9DirectionO(callbackValue, param0Value)
-            return Direction.bridgeJSLiftReturn(ret)
+            let ret = invoke_js_callback_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO(callbackValue, param0Value)
+            return TestModule.Direction.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -356,10 +293,10 @@ private enum _BJS_Closure_10TestModule9DirectionO_9DirectionO {
     }
 }
 
-extension JSTypedClosure where Signature == (Direction) -> Direction {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Direction) -> Direction) {
+extension JSTypedClosure where Signature == (TestModule.Direction) -> TestModule.Direction {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (TestModule.Direction) -> TestModule.Direction) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO,
+            makeClosure: make_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO,
             body: body,
             fileID: fileID,
             line: line
@@ -367,12 +304,75 @@ extension JSTypedClosure where Signature == (Direction) -> Direction {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO")
-@_cdecl("invoke_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO")
-public func _invoke_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO")
+public func _invoke_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Direction) -> Direction>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Direction.bridgeJSLiftParameter(param0))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(TestModule.Direction) -> TestModule.Direction>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(TestModule.Direction.bridgeJSLiftParameter(param0))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO")
+fileprivate func invoke_js_callback_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO_extern(_ callback: Int32, _ param0: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO")
+fileprivate func make_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (TestModule.HttpStatus) -> TestModule.HttpStatus {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0Value = param0.bridgeJSLowerParameter()
+            let ret = invoke_js_callback_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO(callbackValue, param0Value)
+            return TestModule.HttpStatus.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (TestModule.HttpStatus) -> TestModule.HttpStatus {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (TestModule.HttpStatus) -> TestModule.HttpStatus) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO")
+public func _invoke_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(TestModule.HttpStatus) -> TestModule.HttpStatus>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(TestModule.HttpStatus.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -864,102 +864,39 @@ public func _invoke_swift_closure_TestModule_10TestModuleSi_Si(_ boxPtr: UnsafeM
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO")
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO")
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
-    return invoke_js_callback_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO_extern(callback, param0IsSome, param0Value)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO_extern(callback, param0IsSome, param0Bytes, param0Length)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO")
-fileprivate func make_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO")
+fileprivate func make_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuleSq10HttpStatusO_Sq10HttpStatusO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<HttpStatus>) -> Optional<HttpStatus> {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
-            invoke_js_callback_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO(callbackValue, param0IsSome, param0Value)
-            return Optional<HttpStatus>.bridgeJSLiftReturnFromSideChannel()
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (Optional<HttpStatus>) -> Optional<HttpStatus> {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<HttpStatus>) -> Optional<HttpStatus>) {
-        self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO")
-public func _invoke_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<HttpStatus>) -> Optional<HttpStatus>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<HttpStatus>.bridgeJSLiftParameter(param0IsSome, param0Value))
-    return result.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO")
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    return invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO_extern(callback, param0IsSome, param0Bytes, param0Length)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO")
-fileprivate func make_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_10TestModuleSq5ThemeO_Sq5ThemeO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<Theme>) -> Optional<Theme> {
+private enum _BJS_Closure_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<TestModule.Theme>) -> Optional<TestModule.Theme> {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             param0.bridgeJSWithLoweredParameter { (param0IsSome, param0Bytes, param0Length) in
-                invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(callbackValue, param0IsSome, param0Bytes, param0Length)
+                invoke_js_callback_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO(callbackValue, param0IsSome, param0Bytes, param0Length)
             }
-            return Optional<Theme>.bridgeJSLiftReturnFromSideChannel()
+            return Optional<TestModule.Theme>.bridgeJSLiftReturnFromSideChannel()
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -967,10 +904,10 @@ private enum _BJS_Closure_10TestModuleSq5ThemeO_Sq5ThemeO {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<Theme>) -> Optional<Theme> {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<Theme>) -> Optional<Theme>) {
+extension JSTypedClosure where Signature == (Optional<TestModule.Theme>) -> Optional<TestModule.Theme> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<TestModule.Theme>) -> Optional<TestModule.Theme>) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO,
+            makeClosure: make_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO,
             body: body,
             fileID: fileID,
             line: line
@@ -978,12 +915,12 @@ extension JSTypedClosure where Signature == (Optional<Theme>) -> Optional<Theme>
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO")
-public func _invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO")
+public func _invoke_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Theme>) -> Optional<Theme>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Theme>.bridgeJSLiftParameter(param0IsSome, param0Bytes, param0Length))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<TestModule.Theme>) -> Optional<TestModule.Theme>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<TestModule.Theme>.bridgeJSLiftParameter(param0IsSome, param0Bytes, param0Length))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -991,38 +928,38 @@ public func _invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(_ b
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV")
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ callback: Int32, _ param0: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV")
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV_extern(_ callback: Int32, _ param0: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ callback: Int32, _ param0: Int32) -> Void {
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV_extern(_ callback: Int32, _ param0: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(_ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV")
-fileprivate func make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV")
+fileprivate func make_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuleSq6AnimalV_Sq6AnimalV {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<Animal>) -> Optional<Animal> {
+private enum _BJS_Closure_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<TestModule.Animal>) -> Optional<TestModule.Animal> {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0IsSome = param0.bridgeJSLowerParameter()
-            invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(callbackValue, param0IsSome)
-            return Optional<Animal>.bridgeJSLiftReturn()
+            invoke_js_callback_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV(callbackValue, param0IsSome)
+            return Optional<TestModule.Animal>.bridgeJSLiftReturn()
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -1030,10 +967,10 @@ private enum _BJS_Closure_10TestModuleSq6AnimalV_Sq6AnimalV {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<Animal>) -> Optional<Animal> {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<Animal>) -> Optional<Animal>) {
+extension JSTypedClosure where Signature == (Optional<TestModule.Animal>) -> Optional<TestModule.Animal> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<TestModule.Animal>) -> Optional<TestModule.Animal>) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV,
+            makeClosure: make_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV,
             body: body,
             fileID: fileID,
             line: line
@@ -1041,12 +978,12 @@ extension JSTypedClosure where Signature == (Optional<Animal>) -> Optional<Anima
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV")
-public func _invoke_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(_ boxPtr: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV")
+public func _invoke_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV(_ boxPtr: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Animal>) -> Optional<Animal>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Animal>.bridgeJSLiftParameter())
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<TestModule.Animal>) -> Optional<TestModule.Animal>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<TestModule.Animal>.bridgeJSLiftParameter())
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -1054,38 +991,38 @@ public func _invoke_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(_
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC")
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC")
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    return invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC_extern(callback, param0IsSome, param0Pointer)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    return invoke_js_callback_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC_extern(callback, param0IsSome, param0Pointer)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC")
-fileprivate func make_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC")
+fileprivate func make_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuleSq6PersonC_Sq6PersonC {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<Person>) -> Optional<Person> {
+private enum _BJS_Closure_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<TestModule.Person>) -> Optional<TestModule.Person> {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Pointer) = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC(callbackValue, param0IsSome, param0Pointer)
-            return Optional<Person>.bridgeJSLiftReturn(ret)
+            let ret = invoke_js_callback_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC(callbackValue, param0IsSome, param0Pointer)
+            return Optional<TestModule.Person>.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -1093,10 +1030,10 @@ private enum _BJS_Closure_10TestModuleSq6PersonC_Sq6PersonC {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<Person>) -> Optional<Person> {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<Person>) -> Optional<Person>) {
+extension JSTypedClosure where Signature == (Optional<TestModule.Person>) -> Optional<TestModule.Person> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<TestModule.Person>) -> Optional<TestModule.Person>) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC,
+            makeClosure: make_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC,
             body: body,
             fileID: fileID,
             line: line
@@ -1104,12 +1041,12 @@ extension JSTypedClosure where Signature == (Optional<Person>) -> Optional<Perso
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC")
-public func _invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC")
+public func _invoke_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Person>) -> Optional<Person>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Person>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<TestModule.Person>) -> Optional<TestModule.Person>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<TestModule.Person>.bridgeJSLiftParameter(param0IsSome, param0Value))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -1117,38 +1054,38 @@ public func _invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC(_
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO")
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO")
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO_extern(callback, param0IsSome, param0CaseId)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO_extern(callback, param0IsSome, param0CaseId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO")
-fileprivate func make_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO")
+fileprivate func make_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuleSq9APIResultO_Sq9APIResultO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<APIResult>) -> Optional<APIResult> {
+private enum _BJS_Closure_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<TestModule.APIResult>) -> Optional<TestModule.APIResult> {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0CaseId) = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(callbackValue, param0IsSome, param0CaseId)
-            return Optional<APIResult>.bridgeJSLiftReturn(ret)
+            let ret = invoke_js_callback_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO(callbackValue, param0IsSome, param0CaseId)
+            return Optional<TestModule.APIResult>.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -1156,10 +1093,10 @@ private enum _BJS_Closure_10TestModuleSq9APIResultO_Sq9APIResultO {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<APIResult>) -> Optional<APIResult> {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<APIResult>) -> Optional<APIResult>) {
+extension JSTypedClosure where Signature == (Optional<TestModule.APIResult>) -> Optional<TestModule.APIResult> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<TestModule.APIResult>) -> Optional<TestModule.APIResult>) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO,
+            makeClosure: make_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO,
             body: body,
             fileID: fileID,
             line: line
@@ -1167,12 +1104,12 @@ extension JSTypedClosure where Signature == (Optional<APIResult>) -> Optional<AP
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO")
-public func _invoke_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO")
+public func _invoke_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<APIResult>) -> Optional<APIResult>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<APIResult>.bridgeJSLiftParameter(param0IsSome, param0CaseId))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<TestModule.APIResult>) -> Optional<TestModule.APIResult>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<TestModule.APIResult>.bridgeJSLiftParameter(param0IsSome, param0CaseId))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -1180,38 +1117,38 @@ public func _invoke_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIRes
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO")
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO")
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32 {
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32 {
-    return invoke_js_callback_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO_extern(callback, param0IsSome, param0Value)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32 {
+    return invoke_js_callback_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO_extern(callback, param0IsSome, param0Value)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO")
-fileprivate func make_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO")
+fileprivate func make_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuleSq9DirectionO_Sq9DirectionO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<Direction>) -> Optional<Direction> {
+private enum _BJS_Closure_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<TestModule.Direction>) -> Optional<TestModule.Direction> {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO(callbackValue, param0IsSome, param0Value)
-            return Optional<Direction>.bridgeJSLiftReturn(ret)
+            let ret = invoke_js_callback_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO(callbackValue, param0IsSome, param0Value)
+            return Optional<TestModule.Direction>.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -1219,10 +1156,10 @@ private enum _BJS_Closure_10TestModuleSq9DirectionO_Sq9DirectionO {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<Direction>) -> Optional<Direction> {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<Direction>) -> Optional<Direction>) {
+extension JSTypedClosure where Signature == (Optional<TestModule.Direction>) -> Optional<TestModule.Direction> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<TestModule.Direction>) -> Optional<TestModule.Direction>) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO,
+            makeClosure: make_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO,
             body: body,
             fileID: fileID,
             line: line
@@ -1230,12 +1167,75 @@ extension JSTypedClosure where Signature == (Optional<Direction>) -> Optional<Di
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO")
-public func _invoke_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO")
+public func _invoke_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Direction>) -> Optional<Direction>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Direction>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<TestModule.Direction>) -> Optional<TestModule.Direction>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<TestModule.Direction>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO")
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO_extern(callback, param0IsSome, param0Value)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO")
+fileprivate func make_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<TestModule.HttpStatus>) -> Optional<TestModule.HttpStatus> {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
+            invoke_js_callback_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO(callbackValue, param0IsSome, param0Value)
+            return Optional<TestModule.HttpStatus>.bridgeJSLiftReturnFromSideChannel()
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Optional<TestModule.HttpStatus>) -> Optional<TestModule.HttpStatus> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<TestModule.HttpStatus>) -> Optional<TestModule.HttpStatus>) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO")
+public func _invoke_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<TestModule.HttpStatus>) -> Optional<TestModule.HttpStatus>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<TestModule.HttpStatus>.bridgeJSLiftParameter(param0IsSome, param0Value))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -1630,42 +1630,42 @@ public func _invoke_swift_closure_TestModule_10TestModuleYaKSS_SS(_ boxPtr: Unsa
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO")
-fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleYaKSb_20TestModule_APIResultO")
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSb_20TestModule_APIResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSb_20TestModule_APIResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO_extern(resolveRef, rejectRef, callback, param0)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleYaKSb_20TestModule_APIResultO(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleYaKSb_20TestModule_APIResultO_extern(resolveRef, rejectRef, callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO")
-fileprivate func make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO")
+fileprivate func make_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuleYaKSb_9APIResultO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Bool) async throws(JSException) -> APIResult {
+private enum _BJS_Closure_10TestModuleYaKSb_20TestModule_APIResultO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Bool) async throws(JSException) -> TestModule.APIResult {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: Bool) async throws(JSException) -> APIResult in
+        return { [callback] (param0: Bool) async throws(JSException) -> TestModule.APIResult in
             #if arch(wasm32)
             let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
-                    JSTypedClosure<(sending APIResult) -> Void>($0)
+                    JSTypedClosure<(sending TestModule.APIResult) -> Void>($0)
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
                 let callbackValue = callback.bridgeJSLowerParameter()
                 let param0Value = param0.bridgeJSLowerParameter()
-                invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO(resolveRef, rejectRef, callbackValue, param0Value)
+                invoke_js_callback_TestModule_10TestModuleYaKSb_20TestModule_APIResultO(resolveRef, rejectRef, callbackValue, param0Value)
             }
             return resolved
             #else
@@ -1675,10 +1675,10 @@ private enum _BJS_Closure_10TestModuleYaKSb_9APIResultO {
     }
 }
 
-extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> APIResult {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Bool) async throws(JSException) -> APIResult) {
+extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> TestModule.APIResult {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Bool) async throws(JSException) -> TestModule.APIResult) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO,
+            makeClosure: make_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO,
             body: body,
             fileID: fileID,
             line: line
@@ -1686,12 +1686,12 @@ extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> 
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO")
-public func _invoke_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO")
+public func _invoke_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Bool) async throws(JSException) -> APIResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    return _bjs_makePromise(resolve: Promise_resolve_9APIResultO, reject: Promise_reject) { () async throws(JSException) -> APIResult in
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Bool) async throws(JSException) -> TestModule.APIResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_20TestModule_APIResultO, reject: Promise_reject) { () async throws(JSException) -> TestModule.APIResult in
         return try await closure(Bool.bridgeJSLiftParameter(param0))
     }
     #else
@@ -1700,42 +1700,42 @@ public func _invoke_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO(_ box
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV")
-fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModuleYaSS_17TestModule_AnimalV")
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_17TestModule_AnimalV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_17TestModule_AnimalV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    return invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModuleYaSS_17TestModule_AnimalV(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModuleYaSS_17TestModule_AnimalV_extern(resolveRef, rejectRef, callback, param0Bytes, param0Length)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV")
-fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV")
+fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModuleYaSS_6AnimalV {
-    static func bridgeJSLift(_ callbackId: Int32) -> (String) async -> Animal {
+private enum _BJS_Closure_10TestModuleYaSS_17TestModule_AnimalV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) async -> TestModule.Animal {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: String) async -> Animal in
+        return { [callback] (param0: String) async -> TestModule.Animal in
             #if arch(wasm32)
             let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
-                    JSTypedClosure<(sending Animal) -> Void>($0)
+                    JSTypedClosure<(sending TestModule.Animal) -> Void>($0)
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
                 let callbackValue = callback.bridgeJSLowerParameter()
                 param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                    invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
+                    invoke_js_callback_TestModule_10TestModuleYaSS_17TestModule_AnimalV(resolveRef, rejectRef, callbackValue, param0Bytes, param0Length)
                 }
             }
             return resolved
@@ -1746,10 +1746,10 @@ private enum _BJS_Closure_10TestModuleYaSS_6AnimalV {
     }
 }
 
-extension JSTypedClosure where Signature == (String) async -> Animal {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async -> Animal) {
+extension JSTypedClosure where Signature == (String) async -> TestModule.Animal {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) async -> TestModule.Animal) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV,
+            makeClosure: make_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV,
             body: body,
             fileID: fileID,
             line: line
@@ -1757,12 +1757,12 @@ extension JSTypedClosure where Signature == (String) async -> Animal {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleYaSS_6AnimalV")
-@_cdecl("invoke_swift_closure_TestModule_10TestModuleYaSS_6AnimalV")
-public func _invoke_swift_closure_TestModule_10TestModuleYaSS_6AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV")
+@_cdecl("invoke_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV")
+public func _invoke_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async -> Animal>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    return _bjs_makePromise(resolve: Promise_resolve_6AnimalV, reject: Promise_reject) {
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) async -> TestModule.Animal>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_17TestModule_AnimalV, reject: Promise_reject) {
         return await closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
     }
     #else
@@ -1842,37 +1842,37 @@ public func _invoke_swift_closure_TestModule_10TestModuleYaSS_SS(_ boxPtr: Unsaf
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModules6AnimalV_y")
-fileprivate func invoke_js_callback_TestModule_10TestModules6AnimalV_y_extern(_ callback: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModules17TestModule_AnimalV_y")
+fileprivate func invoke_js_callback_TestModule_10TestModules17TestModule_AnimalV_y_extern(_ callback: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_TestModule_10TestModules6AnimalV_y_extern(_ callback: Int32) -> Void {
+fileprivate func invoke_js_callback_TestModule_10TestModules17TestModule_AnimalV_y_extern(_ callback: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModules6AnimalV_y(_ callback: Int32) -> Void {
-    return invoke_js_callback_TestModule_10TestModules6AnimalV_y_extern(callback)
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModules17TestModule_AnimalV_y(_ callback: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModules17TestModule_AnimalV_y_extern(callback)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModules6AnimalV_y")
-fileprivate func make_swift_closure_TestModule_10TestModules6AnimalV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y")
+fileprivate func make_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_TestModule_10TestModules6AnimalV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModules6AnimalV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModules6AnimalV_y_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_10TestModules6AnimalV_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending Animal) -> Void {
+private enum _BJS_Closure_10TestModules17TestModule_AnimalV_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending TestModule.Animal) -> Void {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let _ = param0.bridgeJSLowerParameter()
-            invoke_js_callback_TestModule_10TestModules6AnimalV_y(callbackValue)
+            invoke_js_callback_TestModule_10TestModules17TestModule_AnimalV_y(callbackValue)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -1880,10 +1880,10 @@ private enum _BJS_Closure_10TestModules6AnimalV_y {
     }
 }
 
-extension JSTypedClosure where Signature == (sending Animal) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending Animal) -> Void) {
+extension JSTypedClosure where Signature == (sending TestModule.Animal) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending TestModule.Animal) -> Void) {
         self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModules6AnimalV_y,
+            makeClosure: make_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y,
             body: body,
             fileID: fileID,
             line: line
@@ -1891,12 +1891,73 @@ extension JSTypedClosure where Signature == (sending Animal) -> Void {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModules6AnimalV_y")
-@_cdecl("invoke_swift_closure_TestModule_10TestModules6AnimalV_y")
-public func _invoke_swift_closure_TestModule_10TestModules6AnimalV_y(_ boxPtr: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y")
+@_cdecl("invoke_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y")
+public func _invoke_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y(_ boxPtr: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending Animal) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(Animal.bridgeJSLiftParameter())
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending TestModule.Animal) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(TestModule.Animal.bridgeJSLiftParameter())
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModules20TestModule_APIResultO_y")
+fileprivate func invoke_js_callback_TestModule_10TestModules20TestModule_APIResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_TestModule_10TestModules20TestModule_APIResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModules20TestModule_APIResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_TestModule_10TestModules20TestModule_APIResultO_y_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y")
+fileprivate func make_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_10TestModules20TestModule_APIResultO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending TestModule.APIResult) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0CaseId = param0.bridgeJSLowerParameter()
+            invoke_js_callback_TestModule_10TestModules20TestModule_APIResultO_y(callbackValue, param0CaseId)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending TestModule.APIResult) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending TestModule.APIResult) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y")
+@_cdecl("invoke_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y")
+public func _invoke_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending TestModule.APIResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(TestModule.APIResult.bridgeJSLiftParameter(param0))
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -1964,67 +2025,6 @@ public func _invoke_swift_closure_TestModule_10TestModules7JSValueV_y(_ boxPtr: 
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModules9APIResultO_y")
-fileprivate func invoke_js_callback_TestModule_10TestModules9APIResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_TestModule_10TestModules9APIResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_TestModule_10TestModules9APIResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_TestModule_10TestModules9APIResultO_y_extern(callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_TestModule_10TestModules9APIResultO_y")
-fileprivate func make_swift_closure_TestModule_10TestModules9APIResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_TestModule_10TestModules9APIResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_TestModule_10TestModules9APIResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_TestModule_10TestModules9APIResultO_y_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_10TestModules9APIResultO_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending APIResult) -> Void {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0CaseId = param0.bridgeJSLowerParameter()
-            invoke_js_callback_TestModule_10TestModules9APIResultO_y(callbackValue, param0CaseId)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (sending APIResult) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending APIResult) -> Void) {
-        self.init(
-            makeClosure: make_swift_closure_TestModule_10TestModules9APIResultO_y,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_TestModule_10TestModules9APIResultO_y")
-@_cdecl("invoke_swift_closure_TestModule_10TestModules9APIResultO_y")
-public func _invoke_swift_closure_TestModule_10TestModules9APIResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending APIResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(APIResult.bridgeJSLiftParameter(param0))
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
 @_extern(wasm, module: "bjs", name: "invoke_js_callback_TestModule_10TestModulesSS_y")
 fileprivate func invoke_js_callback_TestModule_10TestModulesSS_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
 #else
@@ -2086,15 +2086,15 @@ public func _invoke_swift_closure_TestModule_10TestModulesSS_y(_ boxPtr: UnsafeM
     #endif
 }
 
-extension Direction: _BridgedSwiftCaseEnum {
+extension TestModule.Direction: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Direction {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TestModule.Direction {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Direction {
-        return Direction(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TestModule.Direction {
+        return TestModule.Direction(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -2129,14 +2129,14 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension APIResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
+extension TestModule.APIResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TestModule.APIResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -2151,7 +2151,7 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         case 5:
             return .info
         default:
-            fatalError("Unknown APIResult case ID: \(caseId)")
+            fatalError("Unknown TestModule.APIResult case ID: \(caseId)")
         }
     }
 
@@ -2178,10 +2178,10 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension Animal: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Animal {
+extension TestModule.Animal: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Animal {
         let type = String.bridgeJSStackPop()
-        return Animal(type: type)
+        return TestModule.Animal(type: type)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -2189,77 +2189,77 @@ extension Animal: _BridgedSwiftStruct {
     }
 
     public init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Animal(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Animal(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     public func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Animal()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Animal()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Animal")
-fileprivate func _bjs_struct_lower_Animal_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Animal")
+fileprivate func _bjs_struct_lower_TestModule_Animal_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Animal_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Animal_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Animal(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Animal_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Animal(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Animal_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Animal")
-fileprivate func _bjs_struct_lift_Animal_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Animal")
+fileprivate func _bjs_struct_lift_TestModule_Animal_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Animal_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Animal_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Animal() -> Int32 {
-    return _bjs_struct_lift_Animal_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Animal() -> Int32 {
+    return _bjs_struct_lift_TestModule_Animal_extern()
 }
 
-@_expose(wasm, "bjs_Animal_init")
-@_cdecl("bjs_Animal_init")
-public func _bjs_Animal_init(_ typeBytes: Int32, _ typeLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Animal_init")
+@_cdecl("bjs_TestModule_Animal_init")
+public func _bjs_TestModule_Animal_init(_ typeBytes: Int32, _ typeLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Animal(type: String.bridgeJSLiftParameter(typeBytes, typeLength))
+    let ret = TestModule.Animal(type: String.bridgeJSLiftParameter(typeBytes, typeLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripAnimal")
-@_cdecl("bjs_roundtripAnimal")
-public func _bjs_roundtripAnimal(_ animalClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripAnimal")
+@_cdecl("bjs_TestModule_roundtripAnimal")
+public func _bjs_TestModule_roundtripAnimal(_ animalClosure: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripAnimal(_: _BJS_Closure_10TestModule6AnimalV_6AnimalV.bridgeJSLift(animalClosure))
+    let ret = roundtripAnimal(_: _BJS_Closure_10TestModule17TestModule_AnimalV_17TestModule_AnimalV.bridgeJSLift(animalClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalAnimal")
-@_cdecl("bjs_roundtripOptionalAnimal")
-public func _bjs_roundtripOptionalAnimal(_ animalClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalAnimal")
+@_cdecl("bjs_TestModule_roundtripOptionalAnimal")
+public func _bjs_TestModule_roundtripOptionalAnimal(_ animalClosure: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripOptionalAnimal(_: _BJS_Closure_10TestModuleSq6AnimalV_Sq6AnimalV.bridgeJSLift(animalClosure))
+    let ret = roundtripOptionalAnimal(_: _BJS_Closure_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV.bridgeJSLift(animalClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripString")
-@_cdecl("bjs_roundtripString")
-public func _bjs_roundtripString(_ stringClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripString")
+@_cdecl("bjs_TestModule_roundtripString")
+public func _bjs_TestModule_roundtripString(_ stringClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripString(_: _BJS_Closure_10TestModuleSS_SS.bridgeJSLift(stringClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2268,9 +2268,9 @@ public func _bjs_roundtripString(_ stringClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripInt")
-@_cdecl("bjs_roundtripInt")
-public func _bjs_roundtripInt(_ intClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripInt")
+@_cdecl("bjs_TestModule_roundtripInt")
+public func _bjs_TestModule_roundtripInt(_ intClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripInt(_: _BJS_Closure_10TestModuleSi_Si.bridgeJSLift(intClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2279,9 +2279,9 @@ public func _bjs_roundtripInt(_ intClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripBool")
-@_cdecl("bjs_roundtripBool")
-public func _bjs_roundtripBool(_ boolClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripBool")
+@_cdecl("bjs_TestModule_roundtripBool")
+public func _bjs_TestModule_roundtripBool(_ boolClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripBool(_: _BJS_Closure_10TestModuleSb_Sb.bridgeJSLift(boolClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2290,9 +2290,9 @@ public func _bjs_roundtripBool(_ boolClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripFloat")
-@_cdecl("bjs_roundtripFloat")
-public func _bjs_roundtripFloat(_ floatClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripFloat")
+@_cdecl("bjs_TestModule_roundtripFloat")
+public func _bjs_TestModule_roundtripFloat(_ floatClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripFloat(_: _BJS_Closure_10TestModuleSf_Sf.bridgeJSLift(floatClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2301,9 +2301,9 @@ public func _bjs_roundtripFloat(_ floatClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripDouble")
-@_cdecl("bjs_roundtripDouble")
-public func _bjs_roundtripDouble(_ doubleClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripDouble")
+@_cdecl("bjs_TestModule_roundtripDouble")
+public func _bjs_TestModule_roundtripDouble(_ doubleClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripDouble(_: _BJS_Closure_10TestModuleSd_Sd.bridgeJSLift(doubleClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2312,9 +2312,9 @@ public func _bjs_roundtripDouble(_ doubleClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalString")
-@_cdecl("bjs_roundtripOptionalString")
-public func _bjs_roundtripOptionalString(_ stringClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalString")
+@_cdecl("bjs_TestModule_roundtripOptionalString")
+public func _bjs_TestModule_roundtripOptionalString(_ stringClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripOptionalString(_: _BJS_Closure_10TestModuleSqSS_SqSS.bridgeJSLift(stringClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2323,9 +2323,9 @@ public func _bjs_roundtripOptionalString(_ stringClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalInt")
-@_cdecl("bjs_roundtripOptionalInt")
-public func _bjs_roundtripOptionalInt(_ intClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalInt")
+@_cdecl("bjs_TestModule_roundtripOptionalInt")
+public func _bjs_TestModule_roundtripOptionalInt(_ intClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripOptionalInt(_: _BJS_Closure_10TestModuleSqSi_SqSi.bridgeJSLift(intClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2334,9 +2334,9 @@ public func _bjs_roundtripOptionalInt(_ intClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalBool")
-@_cdecl("bjs_roundtripOptionalBool")
-public func _bjs_roundtripOptionalBool(_ boolClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalBool")
+@_cdecl("bjs_TestModule_roundtripOptionalBool")
+public func _bjs_TestModule_roundtripOptionalBool(_ boolClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripOptionalBool(_: _BJS_Closure_10TestModuleSqSb_SqSb.bridgeJSLift(boolClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2345,9 +2345,9 @@ public func _bjs_roundtripOptionalBool(_ boolClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalFloat")
-@_cdecl("bjs_roundtripOptionalFloat")
-public func _bjs_roundtripOptionalFloat(_ floatClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalFloat")
+@_cdecl("bjs_TestModule_roundtripOptionalFloat")
+public func _bjs_TestModule_roundtripOptionalFloat(_ floatClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripOptionalFloat(_: _BJS_Closure_10TestModuleSqSf_SqSf.bridgeJSLift(floatClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2356,9 +2356,9 @@ public func _bjs_roundtripOptionalFloat(_ floatClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalDouble")
-@_cdecl("bjs_roundtripOptionalDouble")
-public func _bjs_roundtripOptionalDouble(_ doubleClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalDouble")
+@_cdecl("bjs_TestModule_roundtripOptionalDouble")
+public func _bjs_TestModule_roundtripOptionalDouble(_ doubleClosure: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundtripOptionalDouble(_: _BJS_Closure_10TestModuleSqSd_SqSd.bridgeJSLift(doubleClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -2367,31 +2367,31 @@ public func _bjs_roundtripOptionalDouble(_ doubleClosure: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripPerson")
-@_cdecl("bjs_roundtripPerson")
-public func _bjs_roundtripPerson(_ personClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripPerson")
+@_cdecl("bjs_TestModule_roundtripPerson")
+public func _bjs_TestModule_roundtripPerson(_ personClosure: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripPerson(_: _BJS_Closure_10TestModule6PersonC_6PersonC.bridgeJSLift(personClosure))
+    let ret = roundtripPerson(_: _BJS_Closure_10TestModule17TestModule_PersonC_17TestModule_PersonC.bridgeJSLift(personClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalPerson")
-@_cdecl("bjs_roundtripOptionalPerson")
-public func _bjs_roundtripOptionalPerson(_ personClosure: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalPerson")
+@_cdecl("bjs_TestModule_roundtripOptionalPerson")
+public func _bjs_TestModule_roundtripOptionalPerson(_ personClosure: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripOptionalPerson(_: _BJS_Closure_10TestModuleSq6PersonC_Sq6PersonC.bridgeJSLift(personClosure))
+    let ret = roundtripOptionalPerson(_: _BJS_Closure_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC.bridgeJSLift(personClosure))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeThrowingParser")
-@_cdecl("bjs_makeThrowingParser")
-public func _bjs_makeThrowingParser() -> Int32 {
+@_expose(wasm, "bjs_TestModule_makeThrowingParser")
+@_cdecl("bjs_TestModule_makeThrowingParser")
+public func _bjs_TestModule_makeThrowingParser() -> Int32 {
     #if arch(wasm32)
     let ret = makeThrowingParser()
     return ret.bridgeJSLowerReturn()
@@ -2400,9 +2400,9 @@ public func _bjs_makeThrowingParser() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_validateWith")
-@_cdecl("bjs_validateWith")
-public func _bjs_validateWith(_ validate: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_validateWith")
+@_cdecl("bjs_TestModule_validateWith")
+public func _bjs_TestModule_validateWith(_ validate: Int32) -> Void {
     #if arch(wasm32)
     validateWith(_: _BJS_Closure_10TestModuleKSS_Sb.bridgeJSLift(validate))
     #else
@@ -2410,9 +2410,9 @@ public func _bjs_validateWith(_ validate: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_makeFetcher")
-@_cdecl("bjs_makeFetcher")
-public func _bjs_makeFetcher() -> Int32 {
+@_expose(wasm, "bjs_TestModule_makeFetcher")
+@_cdecl("bjs_TestModule_makeFetcher")
+public func _bjs_TestModule_makeFetcher() -> Int32 {
     #if arch(wasm32)
     let ret = makeFetcher()
     return ret.bridgeJSLowerReturn()
@@ -2421,9 +2421,9 @@ public func _bjs_makeFetcher() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAsyncEcho")
-@_cdecl("bjs_makeAsyncEcho")
-public func _bjs_makeAsyncEcho() -> Int32 {
+@_expose(wasm, "bjs_TestModule_makeAsyncEcho")
+@_cdecl("bjs_TestModule_makeAsyncEcho")
+public func _bjs_TestModule_makeAsyncEcho() -> Int32 {
     #if arch(wasm32)
     let ret = makeAsyncEcho()
     return ret.bridgeJSLowerReturn()
@@ -2432,9 +2432,9 @@ public func _bjs_makeAsyncEcho() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAnimalLoader")
-@_cdecl("bjs_makeAnimalLoader")
-public func _bjs_makeAnimalLoader() -> Int32 {
+@_expose(wasm, "bjs_TestModule_makeAnimalLoader")
+@_cdecl("bjs_TestModule_makeAnimalLoader")
+public func _bjs_TestModule_makeAnimalLoader() -> Int32 {
     #if arch(wasm32)
     let ret = makeAnimalLoader()
     return ret.bridgeJSLowerReturn()
@@ -2443,9 +2443,9 @@ public func _bjs_makeAnimalLoader() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_makeResultLoader")
-@_cdecl("bjs_makeResultLoader")
-public func _bjs_makeResultLoader() -> Int32 {
+@_expose(wasm, "bjs_TestModule_makeResultLoader")
+@_cdecl("bjs_TestModule_makeResultLoader")
+public func _bjs_TestModule_makeResultLoader() -> Int32 {
     #if arch(wasm32)
     let ret = makeResultLoader()
     return ret.bridgeJSLowerReturn()
@@ -2454,187 +2454,187 @@ public func _bjs_makeResultLoader() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripDirection")
-@_cdecl("bjs_roundtripDirection")
-public func _bjs_roundtripDirection(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripDirection")
+@_cdecl("bjs_TestModule_roundtripDirection")
+public func _bjs_TestModule_roundtripDirection(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripDirection(_: _BJS_Closure_10TestModule9DirectionO_9DirectionO.bridgeJSLift(callback))
+    let ret = roundtripDirection(_: _BJS_Closure_10TestModule20TestModule_DirectionO_20TestModule_DirectionO.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripTheme")
-@_cdecl("bjs_roundtripTheme")
-public func _bjs_roundtripTheme(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripTheme")
+@_cdecl("bjs_TestModule_roundtripTheme")
+public func _bjs_TestModule_roundtripTheme(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripTheme(_: _BJS_Closure_10TestModule5ThemeO_5ThemeO.bridgeJSLift(callback))
+    let ret = roundtripTheme(_: _BJS_Closure_10TestModule16TestModule_ThemeO_16TestModule_ThemeO.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripHttpStatus")
-@_cdecl("bjs_roundtripHttpStatus")
-public func _bjs_roundtripHttpStatus(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripHttpStatus")
+@_cdecl("bjs_TestModule_roundtripHttpStatus")
+public func _bjs_TestModule_roundtripHttpStatus(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripHttpStatus(_: _BJS_Closure_10TestModule10HttpStatusO_10HttpStatusO.bridgeJSLift(callback))
+    let ret = roundtripHttpStatus(_: _BJS_Closure_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripAPIResult")
-@_cdecl("bjs_roundtripAPIResult")
-public func _bjs_roundtripAPIResult(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripAPIResult")
+@_cdecl("bjs_TestModule_roundtripAPIResult")
+public func _bjs_TestModule_roundtripAPIResult(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripAPIResult(_: _BJS_Closure_10TestModule9APIResultO_9APIResultO.bridgeJSLift(callback))
+    let ret = roundtripAPIResult(_: _BJS_Closure_10TestModule20TestModule_APIResultO_20TestModule_APIResultO.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalDirection")
-@_cdecl("bjs_roundtripOptionalDirection")
-public func _bjs_roundtripOptionalDirection(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalDirection")
+@_cdecl("bjs_TestModule_roundtripOptionalDirection")
+public func _bjs_TestModule_roundtripOptionalDirection(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripOptionalDirection(_: _BJS_Closure_10TestModuleSq9DirectionO_Sq9DirectionO.bridgeJSLift(callback))
+    let ret = roundtripOptionalDirection(_: _BJS_Closure_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalTheme")
-@_cdecl("bjs_roundtripOptionalTheme")
-public func _bjs_roundtripOptionalTheme(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalTheme")
+@_cdecl("bjs_TestModule_roundtripOptionalTheme")
+public func _bjs_TestModule_roundtripOptionalTheme(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripOptionalTheme(_: _BJS_Closure_10TestModuleSq5ThemeO_Sq5ThemeO.bridgeJSLift(callback))
+    let ret = roundtripOptionalTheme(_: _BJS_Closure_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalHttpStatus")
-@_cdecl("bjs_roundtripOptionalHttpStatus")
-public func _bjs_roundtripOptionalHttpStatus(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalHttpStatus")
+@_cdecl("bjs_TestModule_roundtripOptionalHttpStatus")
+public func _bjs_TestModule_roundtripOptionalHttpStatus(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripOptionalHttpStatus(_: _BJS_Closure_10TestModuleSq10HttpStatusO_Sq10HttpStatusO.bridgeJSLift(callback))
+    let ret = roundtripOptionalHttpStatus(_: _BJS_Closure_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalAPIResult")
-@_cdecl("bjs_roundtripOptionalAPIResult")
-public func _bjs_roundtripOptionalAPIResult(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalAPIResult")
+@_cdecl("bjs_TestModule_roundtripOptionalAPIResult")
+public func _bjs_TestModule_roundtripOptionalAPIResult(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripOptionalAPIResult(_: _BJS_Closure_10TestModuleSq9APIResultO_Sq9APIResultO.bridgeJSLift(callback))
+    let ret = roundtripOptionalAPIResult(_: _BJS_Closure_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripOptionalDirection")
-@_cdecl("bjs_roundtripOptionalDirection")
-public func _bjs_roundtripOptionalDirection(_ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_TestModule_roundtripOptionalDirection")
+@_cdecl("bjs_TestModule_roundtripOptionalDirection")
+public func _bjs_TestModule_roundtripOptionalDirection(_ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripOptionalDirection(_: _BJS_Closure_10TestModuleSq9DirectionO_Sq9DirectionO.bridgeJSLift(callback))
+    let ret = roundtripOptionalDirection(_: _BJS_Closure_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Person_init")
-@_cdecl("bjs_Person_init")
-public func _bjs_Person_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Person_init")
+@_cdecl("bjs_TestModule_Person_init")
+public func _bjs_TestModule_Person_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Person(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Person(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Person_deinit")
-@_cdecl("bjs_Person_deinit")
-public func _bjs_Person_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Person_deinit")
+@_cdecl("bjs_TestModule_Person_deinit")
+public func _bjs_TestModule_Person_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Person>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Person>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Person: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Person: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     public var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Person_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Person_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     public consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Person_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Person_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Person_wrap")
-fileprivate func _bjs_Person_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Person_wrap")
+fileprivate func _bjs_TestModule_Person_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Person_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Person_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Person_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Person_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Person_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Person_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_TestProcessor_init")
-@_cdecl("bjs_TestProcessor_init")
-public func _bjs_TestProcessor_init(_ transform: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_TestProcessor_init")
+@_cdecl("bjs_TestModule_TestProcessor_init")
+public func _bjs_TestModule_TestProcessor_init(_ transform: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = TestProcessor(transform: _BJS_Closure_10TestModuleSS_SS.bridgeJSLift(transform))
+    let ret = TestModule.TestProcessor(transform: _BJS_Closure_10TestModuleSS_SS.bridgeJSLift(transform))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TestProcessor_deinit")
-@_cdecl("bjs_TestProcessor_deinit")
-public func _bjs_TestProcessor_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_TestProcessor_deinit")
+@_cdecl("bjs_TestModule_TestProcessor_deinit")
+public func _bjs_TestModule_TestProcessor_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<TestProcessor>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.TestProcessor>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension TestProcessor: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.TestProcessor: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestProcessor_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_TestProcessor_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_TestProcessor_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_TestProcessor_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_TestProcessor_wrap")
-fileprivate func _bjs_TestProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_TestProcessor_wrap")
+fileprivate func _bjs_TestModule_TestProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_TestProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_TestProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_TestProcessor_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_TestProcessor_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_TestProcessor_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_TestProcessor_wrap_extern(pointer)
 }
 
 @JSFunction func Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
@@ -2680,44 +2680,44 @@ func _$Promise_resolve_SS(_ promise: JSObject, _ value: String) throws(JSExcepti
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_6AnimalV(_ promise: JSObject, _ value: Animal) throws(JSException)
+@JSFunction func Promise_resolve_17TestModule_AnimalV(_ promise: JSObject, _ value: TestModule.Animal) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_6AnimalV")
-fileprivate func promise_resolve_TestModule_6AnimalV_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_17TestModule_AnimalV")
+fileprivate func promise_resolve_TestModule_17TestModule_AnimalV_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_6AnimalV_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_17TestModule_AnimalV_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_6AnimalV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_TestModule_6AnimalV_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_TestModule_17TestModule_AnimalV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_17TestModule_AnimalV_extern(promise, value)
 }
 
-func _$Promise_resolve_6AnimalV(_ promise: JSObject, _ value: Animal) throws(JSException) -> Void {
+func _$Promise_resolve_17TestModule_AnimalV(_ promise: JSObject, _ value: TestModule.Animal) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_6AnimalV(promiseValue, valueObjectId)
+    promise_resolve_TestModule_17TestModule_AnimalV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_9APIResultO(_ promise: JSObject, _ value: APIResult) throws(JSException)
+@JSFunction func Promise_resolve_20TestModule_APIResultO(_ promise: JSObject, _ value: TestModule.APIResult) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_9APIResultO")
-fileprivate func promise_resolve_TestModule_9APIResultO_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_TestModule_20TestModule_APIResultO")
+fileprivate func promise_resolve_TestModule_20TestModule_APIResultO_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_TestModule_9APIResultO_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_TestModule_20TestModule_APIResultO_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_TestModule_9APIResultO(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_TestModule_9APIResultO_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_TestModule_20TestModule_APIResultO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_TestModule_20TestModule_APIResultO_extern(promise, value)
 }
 
-func _$Promise_resolve_9APIResultO(_ promise: JSObject, _ value: APIResult) throws(JSException) -> Void {
+func _$Promise_resolve_20TestModule_APIResultO(_ promise: JSObject, _ value: TestModule.APIResult) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueCaseId = value.bridgeJSLowerParameter()
-    promise_resolve_TestModule_9APIResultO(promiseValue, valueCaseId)
+    promise_resolve_TestModule_20TestModule_APIResultO(promiseValue, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_runValidator",
+        "abiName" : "bjs_TestModule_runValidator",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -56,7 +56,7 @@
         }
       },
       {
-        "abiName" : "bjs_loadEach",
+        "abiName" : "bjs_TestModule_loadEach",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftClosureImports.swift
@@ -338,9 +338,9 @@ public func _invoke_swift_closure_TestModule_10TestModulesSS_y(_ boxPtr: UnsafeM
     #endif
 }
 
-@_expose(wasm, "bjs_runValidator")
-@_cdecl("bjs_runValidator")
-public func _bjs_runValidator(_ cb: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_runValidator")
+@_cdecl("bjs_TestModule_runValidator")
+public func _bjs_TestModule_runValidator(_ cb: Int32) -> Void {
     #if arch(wasm32)
     runValidator(_: _BJS_Closure_10TestModuleKSS_Sb.bridgeJSLift(cb))
     #else
@@ -348,9 +348,9 @@ public func _bjs_runValidator(_ cb: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_loadEach")
-@_cdecl("bjs_loadEach")
-public func _bjs_loadEach(_ fetch: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_loadEach")
+@_cdecl("bjs_TestModule_loadEach")
+public func _bjs_TestModule_loadEach(_ fetch: Int32) -> Void {
     #if arch(wasm32)
     loadEach(_: _BJS_Closure_10TestModuleYaKSS_SS.bridgeJSLift(fetch))
     #else

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_Greeter_init",
+          "abiName" : "bjs_TestModule_Greeter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -26,7 +26,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Greeter_greet",
+            "abiName" : "bjs_TestModule_Greeter_greet",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -56,7 +56,7 @@
             }
           }
         ],
-        "swiftCallName" : "Greeter"
+        "swiftCallName" : "TestModule.Greeter"
       }
     ],
     "enums" : [
@@ -86,14 +86,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Precision",
+        "swiftCallName" : "TestModule.Precision",
         "tsFullPath" : "Precision"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_roundtrip",
+        "abiName" : "bjs_TestModule_roundtrip",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -106,19 +106,19 @@
             "name" : "session",
             "type" : {
               "swiftStruct" : {
-                "_0" : "Person"
+                "_0" : "TestModule.Person"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "Person"
+            "_0" : "TestModule.Person"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripContainer",
+        "abiName" : "bjs_TestModule_roundtripContainer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -131,14 +131,14 @@
             "name" : "container",
             "type" : {
               "swiftStruct" : {
-                "_0" : "Container"
+                "_0" : "TestModule.Container"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "Container"
+            "_0" : "TestModule.Container"
           }
         }
       }
@@ -149,7 +149,7 @@
     "structs" : [
       {
         "constructor" : {
-          "abiName" : "bjs_DataPoint_init",
+          "abiName" : "bjs_TestModule_DataPoint_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -218,7 +218,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_DataPoint_static_origin",
+            "abiName" : "bjs_TestModule_DataPoint_static_origin",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -230,12 +230,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "DataPoint"
+                "_0" : "TestModule.DataPoint"
               }
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "DataPoint"
+                "_0" : "TestModule_DataPoint"
               }
             }
           }
@@ -311,7 +311,7 @@
             "name" : "dimensions",
             "staticContext" : {
               "structName" : {
-                "_0" : "DataPoint"
+                "_0" : "TestModule_DataPoint"
               }
             },
             "type" : {
@@ -324,7 +324,7 @@
             }
           }
         ],
-        "swiftCallName" : "DataPoint"
+        "swiftCallName" : "TestModule.DataPoint"
       },
       {
         "methods" : [
@@ -371,7 +371,7 @@
             }
           }
         ],
-        "swiftCallName" : "Address"
+        "swiftCallName" : "TestModule.Address"
       },
       {
         "methods" : [
@@ -408,7 +408,7 @@
             "name" : "address",
             "type" : {
               "swiftStruct" : {
-                "_0" : "Address"
+                "_0" : "TestModule.Address"
               }
             }
           },
@@ -428,7 +428,7 @@
             }
           }
         ],
-        "swiftCallName" : "Person"
+        "swiftCallName" : "TestModule.Person"
       },
       {
         "methods" : [
@@ -455,12 +455,12 @@
             "name" : "owner",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "TestModule.Greeter"
               }
             }
           }
         ],
-        "swiftCallName" : "Session"
+        "swiftCallName" : "TestModule.Session"
       },
       {
         "methods" : [
@@ -484,7 +484,7 @@
             "name" : "precision",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Precision",
+                "_0" : "TestModule.Precision",
                 "_1" : "Float"
               }
             }
@@ -497,7 +497,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Precision",
+                    "_0" : "TestModule.Precision",
                     "_1" : "Float"
                   }
                 },
@@ -506,12 +506,12 @@
             }
           }
         ],
-        "swiftCallName" : "Measurement"
+        "swiftCallName" : "TestModule.Measurement"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_ConfigStruct_static_update",
+            "abiName" : "bjs_TestModule_ConfigStruct_static_update",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -536,7 +536,7 @@
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "ConfigStruct"
+                "_0" : "TestModule_ConfigStruct"
               }
             }
           }
@@ -549,7 +549,7 @@
             "name" : "maxRetries",
             "staticContext" : {
               "structName" : {
-                "_0" : "ConfigStruct"
+                "_0" : "TestModule_ConfigStruct"
               }
             },
             "type" : {
@@ -567,7 +567,7 @@
             "name" : "defaultConfig",
             "staticContext" : {
               "structName" : {
-                "_0" : "ConfigStruct"
+                "_0" : "TestModule_ConfigStruct"
               }
             },
             "type" : {
@@ -582,7 +582,7 @@
             "name" : "timeout",
             "staticContext" : {
               "structName" : {
-                "_0" : "ConfigStruct"
+                "_0" : "TestModule_ConfigStruct"
               }
             },
             "type" : {
@@ -597,7 +597,7 @@
             "name" : "computedSetting",
             "staticContext" : {
               "structName" : {
-                "_0" : "ConfigStruct"
+                "_0" : "TestModule_ConfigStruct"
               }
             },
             "type" : {
@@ -607,7 +607,7 @@
             }
           }
         ],
-        "swiftCallName" : "ConfigStruct"
+        "swiftCallName" : "TestModule.ConfigStruct"
       },
       {
         "methods" : [
@@ -641,12 +641,12 @@
             }
           }
         ],
-        "swiftCallName" : "Container"
+        "swiftCallName" : "TestModule.Container"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_Vector2D_magnitude",
+            "abiName" : "bjs_TestModule_Vector2D_magnitude",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -663,7 +663,7 @@
             }
           },
           {
-            "abiName" : "bjs_Vector2D_scaled",
+            "abiName" : "bjs_TestModule_Vector2D_scaled",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -683,7 +683,7 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Vector2D"
+                "_0" : "TestModule.Vector2D"
               }
             }
           }
@@ -711,7 +711,7 @@
             }
           }
         ],
-        "swiftCallName" : "Vector2D"
+        "swiftCallName" : "TestModule.Vector2D"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStruct.swift
@@ -1,14 +1,14 @@
-extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension TestModule.Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension DataPoint: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> DataPoint {
+extension TestModule.DataPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.DataPoint {
         let optFlag = Optional<Bool>.bridgeJSStackPop()
         let optCount = Optional<Int>.bridgeJSStackPop()
         let label = String.bridgeJSStackPop()
         let y = Double.bridgeJSStackPop()
         let x = Double.bridgeJSStackPop()
-        return DataPoint(x: x, y: y, label: label, optCount: optCount, optFlag: optFlag)
+        return TestModule.DataPoint(x: x, y: y, label: label, optCount: optCount, optFlag: optFlag)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -20,80 +20,80 @@ extension DataPoint: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_DataPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_DataPoint()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_DataPoint()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_DataPoint")
-fileprivate func _bjs_struct_lower_DataPoint_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_DataPoint")
+fileprivate func _bjs_struct_lower_TestModule_DataPoint_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_DataPoint_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_DataPoint_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_DataPoint_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_DataPoint(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_DataPoint_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_DataPoint")
-fileprivate func _bjs_struct_lift_DataPoint_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_DataPoint")
+fileprivate func _bjs_struct_lift_TestModule_DataPoint_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_DataPoint_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_DataPoint_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_DataPoint() -> Int32 {
-    return _bjs_struct_lift_DataPoint_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_DataPoint() -> Int32 {
+    return _bjs_struct_lift_TestModule_DataPoint_extern()
 }
 
-@_expose(wasm, "bjs_DataPoint_init")
-@_cdecl("bjs_DataPoint_init")
-public func _bjs_DataPoint_init(_ x: Float64, _ y: Float64, _ labelBytes: Int32, _ labelLength: Int32, _ optCountIsSome: Int32, _ optCountValue: Int32, _ optFlagIsSome: Int32, _ optFlagValue: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_DataPoint_init")
+@_cdecl("bjs_TestModule_DataPoint_init")
+public func _bjs_TestModule_DataPoint_init(_ x: Float64, _ y: Float64, _ labelBytes: Int32, _ labelLength: Int32, _ optCountIsSome: Int32, _ optCountValue: Int32, _ optFlagIsSome: Int32, _ optFlagValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = DataPoint(x: Double.bridgeJSLiftParameter(x), y: Double.bridgeJSLiftParameter(y), label: String.bridgeJSLiftParameter(labelBytes, labelLength), optCount: Optional<Int>.bridgeJSLiftParameter(optCountIsSome, optCountValue), optFlag: Optional<Bool>.bridgeJSLiftParameter(optFlagIsSome, optFlagValue))
+    let ret = TestModule.DataPoint(x: Double.bridgeJSLiftParameter(x), y: Double.bridgeJSLiftParameter(y), label: String.bridgeJSLiftParameter(labelBytes, labelLength), optCount: Optional<Int>.bridgeJSLiftParameter(optCountIsSome, optCountValue), optFlag: Optional<Bool>.bridgeJSLiftParameter(optFlagIsSome, optFlagValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataPoint_static_dimensions_get")
-@_cdecl("bjs_DataPoint_static_dimensions_get")
-public func _bjs_DataPoint_static_dimensions_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_DataPoint_static_dimensions_get")
+@_cdecl("bjs_TestModule_DataPoint_static_dimensions_get")
+public func _bjs_TestModule_DataPoint_static_dimensions_get() -> Int32 {
     #if arch(wasm32)
-    let ret = DataPoint.dimensions
+    let ret = TestModule.DataPoint.dimensions
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataPoint_static_origin")
-@_cdecl("bjs_DataPoint_static_origin")
-public func _bjs_DataPoint_static_origin() -> Void {
+@_expose(wasm, "bjs_TestModule_DataPoint_static_origin")
+@_cdecl("bjs_TestModule_DataPoint_static_origin")
+public func _bjs_TestModule_DataPoint_static_origin() -> Void {
     #if arch(wasm32)
-    let ret = DataPoint.origin()
+    let ret = TestModule.DataPoint.origin()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Address: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Address {
+extension TestModule.Address: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Address {
         let zipCode = Optional<Int>.bridgeJSStackPop()
         let city = String.bridgeJSStackPop()
         let street = String.bridgeJSStackPop()
-        return Address(street: street, city: city, zipCode: zipCode)
+        return TestModule.Address(street: street, city: city, zipCode: zipCode)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -103,48 +103,48 @@ extension Address: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Address(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Address()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Address()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
-fileprivate func _bjs_struct_lower_Address_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Address")
+fileprivate func _bjs_struct_lower_TestModule_Address_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Address_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Address_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Address_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Address(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Address_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Address")
-fileprivate func _bjs_struct_lift_Address_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Address")
+fileprivate func _bjs_struct_lift_TestModule_Address_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Address_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Address_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Address() -> Int32 {
-    return _bjs_struct_lift_Address_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Address() -> Int32 {
+    return _bjs_struct_lift_TestModule_Address_extern()
 }
 
-extension Person: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Person {
+extension TestModule.Person: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Person {
         let email = Optional<String>.bridgeJSStackPop()
-        let address = Address.bridgeJSStackPop()
+        let address = TestModule.Address.bridgeJSStackPop()
         let age = Int.bridgeJSStackPop()
         let name = String.bridgeJSStackPop()
-        return Person(name: name, age: age, address: address, email: email)
+        return TestModule.Person(name: name, age: age, address: address, email: email)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -155,46 +155,46 @@ extension Person: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Person(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Person(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Person()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Person()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Person")
-fileprivate func _bjs_struct_lower_Person_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Person")
+fileprivate func _bjs_struct_lower_TestModule_Person_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Person_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Person_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Person(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Person_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Person(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Person_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Person")
-fileprivate func _bjs_struct_lift_Person_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Person")
+fileprivate func _bjs_struct_lift_TestModule_Person_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Person_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Person_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Person() -> Int32 {
-    return _bjs_struct_lift_Person_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Person() -> Int32 {
+    return _bjs_struct_lift_TestModule_Person_extern()
 }
 
-extension Session: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Session {
-        let owner = Greeter.bridgeJSStackPop()
+extension TestModule.Session: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Session {
+        let owner = TestModule.Greeter.bridgeJSStackPop()
         let id = Int.bridgeJSStackPop()
-        return Session(id: id, owner: owner)
+        return TestModule.Session(id: id, owner: owner)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -203,47 +203,47 @@ extension Session: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Session(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Session(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Session()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Session()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Session")
-fileprivate func _bjs_struct_lower_Session_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Session")
+fileprivate func _bjs_struct_lower_TestModule_Session_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Session_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Session_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Session(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Session_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Session(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Session_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Session")
-fileprivate func _bjs_struct_lift_Session_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Session")
+fileprivate func _bjs_struct_lift_TestModule_Session_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Session_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Session_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Session() -> Int32 {
-    return _bjs_struct_lift_Session_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Session() -> Int32 {
+    return _bjs_struct_lift_TestModule_Session_extern()
 }
 
-extension Measurement: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Measurement {
-        let optionalPrecision = Optional<Precision>.bridgeJSStackPop()
-        let precision = Precision.bridgeJSStackPop()
+extension TestModule.Measurement: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Measurement {
+        let optionalPrecision = Optional<TestModule.Precision>.bridgeJSStackPop()
+        let precision = TestModule.Precision.bridgeJSStackPop()
         let value = Double.bridgeJSStackPop()
-        return Measurement(value: value, precision: precision, optionalPrecision: optionalPrecision)
+        return TestModule.Measurement(value: value, precision: precision, optionalPrecision: optionalPrecision)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -253,165 +253,165 @@ extension Measurement: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Measurement(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Measurement(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Measurement()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Measurement()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Measurement")
-fileprivate func _bjs_struct_lower_Measurement_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Measurement")
+fileprivate func _bjs_struct_lower_TestModule_Measurement_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Measurement_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Measurement_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Measurement(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Measurement_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Measurement(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Measurement_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Measurement")
-fileprivate func _bjs_struct_lift_Measurement_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Measurement")
+fileprivate func _bjs_struct_lift_TestModule_Measurement_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Measurement_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Measurement_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Measurement() -> Int32 {
-    return _bjs_struct_lift_Measurement_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Measurement() -> Int32 {
+    return _bjs_struct_lift_TestModule_Measurement_extern()
 }
 
-extension ConfigStruct: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ConfigStruct {
-        return ConfigStruct()
+extension TestModule.ConfigStruct: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.ConfigStruct {
+        return TestModule.ConfigStruct()
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_ConfigStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ConfigStruct()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_ConfigStruct()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ConfigStruct")
-fileprivate func _bjs_struct_lower_ConfigStruct_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_ConfigStruct")
+fileprivate func _bjs_struct_lower_TestModule_ConfigStruct_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ConfigStruct_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_ConfigStruct_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_ConfigStruct_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_ConfigStruct(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_ConfigStruct_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ConfigStruct")
-fileprivate func _bjs_struct_lift_ConfigStruct_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_ConfigStruct")
+fileprivate func _bjs_struct_lift_TestModule_ConfigStruct_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_ConfigStruct_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_ConfigStruct_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_ConfigStruct() -> Int32 {
-    return _bjs_struct_lift_ConfigStruct_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_ConfigStruct() -> Int32 {
+    return _bjs_struct_lift_TestModule_ConfigStruct_extern()
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_maxRetries_get")
-@_cdecl("bjs_ConfigStruct_static_maxRetries_get")
-public func _bjs_ConfigStruct_static_maxRetries_get() -> Int32 {
+@_expose(wasm, "bjs_TestModule_ConfigStruct_static_maxRetries_get")
+@_cdecl("bjs_TestModule_ConfigStruct_static_maxRetries_get")
+public func _bjs_TestModule_ConfigStruct_static_maxRetries_get() -> Int32 {
     #if arch(wasm32)
-    let ret = ConfigStruct.maxRetries
+    let ret = TestModule.ConfigStruct.maxRetries
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_defaultConfig_get")
-@_cdecl("bjs_ConfigStruct_static_defaultConfig_get")
-public func _bjs_ConfigStruct_static_defaultConfig_get() -> Void {
+@_expose(wasm, "bjs_TestModule_ConfigStruct_static_defaultConfig_get")
+@_cdecl("bjs_TestModule_ConfigStruct_static_defaultConfig_get")
+public func _bjs_TestModule_ConfigStruct_static_defaultConfig_get() -> Void {
     #if arch(wasm32)
-    let ret = ConfigStruct.defaultConfig
+    let ret = TestModule.ConfigStruct.defaultConfig
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_defaultConfig_set")
-@_cdecl("bjs_ConfigStruct_static_defaultConfig_set")
-public func _bjs_ConfigStruct_static_defaultConfig_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_ConfigStruct_static_defaultConfig_set")
+@_cdecl("bjs_TestModule_ConfigStruct_static_defaultConfig_set")
+public func _bjs_TestModule_ConfigStruct_static_defaultConfig_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    ConfigStruct.defaultConfig = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.ConfigStruct.defaultConfig = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_timeout_get")
-@_cdecl("bjs_ConfigStruct_static_timeout_get")
-public func _bjs_ConfigStruct_static_timeout_get() -> Float64 {
+@_expose(wasm, "bjs_TestModule_ConfigStruct_static_timeout_get")
+@_cdecl("bjs_TestModule_ConfigStruct_static_timeout_get")
+public func _bjs_TestModule_ConfigStruct_static_timeout_get() -> Float64 {
     #if arch(wasm32)
-    let ret = ConfigStruct.timeout
+    let ret = TestModule.ConfigStruct.timeout
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_timeout_set")
-@_cdecl("bjs_ConfigStruct_static_timeout_set")
-public func _bjs_ConfigStruct_static_timeout_set(_ value: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_ConfigStruct_static_timeout_set")
+@_cdecl("bjs_TestModule_ConfigStruct_static_timeout_set")
+public func _bjs_TestModule_ConfigStruct_static_timeout_set(_ value: Float64) -> Void {
     #if arch(wasm32)
-    ConfigStruct.timeout = Double.bridgeJSLiftParameter(value)
+    TestModule.ConfigStruct.timeout = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_computedSetting_get")
-@_cdecl("bjs_ConfigStruct_static_computedSetting_get")
-public func _bjs_ConfigStruct_static_computedSetting_get() -> Void {
+@_expose(wasm, "bjs_TestModule_ConfigStruct_static_computedSetting_get")
+@_cdecl("bjs_TestModule_ConfigStruct_static_computedSetting_get")
+public func _bjs_TestModule_ConfigStruct_static_computedSetting_get() -> Void {
     #if arch(wasm32)
-    let ret = ConfigStruct.computedSetting
+    let ret = TestModule.ConfigStruct.computedSetting
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_update")
-@_cdecl("bjs_ConfigStruct_static_update")
-public func _bjs_ConfigStruct_static_update(_ timeout: Float64) -> Float64 {
+@_expose(wasm, "bjs_TestModule_ConfigStruct_static_update")
+@_cdecl("bjs_TestModule_ConfigStruct_static_update")
+public func _bjs_TestModule_ConfigStruct_static_update(_ timeout: Float64) -> Float64 {
     #if arch(wasm32)
-    let ret = ConfigStruct.update(_: Double.bridgeJSLiftParameter(timeout))
+    let ret = TestModule.ConfigStruct.update(_: Double.bridgeJSLiftParameter(timeout))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Container: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Container {
+extension TestModule.Container: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Container {
         let optionalObject = Optional<JSObject>.bridgeJSStackPop()
         let object = JSObject.bridgeJSStackPop()
-        return Container(object: object, optionalObject: optionalObject)
+        return TestModule.Container(object: object, optionalObject: optionalObject)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -420,46 +420,46 @@ extension Container: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Container(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Container(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Container()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Container()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Container")
-fileprivate func _bjs_struct_lower_Container_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Container")
+fileprivate func _bjs_struct_lower_TestModule_Container_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Container_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Container_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Container(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Container_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Container(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Container_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Container")
-fileprivate func _bjs_struct_lift_Container_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Container")
+fileprivate func _bjs_struct_lift_TestModule_Container_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Container_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Container_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Container() -> Int32 {
-    return _bjs_struct_lift_Container_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Container() -> Int32 {
+    return _bjs_struct_lift_TestModule_Container_extern()
 }
 
-extension Vector2D: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Vector2D {
+extension TestModule.Vector2D: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Vector2D {
         let dy = Double.bridgeJSStackPop()
         let dx = Double.bridgeJSStackPop()
-        return Vector2D(dx: dx, dy: dy)
+        return TestModule.Vector2D(dx: dx, dy: dy)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -468,155 +468,155 @@ extension Vector2D: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Vector2D(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Vector2D(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Vector2D()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Vector2D()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Vector2D")
-fileprivate func _bjs_struct_lower_Vector2D_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Vector2D")
+fileprivate func _bjs_struct_lower_TestModule_Vector2D_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Vector2D_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Vector2D_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Vector2D(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Vector2D_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Vector2D(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Vector2D_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Vector2D")
-fileprivate func _bjs_struct_lift_Vector2D_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Vector2D")
+fileprivate func _bjs_struct_lift_TestModule_Vector2D_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Vector2D_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Vector2D_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Vector2D() -> Int32 {
-    return _bjs_struct_lift_Vector2D_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Vector2D() -> Int32 {
+    return _bjs_struct_lift_TestModule_Vector2D_extern()
 }
 
-@_expose(wasm, "bjs_Vector2D_magnitude")
-@_cdecl("bjs_Vector2D_magnitude")
-public func _bjs_Vector2D_magnitude() -> Float64 {
+@_expose(wasm, "bjs_TestModule_Vector2D_magnitude")
+@_cdecl("bjs_TestModule_Vector2D_magnitude")
+public func _bjs_TestModule_Vector2D_magnitude() -> Float64 {
     #if arch(wasm32)
-    let ret = Vector2D.bridgeJSLiftParameter().magnitude()
+    let ret = TestModule.Vector2D.bridgeJSLiftParameter().magnitude()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Vector2D_scaled")
-@_cdecl("bjs_Vector2D_scaled")
-public func _bjs_Vector2D_scaled(_ factor: Float64) -> Void {
+@_expose(wasm, "bjs_TestModule_Vector2D_scaled")
+@_cdecl("bjs_TestModule_Vector2D_scaled")
+public func _bjs_TestModule_Vector2D_scaled(_ factor: Float64) -> Void {
     #if arch(wasm32)
-    let ret = Vector2D.bridgeJSLiftParameter().scaled(by: Double.bridgeJSLiftParameter(factor))
+    let ret = TestModule.Vector2D.bridgeJSLiftParameter().scaled(by: Double.bridgeJSLiftParameter(factor))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtrip")
-@_cdecl("bjs_roundtrip")
-public func _bjs_roundtrip() -> Void {
+@_expose(wasm, "bjs_TestModule_roundtrip")
+@_cdecl("bjs_TestModule_roundtrip")
+public func _bjs_TestModule_roundtrip() -> Void {
     #if arch(wasm32)
-    let ret = roundtrip(_: Person.bridgeJSLiftParameter())
+    let ret = roundtrip(_: TestModule.Person.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripContainer")
-@_cdecl("bjs_roundtripContainer")
-public func _bjs_roundtripContainer() -> Void {
+@_expose(wasm, "bjs_TestModule_roundtripContainer")
+@_cdecl("bjs_TestModule_roundtripContainer")
+public func _bjs_TestModule_roundtripContainer() -> Void {
     #if arch(wasm32)
-    let ret = roundtripContainer(_: Container.bridgeJSLiftParameter())
+    let ret = roundtripContainer(_: TestModule.Container.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_init")
-@_cdecl("bjs_Greeter_init")
-public func _bjs_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_Greeter_init")
+@_cdecl("bjs_TestModule_Greeter_init")
+public func _bjs_TestModule_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = TestModule.Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greet")
-@_cdecl("bjs_Greeter_greet")
-public func _bjs_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_greet")
+@_cdecl("bjs_TestModule_Greeter_greet")
+public func _bjs_TestModule_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greet()
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_get")
-@_cdecl("bjs_Greeter_name_get")
-public func _bjs_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_name_get")
+@_cdecl("bjs_TestModule_Greeter_name_get")
+public func _bjs_TestModule_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).name
+    let ret = TestModule.Greeter.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_set")
-@_cdecl("bjs_Greeter_name_set")
-public func _bjs_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_name_set")
+@_cdecl("bjs_TestModule_Greeter_name_set")
+public func _bjs_TestModule_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    Greeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    TestModule.Greeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_deinit")
-@_cdecl("bjs_Greeter_deinit")
-public func _bjs_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_Greeter_deinit")
+@_cdecl("bjs_TestModule_Greeter_deinit")
+public func _bjs_TestModule_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Greeter>.fromOpaque(pointer).release()
+    Unmanaged<TestModule.Greeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension TestModule.Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_TestModule_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "TestModule", name: "bjs_Greeter_wrap")
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "TestModule", name: "bjs_TestModule_Greeter_wrap")
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_TestModule_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Greeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_TestModule_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_TestModule_Greeter_wrap_extern(pointer)
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.json
@@ -50,7 +50,7 @@
             }
           }
         ],
-        "swiftCallName" : "Point"
+        "swiftCallName" : "TestModule.Point"
       }
     ]
   },
@@ -71,7 +71,7 @@
                 "name" : "point",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "TestModule.Point"
                   }
                 }
               },
@@ -100,7 +100,7 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Point"
+                "_0" : "TestModule.Point"
               }
             }
           },
@@ -119,7 +119,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "TestModule.Point"
                       }
                     },
                     "_1" : "null"
@@ -131,7 +131,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "TestModule.Point"
                   }
                 },
                 "_1" : "null"

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/SwiftStructImports.swift
@@ -1,8 +1,8 @@
-extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+extension TestModule.Point: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.Point {
         let y = Int.bridgeJSStackPop()
         let x = Int.bridgeJSStackPop()
-        return Point(x: x, y: y)
+        return TestModule.Point(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -11,39 +11,39 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_Point()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_Point")
+fileprivate func _bjs_struct_lower_TestModule_Point_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_Point_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Point_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_Point(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_Point_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Point")
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_Point")
+fileprivate func _bjs_struct_lift_TestModule_Point_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_Point_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Point() -> Int32 {
-    return _bjs_struct_lift_Point_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_Point() -> Int32 {
+    return _bjs_struct_lift_TestModule_Point_extern()
 }
 
 #if arch(wasm32)
@@ -58,7 +58,7 @@ fileprivate func bjs_translate_extern(_ point: Int32, _ dx: Int32, _ dy: Int32) 
     return bjs_translate_extern(point, dx, dy)
 }
 
-func _$translate(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException) -> Point {
+func _$translate(_ point: TestModule.Point, _ dx: Int, _ dy: Int) throws(JSException) -> TestModule.Point {
     let pointObjectId = point.bridgeJSLowerParameter()
     let dxValue = dx.bridgeJSLowerParameter()
     let dyValue = dy.bridgeJSLowerParameter()
@@ -66,7 +66,7 @@ func _$translate(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException) -> Po
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Point.bridgeJSLiftReturn(ret)
+    return TestModule.Point.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)
@@ -81,11 +81,11 @@ fileprivate func bjs_roundTripOptional_extern(_ point: Int32) -> Void {
     return bjs_roundTripOptional_extern(point)
 }
 
-func _$roundTripOptional(_ point: Optional<Point>) throws(JSException) -> Optional<Point> {
+func _$roundTripOptional(_ point: Optional<TestModule.Point>) throws(JSException) -> Optional<TestModule.Point> {
     let pointIsSome = point.bridgeJSLowerParameter()
     bjs_roundTripOptional(pointIsSome)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<Point>.bridgeJSLiftReturn()
+    return Optional<TestModule.Point>.bridgeJSLiftReturn()
 }

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Throws.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Throws.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_throwsSomething",
+        "abiName" : "bjs_TestModule_throwsSomething",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Throws.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/Throws.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_throwsSomething")
-@_cdecl("bjs_throwsSomething")
-public func _bjs_throwsSomething() -> Void {
+@_expose(wasm, "bjs_TestModule_throwsSomething")
+@_cdecl("bjs_TestModule_throwsSomething")
+public func _bjs_TestModule_throwsSomething() -> Void {
     #if arch(wasm32)
     do {
         try throwsSomething()

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_takeUnsafeRawPointer",
+        "abiName" : "bjs_TestModule_takeUnsafeRawPointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -39,7 +39,7 @@
         }
       },
       {
-        "abiName" : "bjs_takeUnsafeMutableRawPointer",
+        "abiName" : "bjs_TestModule_takeUnsafeMutableRawPointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -66,7 +66,7 @@
         }
       },
       {
-        "abiName" : "bjs_takeOpaquePointer",
+        "abiName" : "bjs_TestModule_takeOpaquePointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -93,7 +93,7 @@
         }
       },
       {
-        "abiName" : "bjs_takeUnsafePointer",
+        "abiName" : "bjs_TestModule_takeUnsafePointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -121,7 +121,7 @@
         }
       },
       {
-        "abiName" : "bjs_takeUnsafeMutablePointer",
+        "abiName" : "bjs_TestModule_takeUnsafeMutablePointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -149,7 +149,7 @@
         }
       },
       {
-        "abiName" : "bjs_returnUnsafeRawPointer",
+        "abiName" : "bjs_TestModule_returnUnsafeRawPointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -168,7 +168,7 @@
         }
       },
       {
-        "abiName" : "bjs_returnUnsafeMutableRawPointer",
+        "abiName" : "bjs_TestModule_returnUnsafeMutableRawPointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -187,7 +187,7 @@
         }
       },
       {
-        "abiName" : "bjs_returnOpaquePointer",
+        "abiName" : "bjs_TestModule_returnOpaquePointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -206,7 +206,7 @@
         }
       },
       {
-        "abiName" : "bjs_returnUnsafePointer",
+        "abiName" : "bjs_TestModule_returnUnsafePointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -226,7 +226,7 @@
         }
       },
       {
-        "abiName" : "bjs_returnUnsafeMutablePointer",
+        "abiName" : "bjs_TestModule_returnUnsafeMutablePointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -246,7 +246,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripPointerFields",
+        "abiName" : "bjs_TestModule_roundTripPointerFields",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -259,14 +259,14 @@
             "name" : "value",
             "type" : {
               "swiftStruct" : {
-                "_0" : "PointerFields"
+                "_0" : "TestModule.PointerFields"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "PointerFields"
+            "_0" : "TestModule.PointerFields"
           }
         }
       }
@@ -277,7 +277,7 @@
     "structs" : [
       {
         "constructor" : {
-          "abiName" : "bjs_PointerFields_init",
+          "abiName" : "bjs_TestModule_PointerFields_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -411,7 +411,7 @@
             }
           }
         ],
-        "swiftCallName" : "PointerFields"
+        "swiftCallName" : "TestModule.PointerFields"
       }
     ]
   },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/UnsafePointer.swift
@@ -1,11 +1,11 @@
-extension PointerFields: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PointerFields {
+extension TestModule.PointerFields: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> TestModule.PointerFields {
         let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSStackPop()
         let ptr = UnsafePointer<UInt8>.bridgeJSStackPop()
         let opaque = OpaquePointer.bridgeJSStackPop()
         let mutRaw = UnsafeMutableRawPointer.bridgeJSStackPop()
         let raw = UnsafeRawPointer.bridgeJSStackPop()
-        return PointerFields(raw: raw, mutRaw: mutRaw, opaque: opaque, ptr: ptr, mutPtr: mutPtr)
+        return TestModule.PointerFields(raw: raw, mutRaw: mutRaw, opaque: opaque, ptr: ptr, mutPtr: mutPtr)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -17,55 +17,55 @@ extension PointerFields: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_TestModule_PointerFields(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PointerFields()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_TestModule_PointerFields()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PointerFields")
-fileprivate func _bjs_struct_lower_PointerFields_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_TestModule_PointerFields")
+fileprivate func _bjs_struct_lower_TestModule_PointerFields_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PointerFields_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_TestModule_PointerFields_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_PointerFields_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_TestModule_PointerFields(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_TestModule_PointerFields_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PointerFields")
-fileprivate func _bjs_struct_lift_PointerFields_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_TestModule_PointerFields")
+fileprivate func _bjs_struct_lift_TestModule_PointerFields_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_PointerFields_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_TestModule_PointerFields_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_PointerFields() -> Int32 {
-    return _bjs_struct_lift_PointerFields_extern()
+@inline(never) fileprivate func _bjs_struct_lift_TestModule_PointerFields() -> Int32 {
+    return _bjs_struct_lift_TestModule_PointerFields_extern()
 }
 
-@_expose(wasm, "bjs_PointerFields_init")
-@_cdecl("bjs_PointerFields_init")
-public func _bjs_PointerFields_init(_ raw: UnsafeMutableRawPointer, _ mutRaw: UnsafeMutableRawPointer, _ opaque: UnsafeMutableRawPointer, _ ptr: UnsafeMutableRawPointer, _ mutPtr: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_PointerFields_init")
+@_cdecl("bjs_TestModule_PointerFields_init")
+public func _bjs_TestModule_PointerFields_init(_ raw: UnsafeMutableRawPointer, _ mutRaw: UnsafeMutableRawPointer, _ opaque: UnsafeMutableRawPointer, _ ptr: UnsafeMutableRawPointer, _ mutPtr: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PointerFields(raw: UnsafeRawPointer.bridgeJSLiftParameter(raw), mutRaw: UnsafeMutableRawPointer.bridgeJSLiftParameter(mutRaw), opaque: OpaquePointer.bridgeJSLiftParameter(opaque), ptr: UnsafePointer<UInt8>.bridgeJSLiftParameter(ptr), mutPtr: UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter(mutPtr))
+    let ret = TestModule.PointerFields(raw: UnsafeRawPointer.bridgeJSLiftParameter(raw), mutRaw: UnsafeMutableRawPointer.bridgeJSLiftParameter(mutRaw), opaque: OpaquePointer.bridgeJSLiftParameter(opaque), ptr: UnsafePointer<UInt8>.bridgeJSLiftParameter(ptr), mutPtr: UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter(mutPtr))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_takeUnsafeRawPointer")
-@_cdecl("bjs_takeUnsafeRawPointer")
-public func _bjs_takeUnsafeRawPointer(_ p: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_takeUnsafeRawPointer")
+@_cdecl("bjs_TestModule_takeUnsafeRawPointer")
+public func _bjs_TestModule_takeUnsafeRawPointer(_ p: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     takeUnsafeRawPointer(_: UnsafeRawPointer.bridgeJSLiftParameter(p))
     #else
@@ -73,9 +73,9 @@ public func _bjs_takeUnsafeRawPointer(_ p: UnsafeMutableRawPointer) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_takeUnsafeMutableRawPointer")
-@_cdecl("bjs_takeUnsafeMutableRawPointer")
-public func _bjs_takeUnsafeMutableRawPointer(_ p: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_takeUnsafeMutableRawPointer")
+@_cdecl("bjs_TestModule_takeUnsafeMutableRawPointer")
+public func _bjs_TestModule_takeUnsafeMutableRawPointer(_ p: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     takeUnsafeMutableRawPointer(_: UnsafeMutableRawPointer.bridgeJSLiftParameter(p))
     #else
@@ -83,9 +83,9 @@ public func _bjs_takeUnsafeMutableRawPointer(_ p: UnsafeMutableRawPointer) -> Vo
     #endif
 }
 
-@_expose(wasm, "bjs_takeOpaquePointer")
-@_cdecl("bjs_takeOpaquePointer")
-public func _bjs_takeOpaquePointer(_ p: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_takeOpaquePointer")
+@_cdecl("bjs_TestModule_takeOpaquePointer")
+public func _bjs_TestModule_takeOpaquePointer(_ p: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     takeOpaquePointer(_: OpaquePointer.bridgeJSLiftParameter(p))
     #else
@@ -93,9 +93,9 @@ public func _bjs_takeOpaquePointer(_ p: UnsafeMutableRawPointer) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_takeUnsafePointer")
-@_cdecl("bjs_takeUnsafePointer")
-public func _bjs_takeUnsafePointer(_ p: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_takeUnsafePointer")
+@_cdecl("bjs_TestModule_takeUnsafePointer")
+public func _bjs_TestModule_takeUnsafePointer(_ p: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     takeUnsafePointer(_: UnsafePointer<UInt8>.bridgeJSLiftParameter(p))
     #else
@@ -103,9 +103,9 @@ public func _bjs_takeUnsafePointer(_ p: UnsafeMutableRawPointer) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_takeUnsafeMutablePointer")
-@_cdecl("bjs_takeUnsafeMutablePointer")
-public func _bjs_takeUnsafeMutablePointer(_ p: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_TestModule_takeUnsafeMutablePointer")
+@_cdecl("bjs_TestModule_takeUnsafeMutablePointer")
+public func _bjs_TestModule_takeUnsafeMutablePointer(_ p: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
     takeUnsafeMutablePointer(_: UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter(p))
     #else
@@ -113,9 +113,9 @@ public func _bjs_takeUnsafeMutablePointer(_ p: UnsafeMutableRawPointer) -> Void 
     #endif
 }
 
-@_expose(wasm, "bjs_returnUnsafeRawPointer")
-@_cdecl("bjs_returnUnsafeRawPointer")
-public func _bjs_returnUnsafeRawPointer() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_returnUnsafeRawPointer")
+@_cdecl("bjs_TestModule_returnUnsafeRawPointer")
+public func _bjs_TestModule_returnUnsafeRawPointer() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = returnUnsafeRawPointer()
     return ret.bridgeJSLowerReturn()
@@ -124,9 +124,9 @@ public func _bjs_returnUnsafeRawPointer() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_returnUnsafeMutableRawPointer")
-@_cdecl("bjs_returnUnsafeMutableRawPointer")
-public func _bjs_returnUnsafeMutableRawPointer() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_returnUnsafeMutableRawPointer")
+@_cdecl("bjs_TestModule_returnUnsafeMutableRawPointer")
+public func _bjs_TestModule_returnUnsafeMutableRawPointer() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = returnUnsafeMutableRawPointer()
     return ret.bridgeJSLowerReturn()
@@ -135,9 +135,9 @@ public func _bjs_returnUnsafeMutableRawPointer() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_returnOpaquePointer")
-@_cdecl("bjs_returnOpaquePointer")
-public func _bjs_returnOpaquePointer() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_returnOpaquePointer")
+@_cdecl("bjs_TestModule_returnOpaquePointer")
+public func _bjs_TestModule_returnOpaquePointer() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = returnOpaquePointer()
     return ret.bridgeJSLowerReturn()
@@ -146,9 +146,9 @@ public func _bjs_returnOpaquePointer() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_returnUnsafePointer")
-@_cdecl("bjs_returnUnsafePointer")
-public func _bjs_returnUnsafePointer() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_returnUnsafePointer")
+@_cdecl("bjs_TestModule_returnUnsafePointer")
+public func _bjs_TestModule_returnUnsafePointer() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = returnUnsafePointer()
     return ret.bridgeJSLowerReturn()
@@ -157,9 +157,9 @@ public func _bjs_returnUnsafePointer() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_returnUnsafeMutablePointer")
-@_cdecl("bjs_returnUnsafeMutablePointer")
-public func _bjs_returnUnsafeMutablePointer() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_TestModule_returnUnsafeMutablePointer")
+@_cdecl("bjs_TestModule_returnUnsafeMutablePointer")
+public func _bjs_TestModule_returnUnsafeMutablePointer() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = returnUnsafeMutablePointer()
     return ret.bridgeJSLowerReturn()
@@ -168,11 +168,11 @@ public func _bjs_returnUnsafeMutablePointer() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripPointerFields")
-@_cdecl("bjs_roundTripPointerFields")
-public func _bjs_roundTripPointerFields() -> Void {
+@_expose(wasm, "bjs_TestModule_roundTripPointerFields")
+@_cdecl("bjs_TestModule_roundTripPointerFields")
+public func _bjs_TestModule_roundTripPointerFields() -> Void {
     #if arch(wasm32)
-    let ret = roundTripPointerFields(_: PointerFields.bridgeJSLiftParameter())
+    let ret = roundTripPointerFields(_: TestModule.PointerFields.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/VoidParameterVoidReturn.json
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/VoidParameterVoidReturn.json
@@ -12,7 +12,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_check",
+        "abiName" : "bjs_TestModule_check",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/VoidParameterVoidReturn.swift
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSCodegenTests/VoidParameterVoidReturn.swift
@@ -1,6 +1,6 @@
-@_expose(wasm, "bjs_check")
-@_cdecl("bjs_check")
-public func _bjs_check() -> Void {
+@_expose(wasm, "bjs_TestModule_check")
+@_cdecl("bjs_TestModule_check")
+public func _bjs_TestModule_check() -> Void {
     #if arch(wasm32)
     check()
     #else

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Alias.js
@@ -37,7 +37,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createInnerTagValuesHelpers = () => ({
+    const __bjs_createTestModule_InnerTagHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -240,11 +240,11 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_PolygonReference_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_PolygonReference_wrap"] = function(pointer) {
                 const obj = _exports['PolygonReference'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_TagReference_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_TagReference_wrap"] = function(pointer) {
                 const obj = _exports['TagReference'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -387,45 +387,45 @@ export async function createInstantiator(options, swift) {
             }
             class PolygonReference extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PolygonReference_deinit, PolygonReference.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_PolygonReference_deinit, PolygonReference.prototype, null);
                 }
 
                 constructor(underlying) {
-                    const ret = instance.exports.bjs_PolygonReference_init(underlying.pointer);
+                    const ret = instance.exports.bjs_TestModule_PolygonReference_init(underlying.pointer);
                     return PolygonReference.__construct(ret);
                 }
                 snapshot() {
-                    const ret = instance.exports.bjs_PolygonReference_snapshot(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PolygonReference_snapshot(this.pointer);
                     return PolygonReference.__construct(ret);
                 }
                 merge(other) {
-                    const ret = instance.exports.bjs_PolygonReference_merge(this.pointer, other.pointer);
+                    const ret = instance.exports.bjs_TestModule_PolygonReference_merge(this.pointer, other.pointer);
                     return PolygonReference.__construct(ret);
                 }
                 static origin() {
-                    const ret = instance.exports.bjs_PolygonReference_static_origin();
+                    const ret = instance.exports.bjs_TestModule_PolygonReference_static_origin();
                     return PolygonReference.__construct(ret);
                 }
             }
             class TagReference extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TagReference_deinit, TagReference.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_TagReference_deinit, TagReference.prototype, null);
                 }
 
                 constructor(underlying) {
-                    const ret = instance.exports.bjs_TagReference_init(underlying.pointer);
+                    const ret = instance.exports.bjs_TestModule_TagReference_init(underlying.pointer);
                     return TagReference.__construct(ret);
                 }
             }
-            const InnerTagHelpers = __bjs_createInnerTagValuesHelpers();
-            enumHelpers.InnerTag = InnerTagHelpers;
+            const TestModule_InnerTagHelpers = __bjs_createTestModule_InnerTagHelpers();
+            enumHelpers.TestModule_InnerTag = TestModule_InnerTagHelpers;
 
             const exports = {
-                roundtripPolygon: function bjs_roundtripPolygon(polygon) {
-                    const ret = instance.exports.bjs_roundtripPolygon(polygon.pointer);
+                roundtripPolygon: function bjs_TestModule_roundtripPolygon(polygon) {
+                    const ret = instance.exports.bjs_TestModule_roundtripPolygon(polygon.pointer);
                     return PolygonReference.__construct(ret);
                 },
-                optionalPolygon: function bjs_optionalPolygon(polygon) {
+                optionalPolygon: function bjs_TestModule_optionalPolygon(polygon) {
                     const isSome = polygon != null;
                     let result;
                     if (isSome) {
@@ -433,18 +433,18 @@ export async function createInstantiator(options, swift) {
                     } else {
                         result = 0;
                     }
-                    instance.exports.bjs_optionalPolygon(+isSome, result);
+                    instance.exports.bjs_TestModule_optionalPolygon(+isSome, result);
                     const pointer = tmpRetOptionalHeapObject;
                     tmpRetOptionalHeapObject = undefined;
                     const optResult = pointer === null ? null : PolygonReference.__construct(pointer);
                     return optResult;
                 },
-                polygonArray: function bjs_polygonArray(polygons) {
+                polygonArray: function bjs_TestModule_polygonArray(polygons) {
                     for (const elem of polygons) {
                         ptrStack.push(elem.pointer);
                     }
                     i32Stack.push(polygons.length);
-                    instance.exports.bjs_polygonArray();
+                    instance.exports.bjs_TestModule_polygonArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -460,8 +460,8 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                validatePolygon: function bjs_validatePolygon(polygon) {
-                    const ret = instance.exports.bjs_validatePolygon(polygon.pointer);
+                validatePolygon: function bjs_TestModule_validatePolygon(polygon) {
+                    const ret = instance.exports.bjs_TestModule_validatePolygon(polygon.pointer);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -470,23 +470,23 @@ export async function createInstantiator(options, swift) {
                     }
                     return PolygonReference.__construct(ret);
                 },
-                makeTag: function bjs_makeTag(name) {
+                makeTag: function bjs_TestModule_makeTag(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_makeTag(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_makeTag(nameId, nameBytes.length);
                     return TagReference.__construct(ret);
                 },
-                roundtripTags: function bjs_roundtripTags(xs) {
+                roundtripTags: function bjs_TestModule_roundtripTags(xs) {
                     for (const elem of xs) {
                         const isSome = elem != null ? 1 : 0;
                         if (isSome) {
-                            const caseId = enumHelpers.InnerTag.lower(elem);
+                            const caseId = enumHelpers.TestModule_InnerTag.lower(elem);
                             i32Stack.push(caseId);
                         }
                         i32Stack.push(isSome);
                     }
                     i32Stack.push(xs.length);
-                    instance.exports.bjs_roundtripTags();
+                    instance.exports.bjs_TestModule_roundtripTags();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -499,7 +499,7 @@ export async function createInstantiator(options, swift) {
                             if (isSome1 === 0) {
                                 optValue = null;
                             } else {
-                                const enumValue = enumHelpers.InnerTag.lift(i32Stack.pop());
+                                const enumValue = enumHelpers.TestModule_InnerTag.lift(i32Stack.pop());
                                 optValue = enumValue;
                             }
                             arrayResult.push(optValue);
@@ -508,8 +508,8 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                describeUser: function bjs_describeUser(owner) {
-                    const ret = instance.exports.bjs_describeUser(swift.memory.retain(owner));
+                describeUser: function bjs_TestModule_describeUser(owner) {
+                    const ret = instance.exports.bjs_TestModule_describeUser(swift.memory.retain(owner));
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AliasInClosure.js
@@ -232,7 +232,7 @@ export async function createInstantiator(options, swift) {
                 const func = swift.memory.getObject(funcRef);
                 func.__unregister();
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleAl7Polygon_Si"] = function(callbackId, param0) {
+            bjs["invoke_js_callback_TestModule_10TestModuleAl18TestModule_Polygon_Si"] = function(callbackId, param0) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback(_exports['PolygonReference'].__construct(param0));
@@ -242,9 +242,9 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModuleAl7Polygon_Si"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleAl7Polygon_Si = function(param0) {
-                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleAl7Polygon_Si(boxPtr, param0.pointer);
+            bjs["make_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si = function(param0) {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si(boxPtr, param0.pointer);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -253,9 +253,9 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleAl7Polygon_Si);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleAl18TestModule_Polygon_Si);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuley_Al7Polygon"] = function(callbackId) {
+            bjs["invoke_js_callback_TestModule_10TestModuley_Al18TestModule_Polygon"] = function(callbackId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback();
@@ -265,9 +265,9 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModuley_Al7Polygon"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuley_Al7Polygon = function() {
-                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuley_Al7Polygon(boxPtr);
+            bjs["make_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuley_Al18TestModule_Polygon = function() {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuley_Al18TestModule_Polygon(boxPtr);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -276,13 +276,13 @@ export async function createInstantiator(options, swift) {
                     }
                     return _exports['PolygonReference'].__construct(ret);
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuley_Al7Polygon);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuley_Al18TestModule_Polygon);
             }
             // Wrapper functions for module: TestModule
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_PolygonReference_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_PolygonReference_wrap"] = function(pointer) {
                 const obj = _exports['PolygonReference'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -354,21 +354,21 @@ export async function createInstantiator(options, swift) {
             }
             class PolygonReference extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PolygonReference_deinit, PolygonReference.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_PolygonReference_deinit, PolygonReference.prototype, null);
                 }
 
                 constructor(sides) {
-                    const ret = instance.exports.bjs_PolygonReference_init(sides);
+                    const ret = instance.exports.bjs_TestModule_PolygonReference_init(sides);
                     return PolygonReference.__construct(ret);
                 }
             }
             const exports = {
-                makePolygonFactory: function bjs_makePolygonFactory() {
-                    const ret = instance.exports.bjs_makePolygonFactory();
+                makePolygonFactory: function bjs_TestModule_makePolygonFactory() {
+                    const ret = instance.exports.bjs_TestModule_makePolygonFactory();
                     return swift.memory.getObject(ret);
                 },
-                makePolygonInspector: function bjs_makePolygonInspector() {
-                    const ret = instance.exports.bjs_makePolygonInspector();
+                makePolygonInspector: function bjs_TestModule_makePolygonInspector() {
+                    const ret = instance.exports.bjs_TestModule_makePolygonInspector();
                     return swift.memory.getObject(ret);
                 },
                 PolygonReference,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ArrayTypes.js
@@ -44,7 +44,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createPointHelpers = () => ({
+    const __bjs_createTestModule_PointHelpers = () => ({
         lower: (value) => {
             f64Stack.push(value.x);
             f64Stack.push(value.y);
@@ -131,11 +131,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_Point"] = function(objectId) {
-                structHelpers.Point.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Point"] = function(objectId) {
+                structHelpers.TestModule_Point.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Point"] = function() {
-                const value = structHelpers.Point.lift();
+            bjs["swift_js_struct_lift_TestModule_Point"] = function() {
+                const value = structHelpers.TestModule_Point.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -239,11 +239,11 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Item_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Item_wrap"] = function(pointer) {
                 const obj = _exports['Item'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_MultiArrayContainer_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_MultiArrayContainer_wrap"] = function(pointer) {
                 const obj = _exports['MultiArrayContainer'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -432,13 +432,13 @@ export async function createInstantiator(options, swift) {
             }
             class Item extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Item_deinit, Item.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Item_deinit, Item.prototype, null);
                 }
 
             }
             class MultiArrayContainer extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_MultiArrayContainer_deinit, MultiArrayContainer.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_MultiArrayContainer_deinit, MultiArrayContainer.prototype, null);
                 }
 
                 constructor(nums, strs) {
@@ -453,11 +453,11 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(id);
                     }
                     i32Stack.push(strs.length);
-                    const ret = instance.exports.bjs_MultiArrayContainer_init();
+                    const ret = instance.exports.bjs_TestModule_MultiArrayContainer_init();
                     return MultiArrayContainer.__construct(ret);
                 }
                 get numbers() {
-                    instance.exports.bjs_MultiArrayContainer_numbers_get(this.pointer);
+                    instance.exports.bjs_TestModule_MultiArrayContainer_numbers_get(this.pointer);
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -473,7 +473,7 @@ export async function createInstantiator(options, swift) {
                     return arrayResult;
                 }
                 get strings() {
-                    instance.exports.bjs_MultiArrayContainer_strings_get(this.pointer);
+                    instance.exports.bjs_TestModule_MultiArrayContainer_strings_get(this.pointer);
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -489,16 +489,16 @@ export async function createInstantiator(options, swift) {
                     return arrayResult;
                 }
             }
-            const PointHelpers = __bjs_createPointHelpers();
-            structHelpers.Point = PointHelpers;
+            const TestModule_PointHelpers = __bjs_createTestModule_PointHelpers();
+            structHelpers.TestModule_Point = TestModule_PointHelpers;
 
             const exports = {
-                processIntArray: function bjs_processIntArray(values) {
+                processIntArray: function bjs_TestModule_processIntArray(values) {
                     for (const elem of values) {
                         i32Stack.push((elem | 0));
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processIntArray();
+                    instance.exports.bjs_TestModule_processIntArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -513,7 +513,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processStringArray: function bjs_processStringArray(values) {
+                processStringArray: function bjs_TestModule_processStringArray(values) {
                     for (const elem of values) {
                         const bytes = textEncoder.encode(elem);
                         const id = swift.memory.retain(bytes);
@@ -521,7 +521,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(id);
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processStringArray();
+                    instance.exports.bjs_TestModule_processStringArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -536,12 +536,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processDoubleArray: function bjs_processDoubleArray(values) {
+                processDoubleArray: function bjs_TestModule_processDoubleArray(values) {
                     for (const elem of values) {
                         f64Stack.push(elem);
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processDoubleArray();
+                    instance.exports.bjs_TestModule_processDoubleArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -556,12 +556,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processBoolArray: function bjs_processBoolArray(values) {
+                processBoolArray: function bjs_TestModule_processBoolArray(values) {
                     for (const elem of values) {
                         i32Stack.push(elem ? 1 : 0);
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processBoolArray();
+                    instance.exports.bjs_TestModule_processBoolArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -576,12 +576,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processPointArray: function bjs_processPointArray(points) {
+                processPointArray: function bjs_TestModule_processPointArray(points) {
                     for (const elem of points) {
-                        structHelpers.Point.lower(elem);
+                        structHelpers.TestModule_Point.lower(elem);
                     }
                     i32Stack.push(points.length);
-                    instance.exports.bjs_processPointArray();
+                    instance.exports.bjs_TestModule_processPointArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -589,19 +589,19 @@ export async function createInstantiator(options, swift) {
                     } else {
                         arrayResult = [];
                         for (let i = 0; i < arrayLen; i++) {
-                            const struct = structHelpers.Point.lift();
+                            const struct = structHelpers.TestModule_Point.lift();
                             arrayResult.push(struct);
                         }
                         arrayResult.reverse();
                     }
                     return arrayResult;
                 },
-                processDirectionArray: function bjs_processDirectionArray(directions) {
+                processDirectionArray: function bjs_TestModule_processDirectionArray(directions) {
                     for (const elem of directions) {
                         i32Stack.push((elem | 0));
                     }
                     i32Stack.push(directions.length);
-                    instance.exports.bjs_processDirectionArray();
+                    instance.exports.bjs_TestModule_processDirectionArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -616,12 +616,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processStatusArray: function bjs_processStatusArray(statuses) {
+                processStatusArray: function bjs_TestModule_processStatusArray(statuses) {
                     for (const elem of statuses) {
                         i32Stack.push((elem | 0));
                     }
                     i32Stack.push(statuses.length);
-                    instance.exports.bjs_processStatusArray();
+                    instance.exports.bjs_TestModule_processStatusArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -636,31 +636,31 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                sumIntArray: function bjs_sumIntArray(values) {
+                sumIntArray: function bjs_TestModule_sumIntArray(values) {
                     for (const elem of values) {
                         i32Stack.push((elem | 0));
                     }
                     i32Stack.push(values.length);
-                    const ret = instance.exports.bjs_sumIntArray();
+                    const ret = instance.exports.bjs_TestModule_sumIntArray();
                     return ret;
                 },
-                findFirstPoint: function bjs_findFirstPoint(points, matching) {
+                findFirstPoint: function bjs_TestModule_findFirstPoint(points, matching) {
                     for (const elem of points) {
-                        structHelpers.Point.lower(elem);
+                        structHelpers.TestModule_Point.lower(elem);
                     }
                     i32Stack.push(points.length);
                     const matchingBytes = textEncoder.encode(matching);
                     const matchingId = swift.memory.retain(matchingBytes);
-                    instance.exports.bjs_findFirstPoint(matchingId, matchingBytes.length);
-                    const structValue = structHelpers.Point.lift();
+                    instance.exports.bjs_TestModule_findFirstPoint(matchingId, matchingBytes.length);
+                    const structValue = structHelpers.TestModule_Point.lift();
                     return structValue;
                 },
-                processUnsafeRawPointerArray: function bjs_processUnsafeRawPointerArray(values) {
+                processUnsafeRawPointerArray: function bjs_TestModule_processUnsafeRawPointerArray(values) {
                     for (const elem of values) {
                         ptrStack.push((elem | 0));
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processUnsafeRawPointerArray();
+                    instance.exports.bjs_TestModule_processUnsafeRawPointerArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -675,12 +675,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processUnsafeMutableRawPointerArray: function bjs_processUnsafeMutableRawPointerArray(values) {
+                processUnsafeMutableRawPointerArray: function bjs_TestModule_processUnsafeMutableRawPointerArray(values) {
                     for (const elem of values) {
                         ptrStack.push((elem | 0));
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processUnsafeMutableRawPointerArray();
+                    instance.exports.bjs_TestModule_processUnsafeMutableRawPointerArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -695,12 +695,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processOpaquePointerArray: function bjs_processOpaquePointerArray(values) {
+                processOpaquePointerArray: function bjs_TestModule_processOpaquePointerArray(values) {
                     for (const elem of values) {
                         ptrStack.push((elem | 0));
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processOpaquePointerArray();
+                    instance.exports.bjs_TestModule_processOpaquePointerArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -715,7 +715,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processOptionalIntArray: function bjs_processOptionalIntArray(values) {
+                processOptionalIntArray: function bjs_TestModule_processOptionalIntArray(values) {
                     for (const elem of values) {
                         const isSome = elem != null ? 1 : 0;
                         if (isSome) {
@@ -724,7 +724,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(isSome);
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processOptionalIntArray();
+                    instance.exports.bjs_TestModule_processOptionalIntArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -746,7 +746,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processOptionalStringArray: function bjs_processOptionalStringArray(values) {
+                processOptionalStringArray: function bjs_TestModule_processOptionalStringArray(values) {
                     for (const elem of values) {
                         const isSome = elem != null ? 1 : 0;
                         if (isSome) {
@@ -758,7 +758,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(isSome);
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processOptionalStringArray();
+                    instance.exports.bjs_TestModule_processOptionalStringArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -780,7 +780,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processOptionalArray: function bjs_processOptionalArray(values) {
+                processOptionalArray: function bjs_TestModule_processOptionalArray(values) {
                     const isSome = values != null;
                     if (isSome) {
                         for (const elem of values) {
@@ -789,7 +789,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(values.length);
                     }
                     i32Stack.push(+isSome);
-                    instance.exports.bjs_processOptionalArray();
+                    instance.exports.bjs_TestModule_processOptionalArray();
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -811,16 +811,16 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 },
-                processOptionalPointArray: function bjs_processOptionalPointArray(points) {
+                processOptionalPointArray: function bjs_TestModule_processOptionalPointArray(points) {
                     for (const elem of points) {
                         const isSome = elem != null ? 1 : 0;
                         if (isSome) {
-                            structHelpers.Point.lower(elem);
+                            structHelpers.TestModule_Point.lower(elem);
                         }
                         i32Stack.push(isSome);
                     }
                     i32Stack.push(points.length);
-                    instance.exports.bjs_processOptionalPointArray();
+                    instance.exports.bjs_TestModule_processOptionalPointArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -833,7 +833,7 @@ export async function createInstantiator(options, swift) {
                             if (isSome1 === 0) {
                                 optValue = null;
                             } else {
-                                const struct = structHelpers.Point.lift();
+                                const struct = structHelpers.TestModule_Point.lift();
                                 optValue = struct;
                             }
                             arrayResult.push(optValue);
@@ -842,7 +842,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processOptionalDirectionArray: function bjs_processOptionalDirectionArray(directions) {
+                processOptionalDirectionArray: function bjs_TestModule_processOptionalDirectionArray(directions) {
                     for (const elem of directions) {
                         const isSome = elem != null ? 1 : 0;
                         if (isSome) {
@@ -851,7 +851,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(isSome);
                     }
                     i32Stack.push(directions.length);
-                    instance.exports.bjs_processOptionalDirectionArray();
+                    instance.exports.bjs_TestModule_processOptionalDirectionArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -873,7 +873,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processOptionalStatusArray: function bjs_processOptionalStatusArray(statuses) {
+                processOptionalStatusArray: function bjs_TestModule_processOptionalStatusArray(statuses) {
                     for (const elem of statuses) {
                         const isSome = elem != null ? 1 : 0;
                         if (isSome) {
@@ -882,7 +882,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(isSome);
                     }
                     i32Stack.push(statuses.length);
-                    instance.exports.bjs_processOptionalStatusArray();
+                    instance.exports.bjs_TestModule_processOptionalStatusArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -904,7 +904,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processNestedIntArray: function bjs_processNestedIntArray(values) {
+                processNestedIntArray: function bjs_TestModule_processNestedIntArray(values) {
                     for (const elem of values) {
                         for (const elem1 of elem) {
                             i32Stack.push((elem1 | 0));
@@ -912,7 +912,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(elem.length);
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processNestedIntArray();
+                    instance.exports.bjs_TestModule_processNestedIntArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -938,7 +938,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processNestedStringArray: function bjs_processNestedStringArray(values) {
+                processNestedStringArray: function bjs_TestModule_processNestedStringArray(values) {
                     for (const elem of values) {
                         for (const elem1 of elem) {
                             const bytes = textEncoder.encode(elem1);
@@ -949,7 +949,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(elem.length);
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_processNestedStringArray();
+                    instance.exports.bjs_TestModule_processNestedStringArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -975,15 +975,15 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processNestedPointArray: function bjs_processNestedPointArray(points) {
+                processNestedPointArray: function bjs_TestModule_processNestedPointArray(points) {
                     for (const elem of points) {
                         for (const elem1 of elem) {
-                            structHelpers.Point.lower(elem1);
+                            structHelpers.TestModule_Point.lower(elem1);
                         }
                         i32Stack.push(elem.length);
                     }
                     i32Stack.push(points.length);
-                    instance.exports.bjs_processNestedPointArray();
+                    instance.exports.bjs_TestModule_processNestedPointArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -998,7 +998,7 @@ export async function createInstantiator(options, swift) {
                             } else {
                                 arrayResult1 = [];
                                 for (let i1 = 0; i1 < arrayLen1; i1++) {
-                                    const struct = structHelpers.Point.lift();
+                                    const struct = structHelpers.TestModule_Point.lift();
                                     arrayResult1.push(struct);
                                 }
                                 arrayResult1.reverse();
@@ -1009,12 +1009,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processItemArray: function bjs_processItemArray(items) {
+                processItemArray: function bjs_TestModule_processItemArray(items) {
                     for (const elem of items) {
                         ptrStack.push(elem.pointer);
                     }
                     i32Stack.push(items.length);
-                    instance.exports.bjs_processItemArray();
+                    instance.exports.bjs_TestModule_processItemArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -1030,7 +1030,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processNestedItemArray: function bjs_processNestedItemArray(items) {
+                processNestedItemArray: function bjs_TestModule_processNestedItemArray(items) {
                     for (const elem of items) {
                         for (const elem1 of elem) {
                             ptrStack.push(elem1.pointer);
@@ -1038,7 +1038,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(elem.length);
                     }
                     i32Stack.push(items.length);
-                    instance.exports.bjs_processNestedItemArray();
+                    instance.exports.bjs_TestModule_processNestedItemArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -1065,13 +1065,13 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processJSObjectArray: function bjs_processJSObjectArray(objects) {
+                processJSObjectArray: function bjs_TestModule_processJSObjectArray(objects) {
                     for (const elem of objects) {
                         const objId = swift.memory.retain(elem);
                         i32Stack.push(objId);
                     }
                     i32Stack.push(objects.length);
-                    instance.exports.bjs_processJSObjectArray();
+                    instance.exports.bjs_TestModule_processJSObjectArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -1088,7 +1088,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processOptionalJSObjectArray: function bjs_processOptionalJSObjectArray(objects) {
+                processOptionalJSObjectArray: function bjs_TestModule_processOptionalJSObjectArray(objects) {
                     for (const elem of objects) {
                         const isSome = elem != null ? 1 : 0;
                         if (isSome) {
@@ -1098,7 +1098,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(isSome);
                     }
                     i32Stack.push(objects.length);
-                    instance.exports.bjs_processOptionalJSObjectArray();
+                    instance.exports.bjs_TestModule_processOptionalJSObjectArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -1122,7 +1122,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processNestedJSObjectArray: function bjs_processNestedJSObjectArray(objects) {
+                processNestedJSObjectArray: function bjs_TestModule_processNestedJSObjectArray(objects) {
                     for (const elem of objects) {
                         for (const elem1 of elem) {
                             const objId = swift.memory.retain(elem1);
@@ -1131,7 +1131,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(elem.length);
                     }
                     i32Stack.push(objects.length);
-                    instance.exports.bjs_processNestedJSObjectArray();
+                    instance.exports.bjs_TestModule_processNestedJSObjectArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -1159,7 +1159,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                multiArrayParams: function bjs_multiArrayParams(nums, strs) {
+                multiArrayParams: function bjs_TestModule_multiArrayParams(nums, strs) {
                     for (const elem of nums) {
                         i32Stack.push((elem | 0));
                     }
@@ -1171,10 +1171,10 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(id);
                     }
                     i32Stack.push(strs.length);
-                    const ret = instance.exports.bjs_multiArrayParams();
+                    const ret = instance.exports.bjs_TestModule_multiArrayParams();
                     return ret;
                 },
-                multiOptionalArrayParams: function bjs_multiOptionalArrayParams(a, b) {
+                multiOptionalArrayParams: function bjs_TestModule_multiOptionalArrayParams(a, b) {
                     const isSome = a != null;
                     if (isSome) {
                         for (const elem of a) {
@@ -1194,7 +1194,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(b.length);
                     }
                     i32Stack.push(+isSome1);
-                    const ret = instance.exports.bjs_multiOptionalArrayParams();
+                    const ret = instance.exports.bjs_TestModule_multiOptionalArrayParams();
                     return ret;
                 },
                 Direction: DirectionValues,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Async.js
@@ -130,7 +130,7 @@ export async function createInstantiator(options, swift) {
         return jsValue;
     }
 
-    const __bjs_createAsyncPointHelpers = () => ({
+    const __bjs_createTestModule_AsyncPointHelpers = () => ({
         lower: (value) => {
             i32Stack.push((value.x | 0));
             i32Stack.push((value.y | 0));
@@ -216,11 +216,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_AsyncPoint"] = function(objectId) {
-                structHelpers.AsyncPoint.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_AsyncPoint"] = function(objectId) {
+                structHelpers.TestModule_AsyncPoint.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_AsyncPoint"] = function() {
-                const value = structHelpers.AsyncPoint.lift();
+            bjs["swift_js_struct_lift_TestModule_AsyncPoint"] = function() {
+                const value = structHelpers.TestModule_AsyncPoint.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -280,7 +280,7 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_10AsyncPointV"] = function(promise, value) {
+            bjs["promise_resolve_TestModule_21TestModule_AsyncPointV"] = function(promise, value) {
                 try {
                     const value1 = swift.memory.getObject(value);
                     swift.memory.release(value);
@@ -289,14 +289,14 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_14AsyncDirectionO"] = function(promise, value) {
+            bjs["promise_resolve_TestModule_25TestModule_AsyncDirectionO"] = function(promise, value) {
                 try {
                     swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(value);
                 } catch (error) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_10AsyncThemeO"] = function(promise, valueBytes, valueCount) {
+            bjs["promise_resolve_TestModule_21TestModule_AsyncThemeO"] = function(promise, valueBytes, valueCount) {
                 try {
                     const string = decodeString(valueBytes, valueCount);
                     swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(string);
@@ -304,14 +304,14 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_Sq14AsyncDirectionO"] = function(promise, valueIsSome, valueWrappedValue) {
+            bjs["promise_resolve_TestModule_Sq25TestModule_AsyncDirectionO"] = function(promise, valueIsSome, valueWrappedValue) {
                 try {
                     swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(valueIsSome ? valueWrappedValue : null);
                 } catch (error) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_Sq10AsyncThemeO"] = function(promise, valueIsSome, valueBytes, valueCount) {
+            bjs["promise_resolve_TestModule_Sq21TestModule_AsyncThemeO"] = function(promise, valueIsSome, valueBytes, valueCount) {
                 try {
                     let optResult;
                     if (valueIsSome) {
@@ -325,11 +325,11 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_Sq10AsyncPointV"] = function(promise, value) {
+            bjs["promise_resolve_TestModule_Sq21TestModule_AsyncPointV"] = function(promise, value) {
                 try {
                     let optResult;
                     if (value) {
-                        const struct = structHelpers.AsyncPoint.lift();
+                        const struct = structHelpers.TestModule_AsyncPoint.lift();
                         optResult = struct;
                     } else {
                         optResult = null;
@@ -339,7 +339,7 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_Sa10AsyncPointV"] = function(promise) {
+            bjs["promise_resolve_TestModule_Sa21TestModule_AsyncPointV"] = function(promise) {
                 try {
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
@@ -348,7 +348,7 @@ export async function createInstantiator(options, swift) {
                     } else {
                         arrayResult = [];
                         for (let i = 0; i < arrayLen; i++) {
-                            const struct = structHelpers.AsyncPoint.lift();
+                            const struct = structHelpers.TestModule_AsyncPoint.lift();
                             arrayResult.push(struct);
                         }
                         arrayResult.reverse();
@@ -358,7 +358,7 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_Sa14AsyncDirectionO"] = function(promise) {
+            bjs["promise_resolve_TestModule_Sa25TestModule_AsyncDirectionO"] = function(promise) {
                 try {
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
@@ -377,12 +377,12 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_SD10AsyncPointV"] = function(promise) {
+            bjs["promise_resolve_TestModule_SD21TestModule_AsyncPointV"] = function(promise) {
                 try {
                     const dictLen = i32Stack.pop();
                     const dictResult = {};
                     for (let i = 0; i < dictLen; i++) {
-                        const struct = structHelpers.AsyncPoint.lift();
+                        const struct = structHelpers.TestModule_AsyncPoint.lift();
                         const string = strStack.pop();
                         dictResult[string] = struct;
                     }
@@ -391,7 +391,7 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_SD14AsyncDirectionO"] = function(promise) {
+            bjs["promise_resolve_TestModule_SD25TestModule_AsyncDirectionO"] = function(promise) {
                 try {
                     const dictLen = i32Stack.pop();
                     const dictResult = {};
@@ -517,64 +517,64 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const AsyncPointHelpers = __bjs_createAsyncPointHelpers();
-            structHelpers.AsyncPoint = AsyncPointHelpers;
+            const TestModule_AsyncPointHelpers = __bjs_createTestModule_AsyncPointHelpers();
+            structHelpers.TestModule_AsyncPoint = TestModule_AsyncPointHelpers;
 
             const exports = {
-                asyncReturnVoid: function bjs_asyncReturnVoid() {
-                    const ret = instance.exports.bjs_asyncReturnVoid();
+                asyncReturnVoid: function bjs_TestModule_asyncReturnVoid() {
+                    const ret = instance.exports.bjs_TestModule_asyncReturnVoid();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripInt: function bjs_asyncRoundTripInt(v) {
-                    const ret = instance.exports.bjs_asyncRoundTripInt(v);
+                asyncRoundTripInt: function bjs_TestModule_asyncRoundTripInt(v) {
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripInt(v);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripString: function bjs_asyncRoundTripString(v) {
+                asyncRoundTripString: function bjs_TestModule_asyncRoundTripString(v) {
                     const vBytes = textEncoder.encode(v);
                     const vId = swift.memory.retain(vBytes);
-                    const ret = instance.exports.bjs_asyncRoundTripString(vId, vBytes.length);
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripString(vId, vBytes.length);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripBool: function bjs_asyncRoundTripBool(v) {
-                    const ret = instance.exports.bjs_asyncRoundTripBool(v);
+                asyncRoundTripBool: function bjs_TestModule_asyncRoundTripBool(v) {
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripBool(v);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripFloat: function bjs_asyncRoundTripFloat(v) {
-                    const ret = instance.exports.bjs_asyncRoundTripFloat(v);
+                asyncRoundTripFloat: function bjs_TestModule_asyncRoundTripFloat(v) {
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripFloat(v);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripDouble: function bjs_asyncRoundTripDouble(v) {
-                    const ret = instance.exports.bjs_asyncRoundTripDouble(v);
+                asyncRoundTripDouble: function bjs_TestModule_asyncRoundTripDouble(v) {
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripDouble(v);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripJSObject: function bjs_asyncRoundTripJSObject(v) {
-                    const ret = instance.exports.bjs_asyncRoundTripJSObject(swift.memory.retain(v));
+                asyncRoundTripJSObject: function bjs_TestModule_asyncRoundTripJSObject(v) {
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripJSObject(swift.memory.retain(v));
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripStruct: function bjs_asyncRoundTripStruct(v) {
-                    structHelpers.AsyncPoint.lower(v);
-                    const ret = instance.exports.bjs_asyncRoundTripStruct();
+                asyncRoundTripStruct: function bjs_TestModule_asyncRoundTripStruct(v) {
+                    structHelpers.TestModule_AsyncPoint.lower(v);
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripStruct();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripStructThrows: function bjs_asyncRoundTripStructThrows(v) {
-                    structHelpers.AsyncPoint.lower(v);
-                    const ret = instance.exports.bjs_asyncRoundTripStructThrows();
+                asyncRoundTripStructThrows: function bjs_TestModule_asyncRoundTripStructThrows(v) {
+                    structHelpers.TestModule_AsyncPoint.lower(v);
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripStructThrows();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     if (tmpRetException) {
@@ -585,8 +585,8 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret1;
                 },
-                asyncThrowsZeroArg: function bjs_asyncThrowsZeroArg() {
-                    const ret = instance.exports.bjs_asyncThrowsZeroArg();
+                asyncThrowsZeroArg: function bjs_TestModule_asyncThrowsZeroArg() {
+                    const ret = instance.exports.bjs_TestModule_asyncThrowsZeroArg();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     if (tmpRetException) {
@@ -597,36 +597,36 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret1;
                 },
-                asyncCombineStructs: function bjs_asyncCombineStructs(a, b) {
-                    structHelpers.AsyncPoint.lower(a);
-                    structHelpers.AsyncPoint.lower(b);
-                    const ret = instance.exports.bjs_asyncCombineStructs();
+                asyncCombineStructs: function bjs_TestModule_asyncCombineStructs(a, b) {
+                    structHelpers.TestModule_AsyncPoint.lower(a);
+                    structHelpers.TestModule_AsyncPoint.lower(b);
+                    const ret = instance.exports.bjs_TestModule_asyncCombineStructs();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripEnum: function bjs_asyncRoundTripEnum(v) {
-                    const ret = instance.exports.bjs_asyncRoundTripEnum(v);
+                asyncRoundTripEnum: function bjs_TestModule_asyncRoundTripEnum(v) {
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripEnum(v);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripRawEnum: function bjs_asyncRoundTripRawEnum(v) {
+                asyncRoundTripRawEnum: function bjs_TestModule_asyncRoundTripRawEnum(v) {
                     const vBytes = textEncoder.encode(v);
                     const vId = swift.memory.retain(vBytes);
-                    const ret = instance.exports.bjs_asyncRoundTripRawEnum(vId, vBytes.length);
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripRawEnum(vId, vBytes.length);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripOptionalEnum: function bjs_asyncRoundTripOptionalEnum(v) {
+                asyncRoundTripOptionalEnum: function bjs_TestModule_asyncRoundTripOptionalEnum(v) {
                     const isSome = v != null;
-                    const ret = instance.exports.bjs_asyncRoundTripOptionalEnum(+isSome, isSome ? v : 0);
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripOptionalEnum(+isSome, isSome ? v : 0);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripOptionalRawEnum: function bjs_asyncRoundTripOptionalRawEnum(v) {
+                asyncRoundTripOptionalRawEnum: function bjs_TestModule_asyncRoundTripOptionalRawEnum(v) {
                     const isSome = v != null;
                     let result, result1;
                     if (isSome) {
@@ -638,43 +638,43 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    const ret = instance.exports.bjs_asyncRoundTripOptionalRawEnum(+isSome, result, result1);
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripOptionalRawEnum(+isSome, result, result1);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripOptionalStruct: function bjs_asyncRoundTripOptionalStruct(v) {
+                asyncRoundTripOptionalStruct: function bjs_TestModule_asyncRoundTripOptionalStruct(v) {
                     const isSome = v != null;
                     if (isSome) {
-                        structHelpers.AsyncPoint.lower(v);
+                        structHelpers.TestModule_AsyncPoint.lower(v);
                     }
                     i32Stack.push(+isSome);
-                    const ret = instance.exports.bjs_asyncRoundTripOptionalStruct();
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripOptionalStruct();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripStructArray: function bjs_asyncRoundTripStructArray(v) {
+                asyncRoundTripStructArray: function bjs_TestModule_asyncRoundTripStructArray(v) {
                     for (const elem of v) {
-                        structHelpers.AsyncPoint.lower(elem);
+                        structHelpers.TestModule_AsyncPoint.lower(elem);
                     }
                     i32Stack.push(v.length);
-                    const ret = instance.exports.bjs_asyncRoundTripStructArray();
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripStructArray();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripEnumArray: function bjs_asyncRoundTripEnumArray(v) {
+                asyncRoundTripEnumArray: function bjs_TestModule_asyncRoundTripEnumArray(v) {
                     for (const elem of v) {
                         i32Stack.push((elem | 0));
                     }
                     i32Stack.push(v.length);
-                    const ret = instance.exports.bjs_asyncRoundTripEnumArray();
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripEnumArray();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripStructDictionary: function bjs_asyncRoundTripStructDictionary(v) {
+                asyncRoundTripStructDictionary: function bjs_TestModule_asyncRoundTripStructDictionary(v) {
                     const entries = Object.entries(v);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -682,15 +682,15 @@ export async function createInstantiator(options, swift) {
                         const id = swift.memory.retain(bytes);
                         i32Stack.push(bytes.length);
                         i32Stack.push(id);
-                        structHelpers.AsyncPoint.lower(value);
+                        structHelpers.TestModule_AsyncPoint.lower(value);
                     }
                     i32Stack.push(entries.length);
-                    const ret = instance.exports.bjs_asyncRoundTripStructDictionary();
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripStructDictionary();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripEnumDictionary: function bjs_asyncRoundTripEnumDictionary(v) {
+                asyncRoundTripEnumDictionary: function bjs_TestModule_asyncRoundTripEnumDictionary(v) {
                     const entries = Object.entries(v);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -701,7 +701,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push((value | 0));
                     }
                     i32Stack.push(entries.length);
-                    const ret = instance.exports.bjs_asyncRoundTripEnumDictionary();
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripEnumDictionary();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncAssociatedValueEnum.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/AsyncAssociatedValueEnum.js
@@ -127,7 +127,7 @@ export async function createInstantiator(options, swift) {
         return jsValue;
     }
 
-    const __bjs_createAsyncPayloadResultValuesHelpers = () => ({
+    const __bjs_createTestModule_AsyncPayloadResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -246,19 +246,19 @@ export async function createInstantiator(options, swift) {
                 promise[__bjs_promiseSettlers] = { resolve, reject };
                 return swift.memory.retain(promise);
             }
-            bjs["promise_resolve_TestModule_18AsyncPayloadResultO"] = function(promise, value) {
+            bjs["promise_resolve_TestModule_29TestModule_AsyncPayloadResultO"] = function(promise, value) {
                 try {
-                    const enumValue = enumHelpers.AsyncPayloadResult.lift(value);
+                    const enumValue = enumHelpers.TestModule_AsyncPayloadResult.lift(value);
                     swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(enumValue);
                 } catch (error) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_Sq18AsyncPayloadResultO"] = function(promise, valueIsSome, valueCaseId) {
+            bjs["promise_resolve_TestModule_Sq29TestModule_AsyncPayloadResultO"] = function(promise, valueIsSome, valueCaseId) {
                 try {
                     let optResult;
                     if (valueIsSome) {
-                        const enumValue = enumHelpers.AsyncPayloadResult.lift(valueCaseId);
+                        const enumValue = enumHelpers.TestModule_AsyncPayloadResult.lift(valueCaseId);
                         optResult = enumValue;
                     } else {
                         optResult = null;
@@ -380,27 +380,27 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const AsyncPayloadResultHelpers = __bjs_createAsyncPayloadResultValuesHelpers();
-            enumHelpers.AsyncPayloadResult = AsyncPayloadResultHelpers;
+            const TestModule_AsyncPayloadResultHelpers = __bjs_createTestModule_AsyncPayloadResultHelpers();
+            enumHelpers.TestModule_AsyncPayloadResult = TestModule_AsyncPayloadResultHelpers;
 
             const exports = {
-                asyncRoundTripAssociatedValueEnum: function bjs_asyncRoundTripAssociatedValueEnum(value) {
-                    const valueCaseId = enumHelpers.AsyncPayloadResult.lower(value);
-                    const ret = instance.exports.bjs_asyncRoundTripAssociatedValueEnum(valueCaseId);
+                asyncRoundTripAssociatedValueEnum: function bjs_TestModule_asyncRoundTripAssociatedValueEnum(value) {
+                    const valueCaseId = enumHelpers.TestModule_AsyncPayloadResult.lower(value);
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripAssociatedValueEnum(valueCaseId);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                asyncRoundTripOptionalAssociatedValueEnum: function bjs_asyncRoundTripOptionalAssociatedValueEnum(value) {
+                asyncRoundTripOptionalAssociatedValueEnum: function bjs_TestModule_asyncRoundTripOptionalAssociatedValueEnum(value) {
                     const isSome = value != null;
                     let result;
                     if (isSome) {
-                        const valueCaseId = enumHelpers.AsyncPayloadResult.lower(value);
+                        const valueCaseId = enumHelpers.TestModule_AsyncPayloadResult.lower(value);
                         result = valueCaseId;
                     } else {
                         result = 0;
                     }
-                    const ret = instance.exports.bjs_asyncRoundTripOptionalAssociatedValueEnum(+isSome, result);
+                    const ret = instance.exports.bjs_TestModule_asyncRoundTripOptionalAssociatedValueEnum(+isSome, result);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ClassWithNestedTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ClassWithNestedTypes.js
@@ -36,7 +36,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createAccount_CredentialsHelpers = () => ({
+    const __bjs_createTestModule_Account_CredentialsHelpers = () => ({
         lower: (value) => {
             const bytes = textEncoder.encode(value.token);
             const id = swift.memory.retain(bytes);
@@ -123,11 +123,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_Account_Credentials"] = function(objectId) {
-                structHelpers.Account_Credentials.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Account_Credentials"] = function(objectId) {
+                structHelpers.TestModule_Account_Credentials.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Account_Credentials"] = function() {
-                const value = structHelpers.Account_Credentials.lift();
+            bjs["swift_js_struct_lift_TestModule_Account_Credentials"] = function() {
+                const value = structHelpers.TestModule_Account_Credentials.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -231,7 +231,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Account_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Account_wrap"] = function(pointer) {
                 const obj = _exports['Account'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -303,23 +303,23 @@ export async function createInstantiator(options, swift) {
             }
             class Account extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Account_deinit, Account.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Account_deinit, Account.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_Account_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_Account_init(nameId, nameBytes.length);
                     return Account.__construct(ret);
                 }
                 describe() {
-                    instance.exports.bjs_Account_describe(this.pointer);
+                    instance.exports.bjs_TestModule_Account_describe(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 get name() {
-                    instance.exports.bjs_Account_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_Account_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -327,23 +327,23 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_Account_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_Account_name_set(this.pointer, valueId, valueBytes.length);
                 }
                 get role() {
-                    instance.exports.bjs_Account_role_get(this.pointer);
+                    instance.exports.bjs_TestModule_Account_role_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 static get defaultRole() {
-                    instance.exports.bjs_Account_static_defaultRole_get();
+                    instance.exports.bjs_TestModule_Account_static_defaultRole_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
             }
-            const Account_CredentialsHelpers = __bjs_createAccount_CredentialsHelpers();
-            structHelpers.Account_Credentials = Account_CredentialsHelpers;
+            const TestModule_Account_CredentialsHelpers = __bjs_createTestModule_Account_CredentialsHelpers();
+            structHelpers.TestModule_Account_Credentials = TestModule_Account_CredentialsHelpers;
 
             const exports = {
                 Account: Object.assign(Account, {
@@ -352,17 +352,17 @@ export async function createInstantiator(options, swift) {
                         init: function(token) {
                             const tokenBytes = textEncoder.encode(token);
                             const tokenId = swift.memory.retain(tokenBytes);
-                            instance.exports.bjs_Account_Credentials_init(tokenId, tokenBytes.length);
-                            const structValue = structHelpers.Account_Credentials.lift();
+                            instance.exports.bjs_TestModule_Account_Credentials_init(tokenId, tokenBytes.length);
+                            const structValue = structHelpers.TestModule_Account_Credentials.lift();
                             return structValue;
                         },
                         get maxLength() {
-                            const ret = instance.exports.bjs_Account_Credentials_static_maxLength_get();
+                            const ret = instance.exports.bjs_TestModule_Account_Credentials_static_maxLength_get();
                             return ret;
                         },
                         empty: function() {
-                            instance.exports.bjs_Account_Credentials_static_empty();
-                            const structValue = structHelpers.Account_Credentials.lift();
+                            instance.exports.bjs_TestModule_Account_Credentials_static_empty();
+                            const structValue = structHelpers.TestModule_Account_Credentials.lift();
                             return structValue;
                         },
                     },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DefaultParameters.js
@@ -37,7 +37,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createConfigHelpers = () => ({
+    const __bjs_createTestModule_ConfigHelpers = () => ({
         lower: (value) => {
             const bytes = textEncoder.encode(value.name);
             const id = swift.memory.retain(bytes);
@@ -53,7 +53,7 @@ export async function createInstantiator(options, swift) {
             return { name: string, value: int, enabled: bool };
         }
     });
-    const __bjs_createMathOperationsHelpers = () => ({
+    const __bjs_createTestModule_MathOperationsHelpers = () => ({
         lower: (value) => {
             f64Stack.push(value.baseValue);
         },
@@ -61,13 +61,13 @@ export async function createInstantiator(options, swift) {
             const f64 = f64Stack.pop();
             const instance1 = { baseValue: f64 };
             instance1.add = function(a, b = 10.0) {
-                structHelpers.MathOperations.lower(this);
-                const ret = instance.exports.bjs_MathOperations_add(a, b);
+                structHelpers.TestModule_MathOperations.lower(this);
+                const ret = instance.exports.bjs_TestModule_MathOperations_add(a, b);
                 return ret;
             }.bind(instance1);
             instance1.multiply = function(a, b) {
-                structHelpers.MathOperations.lower(this);
-                const ret = instance.exports.bjs_MathOperations_multiply(a, b);
+                structHelpers.TestModule_MathOperations.lower(this);
+                const ret = instance.exports.bjs_TestModule_MathOperations_multiply(a, b);
                 return ret;
             }.bind(instance1);
             return instance1;
@@ -148,18 +148,18 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_Config"] = function(objectId) {
-                structHelpers.Config.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Config"] = function(objectId) {
+                structHelpers.TestModule_Config.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Config"] = function() {
-                const value = structHelpers.Config.lift();
+            bjs["swift_js_struct_lift_TestModule_Config"] = function() {
+                const value = structHelpers.TestModule_Config.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_MathOperations"] = function(objectId) {
-                structHelpers.MathOperations.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_MathOperations"] = function(objectId) {
+                structHelpers.TestModule_MathOperations.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_MathOperations"] = function() {
-                const value = structHelpers.MathOperations.lift();
+            bjs["swift_js_struct_lift_TestModule_MathOperations"] = function() {
+                const value = structHelpers.TestModule_MathOperations.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -263,15 +263,15 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_ConstructorDefaults_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_ConstructorDefaults_wrap"] = function(pointer) {
                 const obj = _exports['ConstructorDefaults'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_DefaultGreeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_DefaultGreeter_wrap"] = function(pointer) {
                 const obj = _exports['DefaultGreeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_EmptyGreeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_EmptyGreeter_wrap"] = function(pointer) {
                 const obj = _exports['EmptyGreeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -343,17 +343,17 @@ export async function createInstantiator(options, swift) {
             }
             class DefaultGreeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_DefaultGreeter_deinit, DefaultGreeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_DefaultGreeter_deinit, DefaultGreeter.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_DefaultGreeter_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_DefaultGreeter_init(nameId, nameBytes.length);
                     return DefaultGreeter.__construct(ret);
                 }
                 get name() {
-                    instance.exports.bjs_DefaultGreeter_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_DefaultGreeter_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -361,22 +361,22 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_DefaultGreeter_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_DefaultGreeter_name_set(this.pointer, valueId, valueBytes.length);
                 }
             }
             class EmptyGreeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_EmptyGreeter_deinit, EmptyGreeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_EmptyGreeter_deinit, EmptyGreeter.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_EmptyGreeter_init();
+                    const ret = instance.exports.bjs_TestModule_EmptyGreeter_init();
                     return EmptyGreeter.__construct(ret);
                 }
             }
             class ConstructorDefaults extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_ConstructorDefaults_deinit, ConstructorDefaults.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_ConstructorDefaults_deinit, ConstructorDefaults.prototype, null);
                 }
 
                 constructor(name = "Default", count = 42, enabled = true, status = StatusValues.Active, tag = null) {
@@ -393,11 +393,11 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    const ret = instance.exports.bjs_ConstructorDefaults_init(nameId, nameBytes.length, count, enabled, status, +isSome, result, result1);
+                    const ret = instance.exports.bjs_TestModule_ConstructorDefaults_init(nameId, nameBytes.length, count, enabled, status, +isSome, result, result1);
                     return ConstructorDefaults.__construct(ret);
                 }
                 get name() {
-                    instance.exports.bjs_ConstructorDefaults_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_ConstructorDefaults_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -405,31 +405,31 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_ConstructorDefaults_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_ConstructorDefaults_name_set(this.pointer, valueId, valueBytes.length);
                 }
                 get count() {
-                    const ret = instance.exports.bjs_ConstructorDefaults_count_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_ConstructorDefaults_count_get(this.pointer);
                     return ret;
                 }
                 set count(value) {
-                    instance.exports.bjs_ConstructorDefaults_count_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_ConstructorDefaults_count_set(this.pointer, value);
                 }
                 get enabled() {
-                    const ret = instance.exports.bjs_ConstructorDefaults_enabled_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_ConstructorDefaults_enabled_get(this.pointer);
                     return ret !== 0;
                 }
                 set enabled(value) {
-                    instance.exports.bjs_ConstructorDefaults_enabled_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_ConstructorDefaults_enabled_set(this.pointer, value);
                 }
                 get status() {
-                    const ret = instance.exports.bjs_ConstructorDefaults_status_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_ConstructorDefaults_status_get(this.pointer);
                     return ret;
                 }
                 set status(value) {
-                    instance.exports.bjs_ConstructorDefaults_status_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_ConstructorDefaults_status_set(this.pointer, value);
                 }
                 get tag() {
-                    instance.exports.bjs_ConstructorDefaults_tag_get(this.pointer);
+                    instance.exports.bjs_TestModule_ConstructorDefaults_tag_get(this.pointer);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -446,41 +446,41 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_ConstructorDefaults_tag_set(this.pointer, +isSome, result, result1);
+                    instance.exports.bjs_TestModule_ConstructorDefaults_tag_set(this.pointer, +isSome, result, result1);
                 }
             }
-            const ConfigHelpers = __bjs_createConfigHelpers();
-            structHelpers.Config = ConfigHelpers;
+            const TestModule_ConfigHelpers = __bjs_createTestModule_ConfigHelpers();
+            structHelpers.TestModule_Config = TestModule_ConfigHelpers;
 
-            const MathOperationsHelpers = __bjs_createMathOperationsHelpers();
-            structHelpers.MathOperations = MathOperationsHelpers;
+            const TestModule_MathOperationsHelpers = __bjs_createTestModule_MathOperationsHelpers();
+            structHelpers.TestModule_MathOperations = TestModule_MathOperationsHelpers;
 
             const exports = {
-                testStringDefault: function bjs_testStringDefault(message = "Hello World") {
+                testStringDefault: function bjs_TestModule_testStringDefault(message = "Hello World") {
                     const messageBytes = textEncoder.encode(message);
                     const messageId = swift.memory.retain(messageBytes);
-                    instance.exports.bjs_testStringDefault(messageId, messageBytes.length);
+                    instance.exports.bjs_TestModule_testStringDefault(messageId, messageBytes.length);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 },
-                testNegativeIntDefault: function bjs_testNegativeIntDefault(value = -42) {
-                    const ret = instance.exports.bjs_testNegativeIntDefault(value);
+                testNegativeIntDefault: function bjs_TestModule_testNegativeIntDefault(value = -42) {
+                    const ret = instance.exports.bjs_TestModule_testNegativeIntDefault(value);
                     return ret;
                 },
-                testBoolDefault: function bjs_testBoolDefault(flag = true) {
-                    const ret = instance.exports.bjs_testBoolDefault(flag);
+                testBoolDefault: function bjs_TestModule_testBoolDefault(flag = true) {
+                    const ret = instance.exports.bjs_TestModule_testBoolDefault(flag);
                     return ret !== 0;
                 },
-                testNegativeFloatDefault: function bjs_testNegativeFloatDefault(temp = -273.15) {
-                    const ret = instance.exports.bjs_testNegativeFloatDefault(temp);
+                testNegativeFloatDefault: function bjs_TestModule_testNegativeFloatDefault(temp = -273.15) {
+                    const ret = instance.exports.bjs_TestModule_testNegativeFloatDefault(temp);
                     return ret;
                 },
-                testDoubleDefault: function bjs_testDoubleDefault(precision = 2.718) {
-                    const ret = instance.exports.bjs_testDoubleDefault(precision);
+                testDoubleDefault: function bjs_TestModule_testDoubleDefault(precision = 2.718) {
+                    const ret = instance.exports.bjs_TestModule_testDoubleDefault(precision);
                     return ret;
                 },
-                testOptionalDefault: function bjs_testOptionalDefault(name = null) {
+                testOptionalDefault: function bjs_TestModule_testOptionalDefault(name = null) {
                     const isSome = name != null;
                     let result, result1;
                     if (isSome) {
@@ -492,12 +492,12 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_testOptionalDefault(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_testOptionalDefault(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                testOptionalStringDefault: function bjs_testOptionalStringDefault(greeting = "Hi") {
+                testOptionalStringDefault: function bjs_TestModule_testOptionalStringDefault(greeting = "Hi") {
                     const isSome = greeting != null;
                     let result, result1;
                     if (isSome) {
@@ -509,59 +509,59 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_testOptionalStringDefault(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_testOptionalStringDefault(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                testMultipleDefaults: function bjs_testMultipleDefaults(title = "Default Title", count = 10, enabled = false) {
+                testMultipleDefaults: function bjs_TestModule_testMultipleDefaults(title = "Default Title", count = 10, enabled = false) {
                     const titleBytes = textEncoder.encode(title);
                     const titleId = swift.memory.retain(titleBytes);
-                    instance.exports.bjs_testMultipleDefaults(titleId, titleBytes.length, count, enabled);
+                    instance.exports.bjs_TestModule_testMultipleDefaults(titleId, titleBytes.length, count, enabled);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 },
-                testEnumDefault: function bjs_testEnumDefault(status = StatusValues.Active) {
-                    const ret = instance.exports.bjs_testEnumDefault(status);
+                testEnumDefault: function bjs_TestModule_testEnumDefault(status = StatusValues.Active) {
+                    const ret = instance.exports.bjs_TestModule_testEnumDefault(status);
                     return ret;
                 },
-                testComplexInit: function bjs_testComplexInit(greeter = new DefaultGreeter("DefaultUser")) {
-                    const ret = instance.exports.bjs_testComplexInit(greeter.pointer);
+                testComplexInit: function bjs_TestModule_testComplexInit(greeter = new DefaultGreeter("DefaultUser")) {
+                    const ret = instance.exports.bjs_TestModule_testComplexInit(greeter.pointer);
                     return DefaultGreeter.__construct(ret);
                 },
-                testEmptyInit: function bjs_testEmptyInit(greeter = new EmptyGreeter()) {
-                    const ret = instance.exports.bjs_testEmptyInit(greeter.pointer);
+                testEmptyInit: function bjs_TestModule_testEmptyInit(greeter = new EmptyGreeter()) {
+                    const ret = instance.exports.bjs_TestModule_testEmptyInit(greeter.pointer);
                     return EmptyGreeter.__construct(ret);
                 },
-                testOptionalStructDefault: function bjs_testOptionalStructDefault(point = null) {
+                testOptionalStructDefault: function bjs_TestModule_testOptionalStructDefault(point = null) {
                     const isSome = point != null;
                     if (isSome) {
-                        structHelpers.Config.lower(point);
+                        structHelpers.TestModule_Config.lower(point);
                     }
                     i32Stack.push(+isSome);
-                    instance.exports.bjs_testOptionalStructDefault();
+                    instance.exports.bjs_TestModule_testOptionalStructDefault();
                     const isSome1 = i32Stack.pop();
-                    const optResult = isSome1 ? structHelpers.Config.lift() : null;
+                    const optResult = isSome1 ? structHelpers.TestModule_Config.lift() : null;
                     return optResult;
                 },
-                testOptionalStructWithValueDefault: function bjs_testOptionalStructWithValueDefault(point = { name: "default", value: 42, enabled: true }) {
+                testOptionalStructWithValueDefault: function bjs_TestModule_testOptionalStructWithValueDefault(point = { name: "default", value: 42, enabled: true }) {
                     const isSome = point != null;
                     if (isSome) {
-                        structHelpers.Config.lower(point);
+                        structHelpers.TestModule_Config.lower(point);
                     }
                     i32Stack.push(+isSome);
-                    instance.exports.bjs_testOptionalStructWithValueDefault();
+                    instance.exports.bjs_TestModule_testOptionalStructWithValueDefault();
                     const isSome1 = i32Stack.pop();
-                    const optResult = isSome1 ? structHelpers.Config.lift() : null;
+                    const optResult = isSome1 ? structHelpers.TestModule_Config.lift() : null;
                     return optResult;
                 },
-                testIntArrayDefault: function bjs_testIntArrayDefault(values = [1, 2, 3]) {
+                testIntArrayDefault: function bjs_TestModule_testIntArrayDefault(values = [1, 2, 3]) {
                     for (const elem of values) {
                         i32Stack.push((elem | 0));
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_testIntArrayDefault();
+                    instance.exports.bjs_TestModule_testIntArrayDefault();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -576,7 +576,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                testStringArrayDefault: function bjs_testStringArrayDefault(names = ["a", "b", "c"]) {
+                testStringArrayDefault: function bjs_TestModule_testStringArrayDefault(names = ["a", "b", "c"]) {
                     for (const elem of names) {
                         const bytes = textEncoder.encode(elem);
                         const id = swift.memory.retain(bytes);
@@ -584,7 +584,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(id);
                     }
                     i32Stack.push(names.length);
-                    instance.exports.bjs_testStringArrayDefault();
+                    instance.exports.bjs_TestModule_testStringArrayDefault();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -599,12 +599,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                testDoubleArrayDefault: function bjs_testDoubleArrayDefault(values = [1.5, 2.5, 3.5]) {
+                testDoubleArrayDefault: function bjs_TestModule_testDoubleArrayDefault(values = [1.5, 2.5, 3.5]) {
                     for (const elem of values) {
                         f64Stack.push(elem);
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_testDoubleArrayDefault();
+                    instance.exports.bjs_TestModule_testDoubleArrayDefault();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -619,12 +619,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                testBoolArrayDefault: function bjs_testBoolArrayDefault(flags = [true, false, true]) {
+                testBoolArrayDefault: function bjs_TestModule_testBoolArrayDefault(flags = [true, false, true]) {
                     for (const elem of flags) {
                         i32Stack.push(elem ? 1 : 0);
                     }
                     i32Stack.push(flags.length);
-                    instance.exports.bjs_testBoolArrayDefault();
+                    instance.exports.bjs_TestModule_testBoolArrayDefault();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -639,12 +639,12 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                testEmptyArrayDefault: function bjs_testEmptyArrayDefault(items = []) {
+                testEmptyArrayDefault: function bjs_TestModule_testEmptyArrayDefault(items = []) {
                     for (const elem of items) {
                         i32Stack.push((elem | 0));
                     }
                     i32Stack.push(items.length);
-                    instance.exports.bjs_testEmptyArrayDefault();
+                    instance.exports.bjs_TestModule_testEmptyArrayDefault();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -659,14 +659,14 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                testMixedWithArrayDefault: function bjs_testMixedWithArrayDefault(name = "test", values = [10, 20, 30], enabled = true) {
+                testMixedWithArrayDefault: function bjs_TestModule_testMixedWithArrayDefault(name = "test", values = [10, 20, 30], enabled = true) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
                     for (const elem of values) {
                         i32Stack.push((elem | 0));
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_testMixedWithArrayDefault(nameId, nameBytes.length, enabled);
+                    instance.exports.bjs_TestModule_testMixedWithArrayDefault(nameId, nameBytes.length, enabled);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -677,12 +677,12 @@ export async function createInstantiator(options, swift) {
                 EmptyGreeter,
                 MathOperations: {
                     init: function(baseValue = 0.0) {
-                        instance.exports.bjs_MathOperations_init(baseValue);
-                        const structValue = structHelpers.MathOperations.lift();
+                        instance.exports.bjs_TestModule_MathOperations_init(baseValue);
+                        const structValue = structHelpers.TestModule_MathOperations.lift();
                         return structValue;
                     },
                     subtract: function(a, b = 5.0) {
-                        const ret = instance.exports.bjs_MathOperations_static_subtract(a, b);
+                        const ret = instance.exports.bjs_TestModule_MathOperations_static_subtract(a, b);
                         return ret;
                     },
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DictionaryTypes.js
@@ -31,7 +31,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createCountersHelpers = () => ({
+    const __bjs_createTestModule_CountersHelpers = () => ({
         lower: (value) => {
             const bytes = textEncoder.encode(value.name);
             const id = swift.memory.retain(bytes);
@@ -147,11 +147,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_Counters"] = function(objectId) {
-                structHelpers.Counters.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Counters"] = function(objectId) {
+                structHelpers.TestModule_Counters.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Counters"] = function() {
-                const value = structHelpers.Counters.lift();
+            bjs["swift_js_struct_lift_TestModule_Counters"] = function() {
+                const value = structHelpers.TestModule_Counters.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -255,7 +255,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Box_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Box_wrap"] = function(pointer) {
                 const obj = _exports['Box'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -352,15 +352,15 @@ export async function createInstantiator(options, swift) {
             }
             class Box extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Box_deinit, Box.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Box_deinit, Box.prototype, null);
                 }
 
             }
-            const CountersHelpers = __bjs_createCountersHelpers();
-            structHelpers.Counters = CountersHelpers;
+            const TestModule_CountersHelpers = __bjs_createTestModule_CountersHelpers();
+            structHelpers.TestModule_Counters = TestModule_CountersHelpers;
 
             const exports = {
-                mirrorDictionary: function bjs_mirrorDictionary(values) {
+                mirrorDictionary: function bjs_TestModule_mirrorDictionary(values) {
                     const entries = Object.entries(values);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -371,7 +371,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push((value | 0));
                     }
                     i32Stack.push(entries.length);
-                    instance.exports.bjs_mirrorDictionary();
+                    instance.exports.bjs_TestModule_mirrorDictionary();
                     const dictLen = i32Stack.pop();
                     const dictResult = {};
                     for (let i = 0; i < dictLen; i++) {
@@ -381,7 +381,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return dictResult;
                 },
-                optionalDictionary: function bjs_optionalDictionary(values) {
+                optionalDictionary: function bjs_TestModule_optionalDictionary(values) {
                     const isSome = values != null;
                     if (isSome) {
                         const entries = Object.entries(values);
@@ -399,7 +399,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(entries.length);
                     }
                     i32Stack.push(+isSome);
-                    instance.exports.bjs_optionalDictionary();
+                    instance.exports.bjs_TestModule_optionalDictionary();
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -416,7 +416,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 },
-                nestedDictionary: function bjs_nestedDictionary(values) {
+                nestedDictionary: function bjs_TestModule_nestedDictionary(values) {
                     const entries = Object.entries(values);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -430,7 +430,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(value.length);
                     }
                     i32Stack.push(entries.length);
-                    instance.exports.bjs_nestedDictionary();
+                    instance.exports.bjs_TestModule_nestedDictionary();
                     const dictLen = i32Stack.pop();
                     const dictResult = {};
                     for (let i = 0; i < dictLen; i++) {
@@ -451,7 +451,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return dictResult;
                 },
-                boxDictionary: function bjs_boxDictionary(boxes) {
+                boxDictionary: function bjs_TestModule_boxDictionary(boxes) {
                     const entries = Object.entries(boxes);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -462,7 +462,7 @@ export async function createInstantiator(options, swift) {
                         ptrStack.push(value.pointer);
                     }
                     i32Stack.push(entries.length);
-                    instance.exports.bjs_boxDictionary();
+                    instance.exports.bjs_TestModule_boxDictionary();
                     const dictLen = i32Stack.pop();
                     const dictResult = {};
                     for (let i = 0; i < dictLen; i++) {
@@ -473,7 +473,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return dictResult;
                 },
-                optionalBoxDictionary: function bjs_optionalBoxDictionary(boxes) {
+                optionalBoxDictionary: function bjs_TestModule_optionalBoxDictionary(boxes) {
                     const entries = Object.entries(boxes);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -488,7 +488,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(isSome);
                     }
                     i32Stack.push(entries.length);
-                    instance.exports.bjs_optionalBoxDictionary();
+                    instance.exports.bjs_TestModule_optionalBoxDictionary();
                     const dictLen = i32Stack.pop();
                     const dictResult = {};
                     for (let i = 0; i < dictLen; i++) {
@@ -506,10 +506,10 @@ export async function createInstantiator(options, swift) {
                     }
                     return dictResult;
                 },
-                roundtripCounters: function bjs_roundtripCounters(counters) {
-                    structHelpers.Counters.lower(counters);
-                    instance.exports.bjs_roundtripCounters();
-                    const structValue = structHelpers.Counters.lift();
+                roundtripCounters: function bjs_TestModule_roundtripCounters(counters) {
+                    structHelpers.TestModule_Counters.lower(counters);
+                    instance.exports.bjs_TestModule_roundtripCounters();
+                    const structValue = structHelpers.TestModule_Counters.lift();
                     return structValue;
                 },
                 Box,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DocComments.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/DocComments.js
@@ -37,7 +37,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createPointHelpers = () => ({
+    const __bjs_createTestModule_PointHelpers = () => ({
         lower: (value) => {
             f64Stack.push(value.x);
             f64Stack.push(value.y);
@@ -123,11 +123,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_Point"] = function(objectId) {
-                structHelpers.Point.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Point"] = function(objectId) {
+                structHelpers.TestModule_Point.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Point"] = function() {
-                const value = structHelpers.Point.lift();
+            bjs["swift_js_struct_lift_TestModule_Point"] = function() {
+                const value = structHelpers.TestModule_Point.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -231,7 +231,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Greeter_wrap"] = function(pointer) {
                 const obj = _exports['Greeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -320,23 +320,23 @@ export async function createInstantiator(options, swift) {
             }
             class Greeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Greeter_deinit, Greeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Greeter_deinit, Greeter.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_Greeter_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_Greeter_init(nameId, nameBytes.length);
                     return Greeter.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs_Greeter_greet(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 get name() {
-                    instance.exports.bjs_Greeter_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -344,37 +344,37 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_Greeter_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_Greeter_name_set(this.pointer, valueId, valueBytes.length);
                 }
             }
-            const PointHelpers = __bjs_createPointHelpers();
-            structHelpers.Point = PointHelpers;
+            const TestModule_PointHelpers = __bjs_createTestModule_PointHelpers();
+            structHelpers.TestModule_Point = TestModule_PointHelpers;
 
             const exports = {
-                greet: function bjs_greet(name, greeting = "Hello") {
+                greet: function bjs_TestModule_greet(name, greeting = "Hello") {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
                     const greetingBytes = textEncoder.encode(greeting);
                     const greetingId = swift.memory.retain(greetingBytes);
-                    instance.exports.bjs_greet(nameId, nameBytes.length, greetingId, greetingBytes.length);
+                    instance.exports.bjs_TestModule_greet(nameId, nameBytes.length, greetingId, greetingBytes.length);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 },
-                add: function bjs_add(a, b) {
-                    const ret = instance.exports.bjs_add(a, b);
+                add: function bjs_TestModule_add(a, b) {
+                    const ret = instance.exports.bjs_TestModule_add(a, b);
                     return ret;
                 },
-                trimmed: function bjs_trimmed() {
-                    instance.exports.bjs_trimmed();
+                trimmed: function bjs_TestModule_trimmed() {
+                    instance.exports.bjs_TestModule_trimmed();
                 },
-                hello: function bjs_hello() {
-                    instance.exports.bjs_hello();
+                hello: function bjs_TestModule_hello() {
+                    instance.exports.bjs_TestModule_hello();
                 },
-                parseInt: function bjs_parseInt(text) {
+                parseInt: function bjs_TestModule_parseInt(text) {
                     const textBytes = textEncoder.encode(text);
                     const textId = swift.memory.retain(textBytes);
-                    const ret = instance.exports.bjs_parseInt(textId, textBytes.length);
+                    const ret = instance.exports.bjs_TestModule_parseInt(textId, textBytes.length);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -383,8 +383,8 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret;
                 },
-                terminator: function bjs_terminator() {
-                    instance.exports.bjs_terminator();
+                terminator: function bjs_TestModule_terminator() {
+                    instance.exports.bjs_TestModule_terminator();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -394,13 +394,13 @@ export async function createInstantiator(options, swift) {
                     canonical: function(label) {
                         const labelBytes = textEncoder.encode(label);
                         const labelId = swift.memory.retain(labelBytes);
-                        instance.exports.bjs_Color_static_canonical(labelId, labelBytes.length);
+                        instance.exports.bjs_TestModule_Color_static_canonical(labelId, labelBytes.length);
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
                     },
                     get fallback() {
-                        instance.exports.bjs_Color_static_fallback_get();
+                        instance.exports.bjs_TestModule_Color_static_fallback_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -408,8 +408,8 @@ export async function createInstantiator(options, swift) {
                 },
                 Greeter,
                 MathUtils: {
-                    double: function bjs_MathUtils_double(value) {
-                        const ret = instance.exports.bjs_MathUtils_double(value);
+                    double: function bjs_TestModule_MathUtils_double(value) {
+                        const ret = instance.exports.bjs_TestModule_MathUtils_double(value);
                         return ret;
                     },
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAlias.js
@@ -207,7 +207,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_ColorBox_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_ColorBox_wrap"] = function(pointer) {
                 const obj = _exports['ColorBox'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -279,19 +279,19 @@ export async function createInstantiator(options, swift) {
             }
             class ColorBox extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_ColorBox_deinit, ColorBox.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_ColorBox_deinit, ColorBox.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_ColorBox_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_ColorBox_init(nameId, nameBytes.length);
                     return ColorBox.__construct(ret);
                 }
             }
             const exports = {
-                roundtripColor: function bjs_roundtripColor(color) {
-                    const ret = instance.exports.bjs_roundtripColor(color.pointer);
+                roundtripColor: function bjs_TestModule_roundtripColor(color) {
+                    const ret = instance.exports.bjs_TestModule_roundtripColor(color.pointer);
                     return ColorBox.__construct(ret);
                 },
                 ColorBox,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValue.js
@@ -112,7 +112,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createPointHelpers = () => ({
+    const __bjs_createTestModule_PointHelpers = () => ({
         lower: (value) => {
             f64Stack.push(value.x);
             f64Stack.push(value.y);
@@ -123,7 +123,7 @@ export async function createInstantiator(options, swift) {
             return { x: f641, y: f64 };
         }
     });
-    const __bjs_createAPIResultValuesHelpers = () => ({
+    const __bjs_createTestModule_APIResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -184,7 +184,7 @@ export async function createInstantiator(options, swift) {
             }
         }
     });
-    const __bjs_createComplexResultValuesHelpers = () => ({
+    const __bjs_createTestModule_ComplexResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -286,7 +286,7 @@ export async function createInstantiator(options, swift) {
             }
         }
     });
-    const __bjs_createResultValuesHelpers = () => ({
+    const __bjs_createTestModule_Utilities_ResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -339,7 +339,7 @@ export async function createInstantiator(options, swift) {
             }
         }
     });
-    const __bjs_createNetworkingResultValuesHelpers = () => ({
+    const __bjs_createTestModule_NetworkingResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -377,7 +377,7 @@ export async function createInstantiator(options, swift) {
             }
         }
     });
-    const __bjs_createAPIOptionalResultValuesHelpers = () => ({
+    const __bjs_createTestModule_APIOptionalResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -493,7 +493,7 @@ export async function createInstantiator(options, swift) {
             }
         }
     });
-    const __bjs_createTypedPayloadResultValuesHelpers = () => ({
+    const __bjs_createTestModule_TypedPayloadResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -565,12 +565,12 @@ export async function createInstantiator(options, swift) {
             }
         }
     });
-    const __bjs_createAllTypesResultValuesHelpers = () => ({
+    const __bjs_createTestModule_AllTypesResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
                 case AllTypesResultValues.Tag.StructPayload: {
-                    structHelpers.Point.lower(value.param0);
+                    structHelpers.TestModule_Point.lower(value.param0);
                     return AllTypesResultValues.Tag.StructPayload;
                 }
                 case AllTypesResultValues.Tag.ClassPayload: {
@@ -583,7 +583,7 @@ export async function createInstantiator(options, swift) {
                     return AllTypesResultValues.Tag.JsObjectPayload;
                 }
                 case AllTypesResultValues.Tag.NestedEnum: {
-                    const caseId = enumHelpers.APIResult.lower(value.param0);
+                    const caseId = enumHelpers.TestModule_APIResult.lower(value.param0);
                     i32Stack.push(caseId);
                     return AllTypesResultValues.Tag.NestedEnum;
                 }
@@ -604,7 +604,7 @@ export async function createInstantiator(options, swift) {
             tag = tag | 0;
             switch (tag) {
                 case AllTypesResultValues.Tag.StructPayload: {
-                    const struct = structHelpers.Point.lift();
+                    const struct = structHelpers.TestModule_Point.lift();
                     return { tag: AllTypesResultValues.Tag.StructPayload, param0: struct };
                 }
                 case AllTypesResultValues.Tag.ClassPayload: {
@@ -619,7 +619,7 @@ export async function createInstantiator(options, swift) {
                     return { tag: AllTypesResultValues.Tag.JsObjectPayload, param0: obj };
                 }
                 case AllTypesResultValues.Tag.NestedEnum: {
-                    const enumValue = enumHelpers.APIResult.lift(i32Stack.pop());
+                    const enumValue = enumHelpers.TestModule_APIResult.lift(i32Stack.pop());
                     return { tag: AllTypesResultValues.Tag.NestedEnum, param0: enumValue };
                 }
                 case AllTypesResultValues.Tag.ArrayPayload: {
@@ -642,14 +642,14 @@ export async function createInstantiator(options, swift) {
             }
         }
     });
-    const __bjs_createOptionalAllTypesResultValuesHelpers = () => ({
+    const __bjs_createTestModule_OptionalAllTypesResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
                 case OptionalAllTypesResultValues.Tag.OptStruct: {
                     const isSome = value.param0 != null ? 1 : 0;
                     if (isSome) {
-                        structHelpers.Point.lower(value.param0);
+                        structHelpers.TestModule_Point.lower(value.param0);
                     }
                     i32Stack.push(isSome);
                     return OptionalAllTypesResultValues.Tag.OptStruct;
@@ -674,7 +674,7 @@ export async function createInstantiator(options, swift) {
                 case OptionalAllTypesResultValues.Tag.OptNestedEnum: {
                     const isSome = value.param0 != null ? 1 : 0;
                     if (isSome) {
-                        const caseId = enumHelpers.APIResult.lower(value.param0);
+                        const caseId = enumHelpers.TestModule_APIResult.lower(value.param0);
                         i32Stack.push(caseId);
                     }
                     i32Stack.push(isSome);
@@ -706,7 +706,7 @@ export async function createInstantiator(options, swift) {
                     if (isSome === 0) {
                         optValue = null;
                     } else {
-                        const struct = structHelpers.Point.lift();
+                        const struct = structHelpers.TestModule_Point.lift();
                         optValue = struct;
                     }
                     return { tag: OptionalAllTypesResultValues.Tag.OptStruct, param0: optValue };
@@ -742,7 +742,7 @@ export async function createInstantiator(options, swift) {
                     if (isSome === 0) {
                         optValue = null;
                     } else {
-                        const enumValue = enumHelpers.APIResult.lift(i32Stack.pop());
+                        const enumValue = enumHelpers.TestModule_APIResult.lift(i32Stack.pop());
                         optValue = enumValue;
                     }
                     return { tag: OptionalAllTypesResultValues.Tag.OptNestedEnum, param0: optValue };
@@ -849,11 +849,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_Point"] = function(objectId) {
-                structHelpers.Point.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Point"] = function(objectId) {
+                structHelpers.TestModule_Point.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Point"] = function() {
-                const value = structHelpers.Point.lift();
+            bjs["swift_js_struct_lift_TestModule_Point"] = function() {
+                const value = structHelpers.TestModule_Point.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -957,7 +957,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_User_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_User_wrap"] = function(pointer) {
                 const obj = _exports['User'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -1029,143 +1029,143 @@ export async function createInstantiator(options, swift) {
             }
             class User extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_User_deinit, User.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_User_deinit, User.prototype, null);
                 }
 
             }
-            const PointHelpers = __bjs_createPointHelpers();
-            structHelpers.Point = PointHelpers;
+            const TestModule_PointHelpers = __bjs_createTestModule_PointHelpers();
+            structHelpers.TestModule_Point = TestModule_PointHelpers;
 
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers();
-            enumHelpers.APIResult = APIResultHelpers;
+            const TestModule_APIResultHelpers = __bjs_createTestModule_APIResultHelpers();
+            enumHelpers.TestModule_APIResult = TestModule_APIResultHelpers;
 
-            const ComplexResultHelpers = __bjs_createComplexResultValuesHelpers();
-            enumHelpers.ComplexResult = ComplexResultHelpers;
+            const TestModule_ComplexResultHelpers = __bjs_createTestModule_ComplexResultHelpers();
+            enumHelpers.TestModule_ComplexResult = TestModule_ComplexResultHelpers;
 
-            const ResultHelpers = __bjs_createResultValuesHelpers();
-            enumHelpers.Result = ResultHelpers;
+            const TestModule_Utilities_ResultHelpers = __bjs_createTestModule_Utilities_ResultHelpers();
+            enumHelpers.TestModule_Utilities_Result = TestModule_Utilities_ResultHelpers;
 
-            const NetworkingResultHelpers = __bjs_createNetworkingResultValuesHelpers();
-            enumHelpers.NetworkingResult = NetworkingResultHelpers;
+            const TestModule_NetworkingResultHelpers = __bjs_createTestModule_NetworkingResultHelpers();
+            enumHelpers.TestModule_NetworkingResult = TestModule_NetworkingResultHelpers;
 
-            const APIOptionalResultHelpers = __bjs_createAPIOptionalResultValuesHelpers();
-            enumHelpers.APIOptionalResult = APIOptionalResultHelpers;
+            const TestModule_APIOptionalResultHelpers = __bjs_createTestModule_APIOptionalResultHelpers();
+            enumHelpers.TestModule_APIOptionalResult = TestModule_APIOptionalResultHelpers;
 
-            const TypedPayloadResultHelpers = __bjs_createTypedPayloadResultValuesHelpers();
-            enumHelpers.TypedPayloadResult = TypedPayloadResultHelpers;
+            const TestModule_TypedPayloadResultHelpers = __bjs_createTestModule_TypedPayloadResultHelpers();
+            enumHelpers.TestModule_TypedPayloadResult = TestModule_TypedPayloadResultHelpers;
 
-            const AllTypesResultHelpers = __bjs_createAllTypesResultValuesHelpers();
-            enumHelpers.AllTypesResult = AllTypesResultHelpers;
+            const TestModule_AllTypesResultHelpers = __bjs_createTestModule_AllTypesResultHelpers();
+            enumHelpers.TestModule_AllTypesResult = TestModule_AllTypesResultHelpers;
 
-            const OptionalAllTypesResultHelpers = __bjs_createOptionalAllTypesResultValuesHelpers();
-            enumHelpers.OptionalAllTypesResult = OptionalAllTypesResultHelpers;
+            const TestModule_OptionalAllTypesResultHelpers = __bjs_createTestModule_OptionalAllTypesResultHelpers();
+            enumHelpers.TestModule_OptionalAllTypesResult = TestModule_OptionalAllTypesResultHelpers;
 
             const exports = {
-                handle: function bjs_handle(result) {
-                    const resultCaseId = enumHelpers.APIResult.lower(result);
-                    instance.exports.bjs_handle(resultCaseId);
+                handle: function bjs_TestModule_handle(result) {
+                    const resultCaseId = enumHelpers.TestModule_APIResult.lower(result);
+                    instance.exports.bjs_TestModule_handle(resultCaseId);
                 },
-                getResult: function bjs_getResult() {
-                    instance.exports.bjs_getResult();
-                    const ret = enumHelpers.APIResult.lift(i32Stack.pop());
+                getResult: function bjs_TestModule_getResult() {
+                    instance.exports.bjs_TestModule_getResult();
+                    const ret = enumHelpers.TestModule_APIResult.lift(i32Stack.pop());
                     return ret;
                 },
-                roundtripAPIResult: function bjs_roundtripAPIResult(result) {
-                    const resultCaseId = enumHelpers.APIResult.lower(result);
-                    instance.exports.bjs_roundtripAPIResult(resultCaseId);
-                    const ret = enumHelpers.APIResult.lift(i32Stack.pop());
+                roundtripAPIResult: function bjs_TestModule_roundtripAPIResult(result) {
+                    const resultCaseId = enumHelpers.TestModule_APIResult.lower(result);
+                    instance.exports.bjs_TestModule_roundtripAPIResult(resultCaseId);
+                    const ret = enumHelpers.TestModule_APIResult.lift(i32Stack.pop());
                     return ret;
                 },
-                roundTripOptionalAPIResult: function bjs_roundTripOptionalAPIResult(result) {
+                roundTripOptionalAPIResult: function bjs_TestModule_roundTripOptionalAPIResult(result) {
                     const isSome = result != null;
                     let result1;
                     if (isSome) {
-                        const resultCaseId = enumHelpers.APIResult.lower(result);
+                        const resultCaseId = enumHelpers.TestModule_APIResult.lower(result);
                         result1 = resultCaseId;
                     } else {
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalAPIResult(+isSome, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalAPIResult(+isSome, result1);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.APIResult.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_APIResult.lift(tag);
                     return optResult;
                 },
-                handleComplex: function bjs_handleComplex(result) {
-                    const resultCaseId = enumHelpers.ComplexResult.lower(result);
-                    instance.exports.bjs_handleComplex(resultCaseId);
+                handleComplex: function bjs_TestModule_handleComplex(result) {
+                    const resultCaseId = enumHelpers.TestModule_ComplexResult.lower(result);
+                    instance.exports.bjs_TestModule_handleComplex(resultCaseId);
                 },
-                getComplexResult: function bjs_getComplexResult() {
-                    instance.exports.bjs_getComplexResult();
-                    const ret = enumHelpers.ComplexResult.lift(i32Stack.pop());
+                getComplexResult: function bjs_TestModule_getComplexResult() {
+                    instance.exports.bjs_TestModule_getComplexResult();
+                    const ret = enumHelpers.TestModule_ComplexResult.lift(i32Stack.pop());
                     return ret;
                 },
-                roundtripComplexResult: function bjs_roundtripComplexResult(result) {
-                    const resultCaseId = enumHelpers.ComplexResult.lower(result);
-                    instance.exports.bjs_roundtripComplexResult(resultCaseId);
-                    const ret = enumHelpers.ComplexResult.lift(i32Stack.pop());
+                roundtripComplexResult: function bjs_TestModule_roundtripComplexResult(result) {
+                    const resultCaseId = enumHelpers.TestModule_ComplexResult.lower(result);
+                    instance.exports.bjs_TestModule_roundtripComplexResult(resultCaseId);
+                    const ret = enumHelpers.TestModule_ComplexResult.lift(i32Stack.pop());
                     return ret;
                 },
-                roundTripOptionalComplexResult: function bjs_roundTripOptionalComplexResult(result) {
+                roundTripOptionalComplexResult: function bjs_TestModule_roundTripOptionalComplexResult(result) {
                     const isSome = result != null;
                     let result1;
                     if (isSome) {
-                        const resultCaseId = enumHelpers.ComplexResult.lower(result);
+                        const resultCaseId = enumHelpers.TestModule_ComplexResult.lower(result);
                         result1 = resultCaseId;
                     } else {
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalComplexResult(+isSome, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalComplexResult(+isSome, result1);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.ComplexResult.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_ComplexResult.lift(tag);
                     return optResult;
                 },
-                roundTripOptionalUtilitiesResult: function bjs_roundTripOptionalUtilitiesResult(result) {
+                roundTripOptionalUtilitiesResult: function bjs_TestModule_roundTripOptionalUtilitiesResult(result) {
                     const isSome = result != null;
                     let result1;
                     if (isSome) {
-                        const resultCaseId = enumHelpers.Result.lower(result);
+                        const resultCaseId = enumHelpers.TestModule_Utilities_Result.lower(result);
                         result1 = resultCaseId;
                     } else {
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalUtilitiesResult(+isSome, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalUtilitiesResult(+isSome, result1);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.Result.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_Utilities_Result.lift(tag);
                     return optResult;
                 },
-                roundTripOptionalNetworkingResult: function bjs_roundTripOptionalNetworkingResult(result) {
+                roundTripOptionalNetworkingResult: function bjs_TestModule_roundTripOptionalNetworkingResult(result) {
                     const isSome = result != null;
                     let result1;
                     if (isSome) {
-                        const resultCaseId = enumHelpers.NetworkingResult.lower(result);
+                        const resultCaseId = enumHelpers.TestModule_NetworkingResult.lower(result);
                         result1 = resultCaseId;
                     } else {
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalNetworkingResult(+isSome, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalNetworkingResult(+isSome, result1);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.NetworkingResult.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_NetworkingResult.lift(tag);
                     return optResult;
                 },
-                roundTripOptionalAPIOptionalResult: function bjs_roundTripOptionalAPIOptionalResult(result) {
+                roundTripOptionalAPIOptionalResult: function bjs_TestModule_roundTripOptionalAPIOptionalResult(result) {
                     const isSome = result != null;
                     let result1;
                     if (isSome) {
-                        const resultCaseId = enumHelpers.APIOptionalResult.lower(result);
+                        const resultCaseId = enumHelpers.TestModule_APIOptionalResult.lower(result);
                         result1 = resultCaseId;
                     } else {
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalAPIOptionalResult(+isSome, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalAPIOptionalResult(+isSome, result1);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.APIOptionalResult.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_APIOptionalResult.lift(tag);
                     return optResult;
                 },
-                compareAPIResults: function bjs_compareAPIResults(result1, result2) {
+                compareAPIResults: function bjs_TestModule_compareAPIResults(result1, result2) {
                     const isSome = result1 != null;
                     let result;
                     if (isSome) {
-                        const result1CaseId = enumHelpers.APIOptionalResult.lower(result1);
+                        const result1CaseId = enumHelpers.TestModule_APIOptionalResult.lower(result1);
                         result = result1CaseId;
                     } else {
                         result = 0;
@@ -1173,74 +1173,74 @@ export async function createInstantiator(options, swift) {
                     const isSome1 = result2 != null;
                     let result3;
                     if (isSome1) {
-                        const result2CaseId = enumHelpers.APIOptionalResult.lower(result2);
+                        const result2CaseId = enumHelpers.TestModule_APIOptionalResult.lower(result2);
                         result3 = result2CaseId;
                     } else {
                         result3 = 0;
                     }
-                    instance.exports.bjs_compareAPIResults(+isSome, result, +isSome1, result3);
+                    instance.exports.bjs_TestModule_compareAPIResults(+isSome, result, +isSome1, result3);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.APIOptionalResult.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_APIOptionalResult.lift(tag);
                     return optResult;
                 },
-                roundTripTypedPayloadResult: function bjs_roundTripTypedPayloadResult(result) {
-                    const resultCaseId = enumHelpers.TypedPayloadResult.lower(result);
-                    instance.exports.bjs_roundTripTypedPayloadResult(resultCaseId);
-                    const ret = enumHelpers.TypedPayloadResult.lift(i32Stack.pop());
+                roundTripTypedPayloadResult: function bjs_TestModule_roundTripTypedPayloadResult(result) {
+                    const resultCaseId = enumHelpers.TestModule_TypedPayloadResult.lower(result);
+                    instance.exports.bjs_TestModule_roundTripTypedPayloadResult(resultCaseId);
+                    const ret = enumHelpers.TestModule_TypedPayloadResult.lift(i32Stack.pop());
                     return ret;
                 },
-                roundTripOptionalTypedPayloadResult: function bjs_roundTripOptionalTypedPayloadResult(result) {
+                roundTripOptionalTypedPayloadResult: function bjs_TestModule_roundTripOptionalTypedPayloadResult(result) {
                     const isSome = result != null;
                     let result1;
                     if (isSome) {
-                        const resultCaseId = enumHelpers.TypedPayloadResult.lower(result);
+                        const resultCaseId = enumHelpers.TestModule_TypedPayloadResult.lower(result);
                         result1 = resultCaseId;
                     } else {
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalTypedPayloadResult(+isSome, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalTypedPayloadResult(+isSome, result1);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.TypedPayloadResult.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_TypedPayloadResult.lift(tag);
                     return optResult;
                 },
-                roundTripAllTypesResult: function bjs_roundTripAllTypesResult(result) {
-                    const resultCaseId = enumHelpers.AllTypesResult.lower(result);
-                    instance.exports.bjs_roundTripAllTypesResult(resultCaseId);
-                    const ret = enumHelpers.AllTypesResult.lift(i32Stack.pop());
+                roundTripAllTypesResult: function bjs_TestModule_roundTripAllTypesResult(result) {
+                    const resultCaseId = enumHelpers.TestModule_AllTypesResult.lower(result);
+                    instance.exports.bjs_TestModule_roundTripAllTypesResult(resultCaseId);
+                    const ret = enumHelpers.TestModule_AllTypesResult.lift(i32Stack.pop());
                     return ret;
                 },
-                roundTripOptionalAllTypesResult: function bjs_roundTripOptionalAllTypesResult(result) {
+                roundTripOptionalAllTypesResult: function bjs_TestModule_roundTripOptionalAllTypesResult(result) {
                     const isSome = result != null;
                     let result1;
                     if (isSome) {
-                        const resultCaseId = enumHelpers.AllTypesResult.lower(result);
+                        const resultCaseId = enumHelpers.TestModule_AllTypesResult.lower(result);
                         result1 = resultCaseId;
                     } else {
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalAllTypesResult(+isSome, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalAllTypesResult(+isSome, result1);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.AllTypesResult.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_AllTypesResult.lift(tag);
                     return optResult;
                 },
-                roundTripOptionalPayloadResult: function bjs_roundTripOptionalPayloadResult(result) {
-                    const resultCaseId = enumHelpers.OptionalAllTypesResult.lower(result);
-                    instance.exports.bjs_roundTripOptionalPayloadResult(resultCaseId);
-                    const ret = enumHelpers.OptionalAllTypesResult.lift(i32Stack.pop());
+                roundTripOptionalPayloadResult: function bjs_TestModule_roundTripOptionalPayloadResult(result) {
+                    const resultCaseId = enumHelpers.TestModule_OptionalAllTypesResult.lower(result);
+                    instance.exports.bjs_TestModule_roundTripOptionalPayloadResult(resultCaseId);
+                    const ret = enumHelpers.TestModule_OptionalAllTypesResult.lift(i32Stack.pop());
                     return ret;
                 },
-                roundTripOptionalPayloadResultOpt: function bjs_roundTripOptionalPayloadResultOpt(result) {
+                roundTripOptionalPayloadResultOpt: function bjs_TestModule_roundTripOptionalPayloadResultOpt(result) {
                     const isSome = result != null;
                     let result1;
                     if (isSome) {
-                        const resultCaseId = enumHelpers.OptionalAllTypesResult.lower(result);
+                        const resultCaseId = enumHelpers.TestModule_OptionalAllTypesResult.lower(result);
                         result1 = resultCaseId;
                     } else {
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalPayloadResultOpt(+isSome, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalPayloadResultOpt(+isSome, result1);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.OptionalAllTypesResult.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_OptionalAllTypesResult.lift(tag);
                     return optResult;
                 },
                 APIResult: APIResultValues,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValueImport.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumAssociatedValueImport.js
@@ -38,7 +38,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createPayloadSignalValuesHelpers = () => ({
+    const __bjs_createTestModule_PayloadSignalHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -250,9 +250,9 @@ export async function createInstantiator(options, swift) {
             const TestModule = importObject["TestModule"] = importObject["TestModule"] || {};
             TestModule["bjs_PayloadSignalControls_roundTrip_static"] = function bjs_PayloadSignalControls_roundTrip_static(signal) {
                 try {
-                    const enumValue = enumHelpers.PayloadSignal.lift(signal);
+                    const enumValue = enumHelpers.TestModule_PayloadSignal.lift(signal);
                     let ret = imports.PayloadSignalControls.roundTrip(enumValue);
-                    const caseId = enumHelpers.PayloadSignal.lower(ret);
+                    const caseId = enumHelpers.TestModule_PayloadSignal.lower(ret);
                     return caseId;
                 } catch (error) {
                     setException(error);
@@ -260,7 +260,7 @@ export async function createInstantiator(options, swift) {
             }
             TestModule["bjs_PayloadSignalControls_send"] = function bjs_PayloadSignalControls_send(self, signal) {
                 try {
-                    const enumValue = enumHelpers.PayloadSignal.lift(signal);
+                    const enumValue = enumHelpers.TestModule_PayloadSignal.lift(signal);
                     swift.memory.getObject(self).send(enumValue);
                 } catch (error) {
                     setException(error);
@@ -269,7 +269,7 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_PayloadSignalControls_current"] = function bjs_PayloadSignalControls_current(self) {
                 try {
                     let ret = swift.memory.getObject(self).current();
-                    const caseId = enumHelpers.PayloadSignal.lower(ret);
+                    const caseId = enumHelpers.TestModule_PayloadSignal.lower(ret);
                     return caseId;
                 } catch (error) {
                     setException(error);
@@ -279,7 +279,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     let optResult;
                     if (signalIsSome) {
-                        const enumValue = enumHelpers.PayloadSignal.lift(signalCaseId);
+                        const enumValue = enumHelpers.TestModule_PayloadSignal.lift(signalCaseId);
                         optResult = enumValue;
                     } else {
                         optResult = null;
@@ -287,7 +287,7 @@ export async function createInstantiator(options, swift) {
                     let ret = swift.memory.getObject(self).roundTripOptional(optResult);
                     const isSome = ret != null;
                     if (isSome) {
-                        const caseId = enumHelpers.PayloadSignal.lower(ret);
+                        const caseId = enumHelpers.TestModule_PayloadSignal.lower(ret);
                         return caseId;
                     } else {
                         return -1;
@@ -310,8 +310,8 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const PayloadSignalHelpers = __bjs_createPayloadSignalValuesHelpers();
-            enumHelpers.PayloadSignal = PayloadSignalHelpers;
+            const TestModule_PayloadSignalHelpers = __bjs_createTestModule_PayloadSignalHelpers();
+            enumHelpers.TestModule_PayloadSignal = TestModule_PayloadSignalHelpers;
 
             const exports = {
                 PayloadSignal: PayloadSignalValues,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumCase.js
@@ -242,34 +242,34 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                setDirection: function bjs_setDirection(direction) {
-                    instance.exports.bjs_setDirection(direction);
+                setDirection: function bjs_TestModule_setDirection(direction) {
+                    instance.exports.bjs_TestModule_setDirection(direction);
                 },
-                getDirection: function bjs_getDirection() {
-                    const ret = instance.exports.bjs_getDirection();
+                getDirection: function bjs_TestModule_getDirection() {
+                    const ret = instance.exports.bjs_TestModule_getDirection();
                     return ret;
                 },
-                processDirection: function bjs_processDirection(input) {
-                    const ret = instance.exports.bjs_processDirection(input);
+                processDirection: function bjs_TestModule_processDirection(input) {
+                    const ret = instance.exports.bjs_TestModule_processDirection(input);
                     return ret;
                 },
-                roundTripOptionalDirection: function bjs_roundTripOptionalDirection(input) {
+                roundTripOptionalDirection: function bjs_TestModule_roundTripOptionalDirection(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalDirection(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_TestModule_roundTripOptionalDirection(+isSome, isSome ? input : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                setTSDirection: function bjs_setTSDirection(direction) {
-                    instance.exports.bjs_setTSDirection(direction);
+                setTSDirection: function bjs_TestModule_setTSDirection(direction) {
+                    instance.exports.bjs_TestModule_setTSDirection(direction);
                 },
-                getTSDirection: function bjs_getTSDirection() {
-                    const ret = instance.exports.bjs_getTSDirection();
+                getTSDirection: function bjs_TestModule_getTSDirection() {
+                    const ret = instance.exports.bjs_TestModule_getTSDirection();
                     return ret;
                 },
-                roundTripOptionalTSDirection: function bjs_roundTripOptionalTSDirection(input) {
+                roundTripOptionalTSDirection: function bjs_TestModule_roundTripOptionalTSDirection(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalTSDirection(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_TestModule_roundTripOptionalTSDirection(+isSome, isSome ? input : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.Global.js
@@ -251,19 +251,19 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Utils_Converter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Utils_Converter_wrap"] = function(pointer) {
                 const obj = _exports.Utils.Converter.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_Formatting_Converter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Formatting_Converter_wrap"] = function(pointer) {
                 const obj = _exports.Formatting.Converter.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_Networking_API_HTTPServer_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Networking_API_HTTPServer_wrap"] = function(pointer) {
                 const obj = _exports.Networking.API.HTTPServer.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_Networking_APIV2_Internal_TestServer_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Internal_TestServer_wrap"] = function(pointer) {
                 const obj = _exports.Networking.APIV2.Internal.TestServer.__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -335,64 +335,64 @@ export async function createInstantiator(options, swift) {
             }
             class Converter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Utils_Converter_deinit, Converter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Utils_Converter_deinit, Converter.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Utils_Converter_init();
+                    const ret = instance.exports.bjs_TestModule_Utils_Converter_init();
                     return Converter.__construct(ret);
                 }
                 toString(value) {
-                    instance.exports.bjs_Utils_Converter_toString(this.pointer, value);
+                    instance.exports.bjs_TestModule_Utils_Converter_toString(this.pointer, value);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 get precision() {
-                    const ret = instance.exports.bjs_Utils_Converter_precision_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_Utils_Converter_precision_get(this.pointer);
                     return ret;
                 }
                 set precision(value) {
-                    instance.exports.bjs_Utils_Converter_precision_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_Utils_Converter_precision_set(this.pointer, value);
                 }
             }
             class HTTPServer extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Networking_API_HTTPServer_deinit, HTTPServer.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Networking_API_HTTPServer_deinit, HTTPServer.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Networking_API_HTTPServer_init();
+                    const ret = instance.exports.bjs_TestModule_Networking_API_HTTPServer_init();
                     return HTTPServer.__construct(ret);
                 }
                 call(method) {
-                    instance.exports.bjs_Networking_API_HTTPServer_call(this.pointer, method);
+                    instance.exports.bjs_TestModule_Networking_API_HTTPServer_call(this.pointer, method);
                 }
             }
             class TestServer extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Networking_APIV2_Internal_TestServer_deinit, TestServer.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Internal_TestServer_deinit, TestServer.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Networking_APIV2_Internal_TestServer_init();
+                    const ret = instance.exports.bjs_TestModule_Internal_TestServer_init();
                     return TestServer.__construct(ret);
                 }
                 call(method) {
-                    instance.exports.bjs_Networking_APIV2_Internal_TestServer_call(this.pointer, method);
+                    instance.exports.bjs_TestModule_Internal_TestServer_call(this.pointer, method);
                 }
             }
             class Converter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Formatting_Converter_deinit, Converter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Formatting_Converter_deinit, Converter.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Formatting_Converter_init();
+                    const ret = instance.exports.bjs_TestModule_Formatting_Converter_init();
                     return Converter.__construct(ret);
                 }
                 format(value) {
-                    instance.exports.bjs_Formatting_Converter_format(this.pointer, value);
+                    instance.exports.bjs_TestModule_Formatting_Converter_format(this.pointer, value);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -451,16 +451,16 @@ export async function createInstantiator(options, swift) {
                 Services: {
                     Graph: {
                         GraphOperations: {
-                            createGraph: function bjs_Services_Graph_GraphOperations_static_createGraph(rootId) {
-                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_createGraph(rootId);
+                            createGraph: function bjs_TestModule_GraphOperations_static_createGraph(rootId) {
+                                const ret = instance.exports.bjs_TestModule_GraphOperations_static_createGraph(rootId);
                                 return ret;
                             },
-                            nodeCount: function bjs_Services_Graph_GraphOperations_static_nodeCount(graphId) {
-                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_nodeCount(graphId);
+                            nodeCount: function bjs_TestModule_GraphOperations_static_nodeCount(graphId) {
+                                const ret = instance.exports.bjs_TestModule_GraphOperations_static_nodeCount(graphId);
                                 return ret;
                             },
-                            validate: function bjs_Services_Graph_GraphOperations_static_validate(graphId) {
-                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_validate(graphId);
+                            validate: function bjs_TestModule_GraphOperations_static_validate(graphId) {
+                                const ret = instance.exports.bjs_TestModule_GraphOperations_static_validate(graphId);
                                 if (tmpRetException) {
                                     const error = swift.memory.getObject(tmpRetException);
                                     swift.memory.release(tmpRetException);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumNamespace.js
@@ -232,19 +232,19 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Utils_Converter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Utils_Converter_wrap"] = function(pointer) {
                 const obj = _exports.Utils.Converter.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_Formatting_Converter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Formatting_Converter_wrap"] = function(pointer) {
                 const obj = _exports.Formatting.Converter.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_Networking_API_HTTPServer_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Networking_API_HTTPServer_wrap"] = function(pointer) {
                 const obj = _exports.Networking.API.HTTPServer.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_Networking_APIV2_Internal_TestServer_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Internal_TestServer_wrap"] = function(pointer) {
                 const obj = _exports.Networking.APIV2.Internal.TestServer.__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -316,64 +316,64 @@ export async function createInstantiator(options, swift) {
             }
             class Converter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Utils_Converter_deinit, Converter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Utils_Converter_deinit, Converter.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Utils_Converter_init();
+                    const ret = instance.exports.bjs_TestModule_Utils_Converter_init();
                     return Converter.__construct(ret);
                 }
                 toString(value) {
-                    instance.exports.bjs_Utils_Converter_toString(this.pointer, value);
+                    instance.exports.bjs_TestModule_Utils_Converter_toString(this.pointer, value);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 get precision() {
-                    const ret = instance.exports.bjs_Utils_Converter_precision_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_Utils_Converter_precision_get(this.pointer);
                     return ret;
                 }
                 set precision(value) {
-                    instance.exports.bjs_Utils_Converter_precision_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_Utils_Converter_precision_set(this.pointer, value);
                 }
             }
             class HTTPServer extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Networking_API_HTTPServer_deinit, HTTPServer.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Networking_API_HTTPServer_deinit, HTTPServer.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Networking_API_HTTPServer_init();
+                    const ret = instance.exports.bjs_TestModule_Networking_API_HTTPServer_init();
                     return HTTPServer.__construct(ret);
                 }
                 call(method) {
-                    instance.exports.bjs_Networking_API_HTTPServer_call(this.pointer, method);
+                    instance.exports.bjs_TestModule_Networking_API_HTTPServer_call(this.pointer, method);
                 }
             }
             class TestServer extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Networking_APIV2_Internal_TestServer_deinit, TestServer.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Internal_TestServer_deinit, TestServer.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Networking_APIV2_Internal_TestServer_init();
+                    const ret = instance.exports.bjs_TestModule_Internal_TestServer_init();
                     return TestServer.__construct(ret);
                 }
                 call(method) {
-                    instance.exports.bjs_Networking_APIV2_Internal_TestServer_call(this.pointer, method);
+                    instance.exports.bjs_TestModule_Internal_TestServer_call(this.pointer, method);
                 }
             }
             class Converter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Formatting_Converter_deinit, Converter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Formatting_Converter_deinit, Converter.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Formatting_Converter_init();
+                    const ret = instance.exports.bjs_TestModule_Formatting_Converter_init();
                     return Converter.__construct(ret);
                 }
                 format(value) {
-                    instance.exports.bjs_Formatting_Converter_format(this.pointer, value);
+                    instance.exports.bjs_TestModule_Formatting_Converter_format(this.pointer, value);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -402,16 +402,16 @@ export async function createInstantiator(options, swift) {
                 Services: {
                     Graph: {
                         GraphOperations: {
-                            createGraph: function bjs_Services_Graph_GraphOperations_static_createGraph(rootId) {
-                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_createGraph(rootId);
+                            createGraph: function bjs_TestModule_GraphOperations_static_createGraph(rootId) {
+                                const ret = instance.exports.bjs_TestModule_GraphOperations_static_createGraph(rootId);
                                 return ret;
                             },
-                            nodeCount: function bjs_Services_Graph_GraphOperations_static_nodeCount(graphId) {
-                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_nodeCount(graphId);
+                            nodeCount: function bjs_TestModule_GraphOperations_static_nodeCount(graphId) {
+                                const ret = instance.exports.bjs_TestModule_GraphOperations_static_nodeCount(graphId);
                                 return ret;
                             },
-                            validate: function bjs_Services_Graph_GraphOperations_static_validate(graphId) {
-                                const ret = instance.exports.bjs_Services_Graph_GraphOperations_static_validate(graphId);
+                            validate: function bjs_TestModule_GraphOperations_static_validate(graphId) {
+                                const ret = instance.exports.bjs_TestModule_GraphOperations_static_validate(graphId);
                                 if (tmpRetException) {
                                     const error = swift.memory.getObject(tmpRetException);
                                     swift.memory.release(tmpRetException);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/EnumRawType.js
@@ -312,18 +312,18 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                setTheme: function bjs_setTheme(theme) {
+                setTheme: function bjs_TestModule_setTheme(theme) {
                     const themeBytes = textEncoder.encode(theme);
                     const themeId = swift.memory.retain(themeBytes);
-                    instance.exports.bjs_setTheme(themeId, themeBytes.length);
+                    instance.exports.bjs_TestModule_setTheme(themeId, themeBytes.length);
                 },
-                getTheme: function bjs_getTheme() {
-                    instance.exports.bjs_getTheme();
+                getTheme: function bjs_TestModule_getTheme() {
+                    instance.exports.bjs_TestModule_getTheme();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 },
-                roundTripOptionalTheme: function bjs_roundTripOptionalTheme(input) {
+                roundTripOptionalTheme: function bjs_TestModule_roundTripOptionalTheme(input) {
                     const isSome = input != null;
                     let result, result1;
                     if (isSome) {
@@ -335,23 +335,23 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalTheme(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalTheme(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                setTSTheme: function bjs_setTSTheme(theme) {
+                setTSTheme: function bjs_TestModule_setTSTheme(theme) {
                     const themeBytes = textEncoder.encode(theme);
                     const themeId = swift.memory.retain(themeBytes);
-                    instance.exports.bjs_setTSTheme(themeId, themeBytes.length);
+                    instance.exports.bjs_TestModule_setTSTheme(themeId, themeBytes.length);
                 },
-                getTSTheme: function bjs_getTSTheme() {
-                    instance.exports.bjs_getTSTheme();
+                getTSTheme: function bjs_TestModule_getTSTheme() {
+                    instance.exports.bjs_TestModule_getTSTheme();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 },
-                roundTripOptionalTSTheme: function bjs_roundTripOptionalTSTheme(input) {
+                roundTripOptionalTSTheme: function bjs_TestModule_roundTripOptionalTSTheme(input) {
                     const isSome = input != null;
                     let result, result1;
                     if (isSome) {
@@ -363,23 +363,23 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalTSTheme(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalTSTheme(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                setFeatureFlag: function bjs_setFeatureFlag(flag) {
+                setFeatureFlag: function bjs_TestModule_setFeatureFlag(flag) {
                     const flagBytes = textEncoder.encode(flag);
                     const flagId = swift.memory.retain(flagBytes);
-                    instance.exports.bjs_setFeatureFlag(flagId, flagBytes.length);
+                    instance.exports.bjs_TestModule_setFeatureFlag(flagId, flagBytes.length);
                 },
-                getFeatureFlag: function bjs_getFeatureFlag() {
-                    instance.exports.bjs_getFeatureFlag();
+                getFeatureFlag: function bjs_TestModule_getFeatureFlag() {
+                    instance.exports.bjs_TestModule_getFeatureFlag();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 },
-                roundTripOptionalFeatureFlag: function bjs_roundTripOptionalFeatureFlag(input) {
+                roundTripOptionalFeatureFlag: function bjs_TestModule_roundTripOptionalFeatureFlag(input) {
                     const isSome = input != null;
                     let result, result1;
                     if (isSome) {
@@ -391,63 +391,63 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalFeatureFlag(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalFeatureFlag(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                setHttpStatus: function bjs_setHttpStatus(status) {
-                    instance.exports.bjs_setHttpStatus(status);
+                setHttpStatus: function bjs_TestModule_setHttpStatus(status) {
+                    instance.exports.bjs_TestModule_setHttpStatus(status);
                 },
-                getHttpStatus: function bjs_getHttpStatus() {
-                    const ret = instance.exports.bjs_getHttpStatus();
+                getHttpStatus: function bjs_TestModule_getHttpStatus() {
+                    const ret = instance.exports.bjs_TestModule_getHttpStatus();
                     return ret;
                 },
-                roundTripOptionalHttpStatus: function bjs_roundTripOptionalHttpStatus(input) {
+                roundTripOptionalHttpStatus: function bjs_TestModule_roundTripOptionalHttpStatus(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalHttpStatus(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_TestModule_roundTripOptionalHttpStatus(+isSome, isSome ? input : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                setTSHttpStatus: function bjs_setTSHttpStatus(status) {
-                    instance.exports.bjs_setTSHttpStatus(status);
+                setTSHttpStatus: function bjs_TestModule_setTSHttpStatus(status) {
+                    instance.exports.bjs_TestModule_setTSHttpStatus(status);
                 },
-                getTSHttpStatus: function bjs_getTSHttpStatus() {
-                    const ret = instance.exports.bjs_getTSHttpStatus();
+                getTSHttpStatus: function bjs_TestModule_getTSHttpStatus() {
+                    const ret = instance.exports.bjs_TestModule_getTSHttpStatus();
                     return ret;
                 },
-                roundTripOptionalHttpStatus: function bjs_roundTripOptionalHttpStatus(input) {
+                roundTripOptionalHttpStatus: function bjs_TestModule_roundTripOptionalHttpStatus(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalHttpStatus(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_TestModule_roundTripOptionalHttpStatus(+isSome, isSome ? input : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                setPriority: function bjs_setPriority(priority) {
-                    instance.exports.bjs_setPriority(priority);
+                setPriority: function bjs_TestModule_setPriority(priority) {
+                    instance.exports.bjs_TestModule_setPriority(priority);
                 },
-                getPriority: function bjs_getPriority() {
-                    const ret = instance.exports.bjs_getPriority();
+                getPriority: function bjs_TestModule_getPriority() {
+                    const ret = instance.exports.bjs_TestModule_getPriority();
                     return ret;
                 },
-                roundTripOptionalPriority: function bjs_roundTripOptionalPriority(input) {
+                roundTripOptionalPriority: function bjs_TestModule_roundTripOptionalPriority(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalPriority(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_TestModule_roundTripOptionalPriority(+isSome, isSome ? input : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                setFileSize: function bjs_setFileSize(size) {
-                    instance.exports.bjs_setFileSize(size);
+                setFileSize: function bjs_TestModule_setFileSize(size) {
+                    instance.exports.bjs_TestModule_setFileSize(size);
                 },
-                getFileSize: function bjs_getFileSize() {
-                    const ret = instance.exports.bjs_getFileSize();
+                getFileSize: function bjs_TestModule_getFileSize() {
+                    const ret = instance.exports.bjs_TestModule_getFileSize();
                     return ret;
                 },
-                roundTripOptionalFileSize: function bjs_roundTripOptionalFileSize(input) {
+                roundTripOptionalFileSize: function bjs_TestModule_roundTripOptionalFileSize(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalFileSize(+isSome, isSome ? input : 0n);
+                    instance.exports.bjs_TestModule_roundTripOptionalFileSize(+isSome, isSome ? input : 0n);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -458,44 +458,44 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 },
-                setUserId: function bjs_setUserId(id) {
-                    instance.exports.bjs_setUserId(id);
+                setUserId: function bjs_TestModule_setUserId(id) {
+                    instance.exports.bjs_TestModule_setUserId(id);
                 },
-                getUserId: function bjs_getUserId() {
-                    const ret = instance.exports.bjs_getUserId();
+                getUserId: function bjs_TestModule_getUserId() {
+                    const ret = instance.exports.bjs_TestModule_getUserId();
                     return ret >>> 0;
                 },
-                roundTripOptionalUserId: function bjs_roundTripOptionalUserId(input) {
+                roundTripOptionalUserId: function bjs_TestModule_roundTripOptionalUserId(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalUserId(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_TestModule_roundTripOptionalUserId(+isSome, isSome ? input : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                setTokenId: function bjs_setTokenId(token) {
-                    instance.exports.bjs_setTokenId(token);
+                setTokenId: function bjs_TestModule_setTokenId(token) {
+                    instance.exports.bjs_TestModule_setTokenId(token);
                 },
-                getTokenId: function bjs_getTokenId() {
-                    const ret = instance.exports.bjs_getTokenId();
+                getTokenId: function bjs_TestModule_getTokenId() {
+                    const ret = instance.exports.bjs_TestModule_getTokenId();
                     return ret >>> 0;
                 },
-                roundTripOptionalTokenId: function bjs_roundTripOptionalTokenId(input) {
+                roundTripOptionalTokenId: function bjs_TestModule_roundTripOptionalTokenId(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalTokenId(+isSome, isSome ? input : 0);
+                    instance.exports.bjs_TestModule_roundTripOptionalTokenId(+isSome, isSome ? input : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                setSessionId: function bjs_setSessionId(session) {
-                    instance.exports.bjs_setSessionId(session);
+                setSessionId: function bjs_TestModule_setSessionId(session) {
+                    instance.exports.bjs_TestModule_setSessionId(session);
                 },
-                getSessionId: function bjs_getSessionId() {
-                    const ret = instance.exports.bjs_getSessionId();
+                getSessionId: function bjs_TestModule_getSessionId() {
+                    const ret = instance.exports.bjs_TestModule_getSessionId();
                     return BigInt.asUintN(64, ret);
                 },
-                roundTripOptionalSessionId: function bjs_roundTripOptionalSessionId(input) {
+                roundTripOptionalSessionId: function bjs_TestModule_roundTripOptionalSessionId(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalSessionId(+isSome, isSome ? input : 0n);
+                    instance.exports.bjs_TestModule_roundTripOptionalSessionId(+isSome, isSome ? input : 0n);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -506,46 +506,46 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 },
-                setPrecision: function bjs_setPrecision(precision) {
-                    instance.exports.bjs_setPrecision(precision);
+                setPrecision: function bjs_TestModule_setPrecision(precision) {
+                    instance.exports.bjs_TestModule_setPrecision(precision);
                 },
-                getPrecision: function bjs_getPrecision() {
-                    const ret = instance.exports.bjs_getPrecision();
+                getPrecision: function bjs_TestModule_getPrecision() {
+                    const ret = instance.exports.bjs_TestModule_getPrecision();
                     return ret;
                 },
-                roundTripOptionalPrecision: function bjs_roundTripOptionalPrecision(input) {
+                roundTripOptionalPrecision: function bjs_TestModule_roundTripOptionalPrecision(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalPrecision(+isSome, isSome ? input : 0.0);
+                    instance.exports.bjs_TestModule_roundTripOptionalPrecision(+isSome, isSome ? input : 0.0);
                     const optResult = tmpRetOptionalFloat;
                     tmpRetOptionalFloat = undefined;
                     return optResult;
                 },
-                setRatio: function bjs_setRatio(ratio) {
-                    instance.exports.bjs_setRatio(ratio);
+                setRatio: function bjs_TestModule_setRatio(ratio) {
+                    instance.exports.bjs_TestModule_setRatio(ratio);
                 },
-                getRatio: function bjs_getRatio() {
-                    const ret = instance.exports.bjs_getRatio();
+                getRatio: function bjs_TestModule_getRatio() {
+                    const ret = instance.exports.bjs_TestModule_getRatio();
                     return ret;
                 },
-                roundTripOptionalRatio: function bjs_roundTripOptionalRatio(input) {
+                roundTripOptionalRatio: function bjs_TestModule_roundTripOptionalRatio(input) {
                     const isSome = input != null;
-                    instance.exports.bjs_roundTripOptionalRatio(+isSome, isSome ? input : 0.0);
+                    instance.exports.bjs_TestModule_roundTripOptionalRatio(+isSome, isSome ? input : 0.0);
                     const optResult = tmpRetOptionalDouble;
                     tmpRetOptionalDouble = undefined;
                     return optResult;
                 },
-                processTheme: function bjs_processTheme(theme) {
+                processTheme: function bjs_TestModule_processTheme(theme) {
                     const themeBytes = textEncoder.encode(theme);
                     const themeId = swift.memory.retain(themeBytes);
-                    const ret = instance.exports.bjs_processTheme(themeId, themeBytes.length);
+                    const ret = instance.exports.bjs_TestModule_processTheme(themeId, themeBytes.length);
                     return ret;
                 },
-                convertPriority: function bjs_convertPriority(status) {
-                    const ret = instance.exports.bjs_convertPriority(status);
+                convertPriority: function bjs_TestModule_convertPriority(status) {
+                    const ret = instance.exports.bjs_TestModule_convertPriority(status);
                     return ret;
                 },
-                validateSession: function bjs_validateSession(session) {
-                    instance.exports.bjs_validateSession(session);
+                validateSession: function bjs_TestModule_validateSession(session) {
+                    instance.exports.bjs_TestModule_validateSession(session);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/FixedWidthIntegers.js
@@ -292,36 +292,36 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                roundTripInt8: function bjs_roundTripInt8(v) {
-                    const ret = instance.exports.bjs_roundTripInt8(v);
+                roundTripInt8: function bjs_TestModule_roundTripInt8(v) {
+                    const ret = instance.exports.bjs_TestModule_roundTripInt8(v);
                     return ret;
                 },
-                roundTripUInt8: function bjs_roundTripUInt8(v) {
-                    const ret = instance.exports.bjs_roundTripUInt8(v);
+                roundTripUInt8: function bjs_TestModule_roundTripUInt8(v) {
+                    const ret = instance.exports.bjs_TestModule_roundTripUInt8(v);
                     return ret >>> 0;
                 },
-                roundTripInt16: function bjs_roundTripInt16(v) {
-                    const ret = instance.exports.bjs_roundTripInt16(v);
+                roundTripInt16: function bjs_TestModule_roundTripInt16(v) {
+                    const ret = instance.exports.bjs_TestModule_roundTripInt16(v);
                     return ret;
                 },
-                roundTripUInt16: function bjs_roundTripUInt16(v) {
-                    const ret = instance.exports.bjs_roundTripUInt16(v);
+                roundTripUInt16: function bjs_TestModule_roundTripUInt16(v) {
+                    const ret = instance.exports.bjs_TestModule_roundTripUInt16(v);
                     return ret >>> 0;
                 },
-                roundTripInt32: function bjs_roundTripInt32(v) {
-                    const ret = instance.exports.bjs_roundTripInt32(v);
+                roundTripInt32: function bjs_TestModule_roundTripInt32(v) {
+                    const ret = instance.exports.bjs_TestModule_roundTripInt32(v);
                     return ret;
                 },
-                roundTripUInt32: function bjs_roundTripUInt32(v) {
-                    const ret = instance.exports.bjs_roundTripUInt32(v);
+                roundTripUInt32: function bjs_TestModule_roundTripUInt32(v) {
+                    const ret = instance.exports.bjs_TestModule_roundTripUInt32(v);
                     return ret >>> 0;
                 },
-                roundTripInt64: function bjs_roundTripInt64(v) {
-                    const ret = instance.exports.bjs_roundTripInt64(v);
+                roundTripInt64: function bjs_TestModule_roundTripInt64(v) {
+                    const ret = instance.exports.bjs_TestModule_roundTripInt64(v);
                     return ret;
                 },
-                roundTripUInt64: function bjs_roundTripUInt64(v) {
-                    const ret = instance.exports.bjs_roundTripUInt64(v);
+                roundTripUInt64: function bjs_TestModule_roundTripUInt64(v) {
+                    const ret = instance.exports.bjs_TestModule_roundTripUInt64(v);
                     return BigInt.asUintN(64, ret);
                 },
             };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.ConfigPointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.ConfigPointer.js
@@ -207,15 +207,15 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_CachedModel_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_CachedModel_wrap"] = function(pointer) {
                 const obj = _exports['CachedModel'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_ExplicitlyUncachedModel_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_ExplicitlyUncachedModel_wrap"] = function(pointer) {
                 const obj = _exports['ExplicitlyUncachedModel'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_UncachedModel_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_UncachedModel_wrap"] = function(pointer) {
                 const obj = _exports['UncachedModel'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -289,17 +289,17 @@ export async function createInstantiator(options, swift) {
                 static __identityCache = new Map();
 
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_CachedModel_deinit, CachedModel.prototype, CachedModel.__identityCache);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_CachedModel_deinit, CachedModel.prototype, CachedModel.__identityCache);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_CachedModel_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_CachedModel_init(nameId, nameBytes.length);
                     return CachedModel.__construct(ret);
                 }
                 get name() {
-                    instance.exports.bjs_CachedModel_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_CachedModel_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -307,43 +307,43 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_CachedModel_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_CachedModel_name_set(this.pointer, valueId, valueBytes.length);
                 }
             }
             class UncachedModel extends SwiftHeapObject {
                 static __identityCache = new Map();
 
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_UncachedModel_deinit, UncachedModel.prototype, UncachedModel.__identityCache);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_UncachedModel_deinit, UncachedModel.prototype, UncachedModel.__identityCache);
                 }
 
                 constructor(value) {
-                    const ret = instance.exports.bjs_UncachedModel_init(value);
+                    const ret = instance.exports.bjs_TestModule_UncachedModel_init(value);
                     return UncachedModel.__construct(ret);
                 }
                 get value() {
-                    const ret = instance.exports.bjs_UncachedModel_value_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_UncachedModel_value_get(this.pointer);
                     return ret;
                 }
                 set value(value) {
-                    instance.exports.bjs_UncachedModel_value_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_UncachedModel_value_set(this.pointer, value);
                 }
             }
             class ExplicitlyUncachedModel extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_ExplicitlyUncachedModel_deinit, ExplicitlyUncachedModel.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_ExplicitlyUncachedModel_deinit, ExplicitlyUncachedModel.prototype, null);
                 }
 
                 constructor(count) {
-                    const ret = instance.exports.bjs_ExplicitlyUncachedModel_init(count);
+                    const ret = instance.exports.bjs_TestModule_ExplicitlyUncachedModel_init(count);
                     return ExplicitlyUncachedModel.__construct(ret);
                 }
                 get count() {
-                    const ret = instance.exports.bjs_ExplicitlyUncachedModel_count_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_ExplicitlyUncachedModel_count_get(this.pointer);
                     return ret;
                 }
                 set count(value) {
-                    instance.exports.bjs_ExplicitlyUncachedModel_count_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_ExplicitlyUncachedModel_count_set(this.pointer, value);
                 }
             }
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.PerClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.PerClass.js
@@ -207,15 +207,15 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_CachedModel_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_CachedModel_wrap"] = function(pointer) {
                 const obj = _exports['CachedModel'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_ExplicitlyUncachedModel_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_ExplicitlyUncachedModel_wrap"] = function(pointer) {
                 const obj = _exports['ExplicitlyUncachedModel'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_UncachedModel_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_UncachedModel_wrap"] = function(pointer) {
                 const obj = _exports['UncachedModel'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -289,17 +289,17 @@ export async function createInstantiator(options, swift) {
                 static __identityCache = new Map();
 
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_CachedModel_deinit, CachedModel.prototype, CachedModel.__identityCache);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_CachedModel_deinit, CachedModel.prototype, CachedModel.__identityCache);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_CachedModel_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_CachedModel_init(nameId, nameBytes.length);
                     return CachedModel.__construct(ret);
                 }
                 get name() {
-                    instance.exports.bjs_CachedModel_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_CachedModel_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -307,41 +307,41 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_CachedModel_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_CachedModel_name_set(this.pointer, valueId, valueBytes.length);
                 }
             }
             class UncachedModel extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_UncachedModel_deinit, UncachedModel.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_UncachedModel_deinit, UncachedModel.prototype, null);
                 }
 
                 constructor(value) {
-                    const ret = instance.exports.bjs_UncachedModel_init(value);
+                    const ret = instance.exports.bjs_TestModule_UncachedModel_init(value);
                     return UncachedModel.__construct(ret);
                 }
                 get value() {
-                    const ret = instance.exports.bjs_UncachedModel_value_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_UncachedModel_value_get(this.pointer);
                     return ret;
                 }
                 set value(value) {
-                    instance.exports.bjs_UncachedModel_value_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_UncachedModel_value_set(this.pointer, value);
                 }
             }
             class ExplicitlyUncachedModel extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_ExplicitlyUncachedModel_deinit, ExplicitlyUncachedModel.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_ExplicitlyUncachedModel_deinit, ExplicitlyUncachedModel.prototype, null);
                 }
 
                 constructor(count) {
-                    const ret = instance.exports.bjs_ExplicitlyUncachedModel_init(count);
+                    const ret = instance.exports.bjs_TestModule_ExplicitlyUncachedModel_init(count);
                     return ExplicitlyUncachedModel.__construct(ret);
                 }
                 get count() {
-                    const ret = instance.exports.bjs_ExplicitlyUncachedModel_count_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_ExplicitlyUncachedModel_count_get(this.pointer);
                     return ret;
                 }
                 set count(value) {
-                    instance.exports.bjs_ExplicitlyUncachedModel_count_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_ExplicitlyUncachedModel_count_set(this.pointer, value);
                 }
             }
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/IdentityModeClass.js
@@ -207,15 +207,15 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_CachedModel_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_CachedModel_wrap"] = function(pointer) {
                 const obj = _exports['CachedModel'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_ExplicitlyUncachedModel_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_ExplicitlyUncachedModel_wrap"] = function(pointer) {
                 const obj = _exports['ExplicitlyUncachedModel'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_UncachedModel_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_UncachedModel_wrap"] = function(pointer) {
                 const obj = _exports['UncachedModel'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -289,17 +289,17 @@ export async function createInstantiator(options, swift) {
                 static __identityCache = new Map();
 
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_CachedModel_deinit, CachedModel.prototype, CachedModel.__identityCache);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_CachedModel_deinit, CachedModel.prototype, CachedModel.__identityCache);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_CachedModel_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_CachedModel_init(nameId, nameBytes.length);
                     return CachedModel.__construct(ret);
                 }
                 get name() {
-                    instance.exports.bjs_CachedModel_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_CachedModel_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -307,41 +307,41 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_CachedModel_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_CachedModel_name_set(this.pointer, valueId, valueBytes.length);
                 }
             }
             class UncachedModel extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_UncachedModel_deinit, UncachedModel.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_UncachedModel_deinit, UncachedModel.prototype, null);
                 }
 
                 constructor(value) {
-                    const ret = instance.exports.bjs_UncachedModel_init(value);
+                    const ret = instance.exports.bjs_TestModule_UncachedModel_init(value);
                     return UncachedModel.__construct(ret);
                 }
                 get value() {
-                    const ret = instance.exports.bjs_UncachedModel_value_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_UncachedModel_value_get(this.pointer);
                     return ret;
                 }
                 set value(value) {
-                    instance.exports.bjs_UncachedModel_value_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_UncachedModel_value_set(this.pointer, value);
                 }
             }
             class ExplicitlyUncachedModel extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_ExplicitlyUncachedModel_deinit, ExplicitlyUncachedModel.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_ExplicitlyUncachedModel_deinit, ExplicitlyUncachedModel.prototype, null);
                 }
 
                 constructor(count) {
-                    const ret = instance.exports.bjs_ExplicitlyUncachedModel_init(count);
+                    const ret = instance.exports.bjs_TestModule_ExplicitlyUncachedModel_init(count);
                     return ExplicitlyUncachedModel.__construct(ret);
                 }
                 get count() {
-                    const ret = instance.exports.bjs_ExplicitlyUncachedModel_count_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_ExplicitlyUncachedModel_count_get(this.pointer);
                     return ret;
                 }
                 set count(value) {
-                    instance.exports.bjs_ExplicitlyUncachedModel_count_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_ExplicitlyUncachedModel_count_set(this.pointer, value);
                 }
             }
             const exports = {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ImportedTypeInExportedInterface.js
@@ -31,7 +31,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createFooContainerHelpers = () => ({
+    const __bjs_createTestModule_FooContainerHelpers = () => ({
         lower: (value) => {
             let id;
             if (value.foo != null) {
@@ -145,11 +145,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_FooContainer"] = function(objectId) {
-                structHelpers.FooContainer.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_FooContainer"] = function(objectId) {
+                structHelpers.TestModule_FooContainer.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_FooContainer"] = function() {
-                const value = structHelpers.FooContainer.lift();
+            bjs["swift_js_struct_lift_TestModule_FooContainer"] = function() {
+                const value = structHelpers.TestModule_FooContainer.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -272,12 +272,12 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const FooContainerHelpers = __bjs_createFooContainerHelpers();
-            structHelpers.FooContainer = FooContainerHelpers;
+            const TestModule_FooContainerHelpers = __bjs_createTestModule_FooContainerHelpers();
+            structHelpers.TestModule_FooContainer = TestModule_FooContainerHelpers;
 
             const exports = {
-                makeFoo: function bjs_makeFoo() {
-                    const ret = instance.exports.bjs_makeFoo();
+                makeFoo: function bjs_TestModule_makeFoo() {
+                    const ret = instance.exports.bjs_TestModule_makeFoo();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     if (tmpRetException) {
@@ -288,13 +288,13 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret1;
                 },
-                processFooArray: function bjs_processFooArray(foos) {
+                processFooArray: function bjs_TestModule_processFooArray(foos) {
                     for (const elem of foos) {
                         const objId = swift.memory.retain(elem);
                         i32Stack.push(objId);
                     }
                     i32Stack.push(foos.length);
-                    instance.exports.bjs_processFooArray();
+                    instance.exports.bjs_TestModule_processFooArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -311,7 +311,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processOptionalFooArray: function bjs_processOptionalFooArray(foos) {
+                processOptionalFooArray: function bjs_TestModule_processOptionalFooArray(foos) {
                     for (const elem of foos) {
                         const isSome = elem != null ? 1 : 0;
                         if (isSome) {
@@ -321,7 +321,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(isSome);
                     }
                     i32Stack.push(foos.length);
-                    instance.exports.bjs_processOptionalFooArray();
+                    instance.exports.bjs_TestModule_processOptionalFooArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -345,10 +345,10 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                roundtripFooContainer: function bjs_roundtripFooContainer(container) {
-                    structHelpers.FooContainer.lower(container);
-                    instance.exports.bjs_roundtripFooContainer();
-                    const structValue = structHelpers.FooContainer.lift();
+                roundtripFooContainer: function bjs_TestModule_roundtripFooContainer(container) {
+                    structHelpers.TestModule_FooContainer.lower(container);
+                    instance.exports.bjs_TestModule_roundtripFooContainer();
+                    const structValue = structHelpers.TestModule_FooContainer.lift();
                     return structValue;
                 },
             };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSTypedArrayTypes.js
@@ -218,26 +218,26 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                processBytes: function bjs_processBytes(data) {
-                    const ret = instance.exports.bjs_processBytes(swift.memory.retain(data));
+                processBytes: function bjs_TestModule_processBytes(data) {
+                    const ret = instance.exports.bjs_TestModule_processBytes(swift.memory.retain(data));
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                processFloats: function bjs_processFloats(data) {
-                    const ret = instance.exports.bjs_processFloats(swift.memory.retain(data));
+                processFloats: function bjs_TestModule_processFloats(data) {
+                    const ret = instance.exports.bjs_TestModule_processFloats(swift.memory.retain(data));
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                processGenericDoubles: function bjs_processGenericDoubles(data) {
-                    const ret = instance.exports.bjs_processGenericDoubles(swift.memory.retain(data));
+                processGenericDoubles: function bjs_TestModule_processGenericDoubles(data) {
+                    const ret = instance.exports.bjs_TestModule_processGenericDoubles(swift.memory.retain(data));
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 },
-                processGenericInts: function bjs_processGenericInts(data) {
-                    const ret = instance.exports.bjs_processGenericInts(swift.memory.retain(data));
+                processGenericInts: function bjs_TestModule_processGenericInts(data) {
+                    const ret = instance.exports.bjs_TestModule_processGenericInts(swift.memory.retain(data));
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/JSValue.js
@@ -297,7 +297,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_JSValueHolder_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_JSValueHolder_wrap"] = function(pointer) {
                 const obj = _exports['JSValueHolder'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -411,7 +411,7 @@ export async function createInstantiator(options, swift) {
             }
             class JSValueHolder extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_JSValueHolder_deinit, JSValueHolder.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_JSValueHolder_deinit, JSValueHolder.prototype, null);
                 }
 
                 constructor(value, optionalValue) {
@@ -428,7 +428,7 @@ export async function createInstantiator(options, swift) {
                         result1 = 0;
                         result2 = 0.0;
                     }
-                    const ret = instance.exports.bjs_JSValueHolder_init(valueKind, valuePayload1, valuePayload2, +isSome, result, result1, result2);
+                    const ret = instance.exports.bjs_TestModule_JSValueHolder_init(valueKind, valuePayload1, valuePayload2, +isSome, result, result1, result2);
                     return JSValueHolder.__construct(ret);
                 }
                 update(value, optionalValue) {
@@ -445,11 +445,11 @@ export async function createInstantiator(options, swift) {
                         result1 = 0;
                         result2 = 0.0;
                     }
-                    instance.exports.bjs_JSValueHolder_update(this.pointer, valueKind, valuePayload1, valuePayload2, +isSome, result, result1, result2);
+                    instance.exports.bjs_TestModule_JSValueHolder_update(this.pointer, valueKind, valuePayload1, valuePayload2, +isSome, result, result1, result2);
                 }
                 echo(value) {
                     const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
-                    instance.exports.bjs_JSValueHolder_echo(this.pointer, valueKind, valuePayload1, valuePayload2);
+                    instance.exports.bjs_TestModule_JSValueHolder_echo(this.pointer, valueKind, valuePayload1, valuePayload2);
                     const jsValuePayload2 = f64Stack.pop();
                     const jsValuePayload1 = i32Stack.pop();
                     const jsValueKind = i32Stack.pop();
@@ -469,7 +469,7 @@ export async function createInstantiator(options, swift) {
                         result1 = 0;
                         result2 = 0.0;
                     }
-                    instance.exports.bjs_JSValueHolder_echoOptional(this.pointer, +isSome, result, result1, result2);
+                    instance.exports.bjs_TestModule_JSValueHolder_echoOptional(this.pointer, +isSome, result, result1, result2);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -484,7 +484,7 @@ export async function createInstantiator(options, swift) {
                     return optResult;
                 }
                 get value() {
-                    instance.exports.bjs_JSValueHolder_value_get(this.pointer);
+                    instance.exports.bjs_TestModule_JSValueHolder_value_get(this.pointer);
                     const jsValuePayload2 = f64Stack.pop();
                     const jsValuePayload1 = i32Stack.pop();
                     const jsValueKind = i32Stack.pop();
@@ -493,10 +493,10 @@ export async function createInstantiator(options, swift) {
                 }
                 set value(value) {
                     const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
-                    instance.exports.bjs_JSValueHolder_value_set(this.pointer, valueKind, valuePayload1, valuePayload2);
+                    instance.exports.bjs_TestModule_JSValueHolder_value_set(this.pointer, valueKind, valuePayload1, valuePayload2);
                 }
                 get optionalValue() {
-                    instance.exports.bjs_JSValueHolder_optionalValue_get(this.pointer);
+                    instance.exports.bjs_TestModule_JSValueHolder_optionalValue_get(this.pointer);
                     const isSome = i32Stack.pop();
                     let optResult;
                     if (isSome) {
@@ -523,20 +523,20 @@ export async function createInstantiator(options, swift) {
                         result1 = 0;
                         result2 = 0.0;
                     }
-                    instance.exports.bjs_JSValueHolder_optionalValue_set(this.pointer, +isSome, result, result1, result2);
+                    instance.exports.bjs_TestModule_JSValueHolder_optionalValue_set(this.pointer, +isSome, result, result1, result2);
                 }
             }
             const exports = {
-                roundTripJSValue: function bjs_roundTripJSValue(value) {
+                roundTripJSValue: function bjs_TestModule_roundTripJSValue(value) {
                     const [valueKind, valuePayload1, valuePayload2] = __bjs_jsValueLower(value);
-                    instance.exports.bjs_roundTripJSValue(valueKind, valuePayload1, valuePayload2);
+                    instance.exports.bjs_TestModule_roundTripJSValue(valueKind, valuePayload1, valuePayload2);
                     const jsValuePayload2 = f64Stack.pop();
                     const jsValuePayload1 = i32Stack.pop();
                     const jsValueKind = i32Stack.pop();
                     const jsValue = __bjs_jsValueLift(jsValueKind, jsValuePayload1, jsValuePayload2);
                     return jsValue;
                 },
-                roundTripOptionalJSValue: function bjs_roundTripOptionalJSValue(value) {
+                roundTripOptionalJSValue: function bjs_TestModule_roundTripOptionalJSValue(value) {
                     const isSome = value != null;
                     let result, result1, result2;
                     if (isSome) {
@@ -549,7 +549,7 @@ export async function createInstantiator(options, swift) {
                         result1 = 0;
                         result2 = 0.0;
                     }
-                    instance.exports.bjs_roundTripOptionalJSValue(+isSome, result, result1, result2);
+                    instance.exports.bjs_TestModule_roundTripOptionalJSValue(+isSome, result, result1, result2);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -563,7 +563,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 },
-                roundTripJSValueArray: function bjs_roundTripJSValueArray(values) {
+                roundTripJSValueArray: function bjs_TestModule_roundTripJSValueArray(values) {
                     for (const elem of values) {
                         const [elemKind, elemPayload1, elemPayload2] = __bjs_jsValueLower(elem);
                         i32Stack.push(elemKind);
@@ -571,7 +571,7 @@ export async function createInstantiator(options, swift) {
                         f64Stack.push(elemPayload2);
                     }
                     i32Stack.push(values.length);
-                    instance.exports.bjs_roundTripJSValueArray();
+                    instance.exports.bjs_TestModule_roundTripJSValueArray();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -589,7 +589,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                roundTripOptionalJSValueArray: function bjs_roundTripOptionalJSValueArray(values) {
+                roundTripOptionalJSValueArray: function bjs_TestModule_roundTripOptionalJSValueArray(values) {
                     const isSome = values != null;
                     if (isSome) {
                         for (const elem of values) {
@@ -601,7 +601,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(values.length);
                     }
                     i32Stack.push(+isSome);
-                    instance.exports.bjs_roundTripOptionalJSValueArray();
+                    instance.exports.bjs_TestModule_roundTripOptionalJSValueArray();
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedGlobal.js
@@ -207,7 +207,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_GlobalAPI_GlobalClass_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_GlobalClass_wrap"] = function(pointer) {
                 const obj = _exports.GlobalAPI.GlobalClass.__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -279,15 +279,15 @@ export async function createInstantiator(options, swift) {
             }
             class GlobalClass extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_GlobalAPI_GlobalClass_deinit, GlobalClass.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_GlobalClass_deinit, GlobalClass.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_GlobalAPI_GlobalClass_init();
+                    const ret = instance.exports.bjs_TestModule_GlobalClass_init();
                     return GlobalClass.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs_GlobalAPI_GlobalClass_greet(this.pointer);
+                    instance.exports.bjs_TestModule_GlobalClass_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -295,8 +295,8 @@ export async function createInstantiator(options, swift) {
             }
             const exports = {
                 GlobalAPI: {
-                    globalFunction: function bjs_GlobalAPI_globalFunction() {
-                        instance.exports.bjs_GlobalAPI_globalFunction();
+                    globalFunction: function bjs_TestModule_GlobalAPI_globalFunction() {
+                        instance.exports.bjs_TestModule_GlobalAPI_globalFunction();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedModules.js
@@ -207,7 +207,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["GlobalModule"]) {
                 importObject["GlobalModule"] = {};
             }
-            importObject["GlobalModule"]["bjs_GlobalAPI_GlobalClass_wrap"] = function(pointer) {
+            importObject["GlobalModule"]["bjs_GlobalModule_GlobalClass_wrap"] = function(pointer) {
                 const obj = _exports.GlobalAPI.GlobalClass.__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -215,7 +215,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["PrivateModule"]) {
                 importObject["PrivateModule"] = {};
             }
-            importObject["PrivateModule"]["bjs_PrivateAPI_PrivateClass_wrap"] = function(pointer) {
+            importObject["PrivateModule"]["bjs_PrivateModule_PrivateClass_wrap"] = function(pointer) {
                 const obj = _exports.PrivateAPI.PrivateClass.__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -287,15 +287,15 @@ export async function createInstantiator(options, swift) {
             }
             class GlobalClass extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_GlobalAPI_GlobalClass_deinit, GlobalClass.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_GlobalModule_GlobalClass_deinit, GlobalClass.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_GlobalAPI_GlobalClass_init();
+                    const ret = instance.exports.bjs_GlobalModule_GlobalClass_init();
                     return GlobalClass.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs_GlobalAPI_GlobalClass_greet(this.pointer);
+                    instance.exports.bjs_GlobalModule_GlobalClass_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -303,15 +303,15 @@ export async function createInstantiator(options, swift) {
             }
             class PrivateClass extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PrivateAPI_PrivateClass_deinit, PrivateClass.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PrivateModule_PrivateClass_deinit, PrivateClass.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_PrivateAPI_PrivateClass_init();
+                    const ret = instance.exports.bjs_PrivateModule_PrivateClass_init();
                     return PrivateClass.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs_PrivateAPI_PrivateClass_greet(this.pointer);
+                    instance.exports.bjs_PrivateModule_PrivateClass_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -322,8 +322,8 @@ export async function createInstantiator(options, swift) {
             }
             const exports = {
                 GlobalAPI: {
-                    globalFunction: function bjs_GlobalAPI_globalFunction() {
-                        instance.exports.bjs_GlobalAPI_globalFunction();
+                    globalFunction: function bjs_GlobalModule_GlobalAPI_globalFunction() {
+                        instance.exports.bjs_GlobalModule_GlobalAPI_globalFunction();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -331,8 +331,8 @@ export async function createInstantiator(options, swift) {
                     GlobalClass,
                 },
                 PrivateAPI: {
-                    privateFunction: function bjs_PrivateAPI_privateFunction() {
-                        instance.exports.bjs_PrivateAPI_privateFunction();
+                    privateFunction: function bjs_PrivateModule_PrivateAPI_privateFunction() {
+                        instance.exports.bjs_PrivateModule_PrivateAPI_privateFunction();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/MixedPrivate.js
@@ -207,7 +207,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_PrivateAPI_PrivateClass_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_PrivateClass_wrap"] = function(pointer) {
                 const obj = _exports.PrivateAPI.PrivateClass.__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -279,15 +279,15 @@ export async function createInstantiator(options, swift) {
             }
             class PrivateClass extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PrivateAPI_PrivateClass_deinit, PrivateClass.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_PrivateClass_deinit, PrivateClass.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_PrivateAPI_PrivateClass_init();
+                    const ret = instance.exports.bjs_TestModule_PrivateClass_init();
                     return PrivateClass.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs_PrivateAPI_PrivateClass_greet(this.pointer);
+                    instance.exports.bjs_TestModule_PrivateClass_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -295,8 +295,8 @@ export async function createInstantiator(options, swift) {
             }
             const exports = {
                 PrivateAPI: {
-                    privateFunction: function bjs_PrivateAPI_privateFunction() {
-                        instance.exports.bjs_PrivateAPI_privateFunction();
+                    privateFunction: function bjs_TestModule_PrivateAPI_privateFunction() {
+                        instance.exports.bjs_TestModule_PrivateAPI_privateFunction();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.Global.js
@@ -207,19 +207,19 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Collections_Container_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Container_wrap"] = function(pointer) {
                 const obj = _exports.Collections.Container.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_Utils_Converters_Converter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Converter_wrap"] = function(pointer) {
                 const obj = _exports.Utils.Converters.Converter.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs___Swift_Foundation_Greeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Greeter_wrap"] = function(pointer) {
                 const obj = _exports.__Swift.Foundation.Greeter.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs___Swift_Foundation_UUID_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_UUID_wrap"] = function(pointer) {
                 const obj = _exports.__Swift.Foundation.UUID.__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -291,27 +291,27 @@ export async function createInstantiator(options, swift) {
             }
             class Greeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs___Swift_Foundation_Greeter_deinit, Greeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Greeter_deinit, Greeter.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs___Swift_Foundation_Greeter_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_Greeter_init(nameId, nameBytes.length);
                     return Greeter.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs___Swift_Foundation_Greeter_greet(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 static makeDefault() {
-                    const ret = instance.exports.bjs___Swift_Foundation_Greeter_static_makeDefault();
+                    const ret = instance.exports.bjs_TestModule_Greeter_static_makeDefault();
                     return Greeter.__construct(ret);
                 }
                 static get defaultGreeting() {
-                    instance.exports.bjs___Swift_Foundation_Greeter_static_defaultGreeting_get();
+                    instance.exports.bjs_TestModule_Greeter_static_defaultGreeting_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -319,15 +319,15 @@ export async function createInstantiator(options, swift) {
             }
             class Converter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Utils_Converters_Converter_deinit, Converter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Converter_deinit, Converter.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Utils_Converters_Converter_init();
+                    const ret = instance.exports.bjs_TestModule_Converter_init();
                     return Converter.__construct(ret);
                 }
                 toString(value) {
-                    instance.exports.bjs_Utils_Converters_Converter_toString(this.pointer, value);
+                    instance.exports.bjs_TestModule_Converter_toString(this.pointer, value);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -335,11 +335,11 @@ export async function createInstantiator(options, swift) {
             }
             class UUID extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs___Swift_Foundation_UUID_deinit, UUID.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_UUID_deinit, UUID.prototype, null);
                 }
 
                 uuidString() {
-                    instance.exports.bjs___Swift_Foundation_UUID_uuidString(this.pointer);
+                    instance.exports.bjs_TestModule_UUID_uuidString(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -347,15 +347,15 @@ export async function createInstantiator(options, swift) {
             }
             class Container extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Collections_Container_deinit, Container.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Container_deinit, Container.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Collections_Container_init();
+                    const ret = instance.exports.bjs_TestModule_Container_init();
                     return Container.__construct(ret);
                 }
                 getItems() {
-                    instance.exports.bjs_Collections_Container_getItems(this.pointer);
+                    instance.exports.bjs_TestModule_Container_getItems(this.pointer);
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -372,7 +372,7 @@ export async function createInstantiator(options, swift) {
                     return arrayResult;
                 }
                 addItem(item) {
-                    instance.exports.bjs_Collections_Container_addItem(this.pointer, item.pointer);
+                    instance.exports.bjs_TestModule_Container_addItem(this.pointer, item.pointer);
                 }
             }
             if (typeof globalThis.Collections === 'undefined') {
@@ -397,8 +397,8 @@ export async function createInstantiator(options, swift) {
                 globalThis.__Swift.Foundation = {};
             }
             const exports = {
-                plainFunction: function bjs_plainFunction() {
-                    instance.exports.bjs_plainFunction();
+                plainFunction: function bjs_TestModule_plainFunction() {
+                    instance.exports.bjs_TestModule_plainFunction();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -408,8 +408,8 @@ export async function createInstantiator(options, swift) {
                 },
                 MyModule: {
                     Utils: {
-                        namespacedFunction: function bjs_MyModule_Utils_namespacedFunction() {
-                            instance.exports.bjs_MyModule_Utils_namespacedFunction();
+                        namespacedFunction: function bjs_TestModule_MyModule_Utils_namespacedFunction() {
+                            instance.exports.bjs_TestModule_MyModule_Utils_namespacedFunction();
                             const ret = tmpRetString;
                             tmpRetString = undefined;
                             return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Namespaces.js
@@ -207,19 +207,19 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Collections_Container_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Container_wrap"] = function(pointer) {
                 const obj = _exports.Collections.Container.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_Utils_Converters_Converter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Converter_wrap"] = function(pointer) {
                 const obj = _exports.Utils.Converters.Converter.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs___Swift_Foundation_Greeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Greeter_wrap"] = function(pointer) {
                 const obj = _exports.__Swift.Foundation.Greeter.__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs___Swift_Foundation_UUID_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_UUID_wrap"] = function(pointer) {
                 const obj = _exports.__Swift.Foundation.UUID.__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -291,27 +291,27 @@ export async function createInstantiator(options, swift) {
             }
             class Greeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs___Swift_Foundation_Greeter_deinit, Greeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Greeter_deinit, Greeter.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs___Swift_Foundation_Greeter_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_Greeter_init(nameId, nameBytes.length);
                     return Greeter.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs___Swift_Foundation_Greeter_greet(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 static makeDefault() {
-                    const ret = instance.exports.bjs___Swift_Foundation_Greeter_static_makeDefault();
+                    const ret = instance.exports.bjs_TestModule_Greeter_static_makeDefault();
                     return Greeter.__construct(ret);
                 }
                 static get defaultGreeting() {
-                    instance.exports.bjs___Swift_Foundation_Greeter_static_defaultGreeting_get();
+                    instance.exports.bjs_TestModule_Greeter_static_defaultGreeting_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -319,15 +319,15 @@ export async function createInstantiator(options, swift) {
             }
             class Converter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Utils_Converters_Converter_deinit, Converter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Converter_deinit, Converter.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Utils_Converters_Converter_init();
+                    const ret = instance.exports.bjs_TestModule_Converter_init();
                     return Converter.__construct(ret);
                 }
                 toString(value) {
-                    instance.exports.bjs_Utils_Converters_Converter_toString(this.pointer, value);
+                    instance.exports.bjs_TestModule_Converter_toString(this.pointer, value);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -335,11 +335,11 @@ export async function createInstantiator(options, swift) {
             }
             class UUID extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs___Swift_Foundation_UUID_deinit, UUID.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_UUID_deinit, UUID.prototype, null);
                 }
 
                 uuidString() {
-                    instance.exports.bjs___Swift_Foundation_UUID_uuidString(this.pointer);
+                    instance.exports.bjs_TestModule_UUID_uuidString(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -347,15 +347,15 @@ export async function createInstantiator(options, swift) {
             }
             class Container extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Collections_Container_deinit, Container.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Container_deinit, Container.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_Collections_Container_init();
+                    const ret = instance.exports.bjs_TestModule_Container_init();
                     return Container.__construct(ret);
                 }
                 getItems() {
-                    instance.exports.bjs_Collections_Container_getItems(this.pointer);
+                    instance.exports.bjs_TestModule_Container_getItems(this.pointer);
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -372,12 +372,12 @@ export async function createInstantiator(options, swift) {
                     return arrayResult;
                 }
                 addItem(item) {
-                    instance.exports.bjs_Collections_Container_addItem(this.pointer, item.pointer);
+                    instance.exports.bjs_TestModule_Container_addItem(this.pointer, item.pointer);
                 }
             }
             const exports = {
-                plainFunction: function bjs_plainFunction() {
-                    instance.exports.bjs_plainFunction();
+                plainFunction: function bjs_TestModule_plainFunction() {
+                    instance.exports.bjs_TestModule_plainFunction();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -387,8 +387,8 @@ export async function createInstantiator(options, swift) {
                 },
                 MyModule: {
                     Utils: {
-                        namespacedFunction: function bjs_MyModule_Utils_namespacedFunction() {
-                            instance.exports.bjs_MyModule_Utils_namespacedFunction();
+                        namespacedFunction: function bjs_TestModule_MyModule_Utils_namespacedFunction() {
+                            instance.exports.bjs_TestModule_MyModule_Utils_namespacedFunction();
                             const ret = tmpRetString;
                             tmpRetString = undefined;
                             return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/NestedType.js
@@ -31,7 +31,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createUser_StatsHelpers = () => ({
+    const __bjs_createTestModule_User_StatsHelpers = () => ({
         lower: (value) => {
             i32Stack.push((value.health | 0));
             f64Stack.push(value.score);
@@ -42,7 +42,7 @@ export async function createInstantiator(options, swift) {
             return { health: int, score: f64 };
         }
     });
-    const __bjs_createPlayer_StatsHelpers = () => ({
+    const __bjs_createTestModule_Player_StatsHelpers = () => ({
         lower: (value) => {
             i32Stack.push((value.level | 0));
             const bytes = textEncoder.encode(value.rating);
@@ -131,18 +131,18 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_User_Stats"] = function(objectId) {
-                structHelpers.User_Stats.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_User_Stats"] = function(objectId) {
+                structHelpers.TestModule_User_Stats.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_User_Stats"] = function() {
-                const value = structHelpers.User_Stats.lift();
+            bjs["swift_js_struct_lift_TestModule_User_Stats"] = function() {
+                const value = structHelpers.TestModule_User_Stats.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Player_Stats"] = function(objectId) {
-                structHelpers.Player_Stats.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Player_Stats"] = function(objectId) {
+                structHelpers.TestModule_Player_Stats.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Player_Stats"] = function() {
-                const value = structHelpers.Player_Stats.lift();
+            bjs["swift_js_struct_lift_TestModule_Player_Stats"] = function() {
+                const value = structHelpers.TestModule_Player_Stats.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -246,11 +246,11 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Player_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Player_wrap"] = function(pointer) {
                 const obj = _exports['Player'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_User_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_User_wrap"] = function(pointer) {
                 const obj = _exports['User'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -322,11 +322,11 @@ export async function createInstantiator(options, swift) {
             }
             class User extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_User_deinit, User.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_User_deinit, User.prototype, null);
                 }
 
                 getName() {
-                    instance.exports.bjs_User_getName(this.pointer);
+                    instance.exports.bjs_TestModule_User_getName(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -334,21 +334,21 @@ export async function createInstantiator(options, swift) {
             }
             class Player extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Player_deinit, Player.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Player_deinit, Player.prototype, null);
                 }
 
                 getTag() {
-                    instance.exports.bjs_Player_getTag(this.pointer);
+                    instance.exports.bjs_TestModule_Player_getTag(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
             }
-            const User_StatsHelpers = __bjs_createUser_StatsHelpers();
-            structHelpers.User_Stats = User_StatsHelpers;
+            const TestModule_User_StatsHelpers = __bjs_createTestModule_User_StatsHelpers();
+            structHelpers.TestModule_User_Stats = TestModule_User_StatsHelpers;
 
-            const Player_StatsHelpers = __bjs_createPlayer_StatsHelpers();
-            structHelpers.Player_Stats = Player_StatsHelpers;
+            const TestModule_Player_StatsHelpers = __bjs_createTestModule_Player_StatsHelpers();
+            structHelpers.TestModule_Player_Stats = TestModule_Player_StatsHelpers;
 
             const exports = {
                 Player,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Optionals.js
@@ -208,11 +208,11 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Greeter_wrap"] = function(pointer) {
                 const obj = _exports['Greeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_OptionalPropertyHolder_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_OptionalPropertyHolder_wrap"] = function(pointer) {
                 const obj = _exports['OptionalPropertyHolder'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -568,7 +568,7 @@ export async function createInstantiator(options, swift) {
             }
             class Greeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Greeter_deinit, Greeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Greeter_deinit, Greeter.prototype, null);
                 }
 
                 constructor(name) {
@@ -583,11 +583,11 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    const ret = instance.exports.bjs_Greeter_init(+isSome, result, result1);
+                    const ret = instance.exports.bjs_TestModule_Greeter_init(+isSome, result, result1);
                     return Greeter.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs_Greeter_greet(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -604,10 +604,10 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_Greeter_changeName(this.pointer, +isSome, result, result1);
+                    instance.exports.bjs_TestModule_Greeter_changeName(this.pointer, +isSome, result, result1);
                 }
                 get name() {
-                    instance.exports.bjs_Greeter_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_name_get(this.pointer);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -624,20 +624,20 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_Greeter_name_set(this.pointer, +isSome, result, result1);
+                    instance.exports.bjs_TestModule_Greeter_name_set(this.pointer, +isSome, result, result1);
                 }
             }
             class OptionalPropertyHolder extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_OptionalPropertyHolder_deinit, OptionalPropertyHolder.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_OptionalPropertyHolder_deinit, OptionalPropertyHolder.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_OptionalPropertyHolder_init();
+                    const ret = instance.exports.bjs_TestModule_OptionalPropertyHolder_init();
                     return OptionalPropertyHolder.__construct(ret);
                 }
                 get optionalName() {
-                    instance.exports.bjs_OptionalPropertyHolder_optionalName_get(this.pointer);
+                    instance.exports.bjs_TestModule_OptionalPropertyHolder_optionalName_get(this.pointer);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -654,20 +654,20 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_OptionalPropertyHolder_optionalName_set(this.pointer, +isSome, result, result1);
+                    instance.exports.bjs_TestModule_OptionalPropertyHolder_optionalName_set(this.pointer, +isSome, result, result1);
                 }
                 get optionalAge() {
-                    instance.exports.bjs_OptionalPropertyHolder_optionalAge_get(this.pointer);
+                    instance.exports.bjs_TestModule_OptionalPropertyHolder_optionalAge_get(this.pointer);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 }
                 set optionalAge(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_OptionalPropertyHolder_optionalAge_set(this.pointer, +isSome, isSome ? value : 0);
+                    instance.exports.bjs_TestModule_OptionalPropertyHolder_optionalAge_set(this.pointer, +isSome, isSome ? value : 0);
                 }
                 get optionalGreeter() {
-                    instance.exports.bjs_OptionalPropertyHolder_optionalGreeter_get(this.pointer);
+                    instance.exports.bjs_TestModule_OptionalPropertyHolder_optionalGreeter_get(this.pointer);
                     const pointer = tmpRetOptionalHeapObject;
                     tmpRetOptionalHeapObject = undefined;
                     const optResult = pointer === null ? null : Greeter.__construct(pointer);
@@ -681,11 +681,11 @@ export async function createInstantiator(options, swift) {
                     } else {
                         result = 0;
                     }
-                    instance.exports.bjs_OptionalPropertyHolder_optionalGreeter_set(this.pointer, +isSome, result);
+                    instance.exports.bjs_TestModule_OptionalPropertyHolder_optionalGreeter_set(this.pointer, +isSome, result);
                 }
             }
             const exports = {
-                roundTripOptionalClass: function bjs_roundTripOptionalClass(value) {
+                roundTripOptionalClass: function bjs_TestModule_roundTripOptionalClass(value) {
                     const isSome = value != null;
                     let result;
                     if (isSome) {
@@ -693,13 +693,13 @@ export async function createInstantiator(options, swift) {
                     } else {
                         result = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalClass(+isSome, result);
+                    instance.exports.bjs_TestModule_roundTripOptionalClass(+isSome, result);
                     const pointer = tmpRetOptionalHeapObject;
                     tmpRetOptionalHeapObject = undefined;
                     const optResult = pointer === null ? null : Greeter.__construct(pointer);
                     return optResult;
                 },
-                testOptionalPropertyRoundtrip: function bjs_testOptionalPropertyRoundtrip(holder) {
+                testOptionalPropertyRoundtrip: function bjs_TestModule_testOptionalPropertyRoundtrip(holder) {
                     const isSome = holder != null;
                     let result;
                     if (isSome) {
@@ -707,13 +707,13 @@ export async function createInstantiator(options, swift) {
                     } else {
                         result = 0;
                     }
-                    instance.exports.bjs_testOptionalPropertyRoundtrip(+isSome, result);
+                    instance.exports.bjs_TestModule_testOptionalPropertyRoundtrip(+isSome, result);
                     const pointer = tmpRetOptionalHeapObject;
                     tmpRetOptionalHeapObject = undefined;
                     const optResult = pointer === null ? null : OptionalPropertyHolder.__construct(pointer);
                     return optResult;
                 },
-                roundTripExportedOptionalJSObject: function bjs_roundTripExportedOptionalJSObject(value) {
+                roundTripExportedOptionalJSObject: function bjs_TestModule_roundTripExportedOptionalJSObject(value) {
                     const isSome = value != null;
                     let result;
                     if (isSome) {
@@ -721,7 +721,7 @@ export async function createInstantiator(options, swift) {
                     } else {
                         result = 0;
                     }
-                    instance.exports.bjs_roundTripExportedOptionalJSObject(+isSome, result);
+                    instance.exports.bjs_TestModule_roundTripExportedOptionalJSObject(+isSome, result);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -734,7 +734,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 },
-                roundTripExportedOptionalJSClass: function bjs_roundTripExportedOptionalJSClass(value) {
+                roundTripExportedOptionalJSClass: function bjs_TestModule_roundTripExportedOptionalJSClass(value) {
                     const isSome = value != null;
                     let result;
                     if (isSome) {
@@ -742,7 +742,7 @@ export async function createInstantiator(options, swift) {
                     } else {
                         result = 0;
                     }
-                    instance.exports.bjs_roundTripExportedOptionalJSClass(+isSome, result);
+                    instance.exports.bjs_TestModule_roundTripExportedOptionalJSClass(+isSome, result);
                     const isSome1 = i32Stack.pop();
                     let optResult;
                     if (isSome1) {
@@ -755,7 +755,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 },
-                roundTripString: function bjs_roundTripString(name) {
+                roundTripString: function bjs_TestModule_roundTripString(name) {
                     const isSome = name != null;
                     let result, result1;
                     if (isSome) {
@@ -767,82 +767,82 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripString(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_roundTripString(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                roundTripInt: function bjs_roundTripInt(value) {
+                roundTripInt: function bjs_TestModule_roundTripInt(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripInt(+isSome, isSome ? value : 0);
+                    instance.exports.bjs_TestModule_roundTripInt(+isSome, isSome ? value : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                roundTripInt8: function bjs_roundTripInt8(value) {
+                roundTripInt8: function bjs_TestModule_roundTripInt8(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripInt8(+isSome, isSome ? value : 0);
+                    instance.exports.bjs_TestModule_roundTripInt8(+isSome, isSome ? value : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                roundTripUInt8: function bjs_roundTripUInt8(value) {
+                roundTripUInt8: function bjs_TestModule_roundTripUInt8(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripUInt8(+isSome, isSome ? value : 0);
+                    instance.exports.bjs_TestModule_roundTripUInt8(+isSome, isSome ? value : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                roundTripInt16: function bjs_roundTripInt16(value) {
+                roundTripInt16: function bjs_TestModule_roundTripInt16(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripInt16(+isSome, isSome ? value : 0);
+                    instance.exports.bjs_TestModule_roundTripInt16(+isSome, isSome ? value : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                roundTripUInt16: function bjs_roundTripUInt16(value) {
+                roundTripUInt16: function bjs_TestModule_roundTripUInt16(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripUInt16(+isSome, isSome ? value : 0);
+                    instance.exports.bjs_TestModule_roundTripUInt16(+isSome, isSome ? value : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                roundTripInt32: function bjs_roundTripInt32(value) {
+                roundTripInt32: function bjs_TestModule_roundTripInt32(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripInt32(+isSome, isSome ? value : 0);
+                    instance.exports.bjs_TestModule_roundTripInt32(+isSome, isSome ? value : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                roundTripUInt32: function bjs_roundTripUInt32(value) {
+                roundTripUInt32: function bjs_TestModule_roundTripUInt32(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripUInt32(+isSome, isSome ? value : 0);
+                    instance.exports.bjs_TestModule_roundTripUInt32(+isSome, isSome ? value : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                roundTripBool: function bjs_roundTripBool(flag) {
+                roundTripBool: function bjs_TestModule_roundTripBool(flag) {
                     const isSome = flag != null;
-                    instance.exports.bjs_roundTripBool(+isSome, isSome ? flag ? 1 : 0 : 0);
+                    instance.exports.bjs_TestModule_roundTripBool(+isSome, isSome ? flag ? 1 : 0 : 0);
                     const optResult = tmpRetOptionalBool;
                     tmpRetOptionalBool = undefined;
                     return optResult;
                 },
-                roundTripFloat: function bjs_roundTripFloat(number) {
+                roundTripFloat: function bjs_TestModule_roundTripFloat(number) {
                     const isSome = number != null;
-                    instance.exports.bjs_roundTripFloat(+isSome, isSome ? number : 0.0);
+                    instance.exports.bjs_TestModule_roundTripFloat(+isSome, isSome ? number : 0.0);
                     const optResult = tmpRetOptionalFloat;
                     tmpRetOptionalFloat = undefined;
                     return optResult;
                 },
-                roundTripDouble: function bjs_roundTripDouble(precision) {
+                roundTripDouble: function bjs_TestModule_roundTripDouble(precision) {
                     const isSome = precision != null;
-                    instance.exports.bjs_roundTripDouble(+isSome, isSome ? precision : 0.0);
+                    instance.exports.bjs_TestModule_roundTripDouble(+isSome, isSome ? precision : 0.0);
                     const optResult = tmpRetOptionalDouble;
                     tmpRetOptionalDouble = undefined;
                     return optResult;
                 },
-                roundTripSyntax: function bjs_roundTripSyntax(name) {
+                roundTripSyntax: function bjs_TestModule_roundTripSyntax(name) {
                     const isSome = name != null;
                     let result, result1;
                     if (isSome) {
@@ -854,12 +854,12 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripSyntax(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_roundTripSyntax(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                roundTripMixSyntax: function bjs_roundTripMixSyntax(name) {
+                roundTripMixSyntax: function bjs_TestModule_roundTripMixSyntax(name) {
                     const isSome = name != null;
                     let result, result1;
                     if (isSome) {
@@ -871,12 +871,12 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripMixSyntax(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_roundTripMixSyntax(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                roundTripSwiftSyntax: function bjs_roundTripSwiftSyntax(name) {
+                roundTripSwiftSyntax: function bjs_TestModule_roundTripSwiftSyntax(name) {
                     const isSome = name != null;
                     let result, result1;
                     if (isSome) {
@@ -888,12 +888,12 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripSwiftSyntax(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_roundTripSwiftSyntax(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                roundTripMixedSwiftSyntax: function bjs_roundTripMixedSwiftSyntax(name) {
+                roundTripMixedSwiftSyntax: function bjs_TestModule_roundTripMixedSwiftSyntax(name) {
                     const isSome = name != null;
                     let result, result1;
                     if (isSome) {
@@ -905,26 +905,26 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripMixedSwiftSyntax(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_roundTripMixedSwiftSyntax(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                roundTripWithSpaces: function bjs_roundTripWithSpaces(value) {
+                roundTripWithSpaces: function bjs_TestModule_roundTripWithSpaces(value) {
                     const isSome = value != null;
-                    instance.exports.bjs_roundTripWithSpaces(+isSome, isSome ? value : 0.0);
+                    instance.exports.bjs_TestModule_roundTripWithSpaces(+isSome, isSome ? value : 0.0);
                     const optResult = tmpRetOptionalDouble;
                     tmpRetOptionalDouble = undefined;
                     return optResult;
                 },
-                roundTripAlias: function bjs_roundTripAlias(age) {
+                roundTripAlias: function bjs_TestModule_roundTripAlias(age) {
                     const isSome = age != null;
-                    instance.exports.bjs_roundTripAlias(+isSome, isSome ? age : 0);
+                    instance.exports.bjs_TestModule_roundTripAlias(+isSome, isSome ? age : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     return optResult;
                 },
-                roundTripOptionalAlias: function bjs_roundTripOptionalAlias(name) {
+                roundTripOptionalAlias: function bjs_TestModule_roundTripOptionalAlias(name) {
                     const isSome = name != null;
                     let result, result1;
                     if (isSome) {
@@ -936,12 +936,12 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_roundTripOptionalAlias(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_roundTripOptionalAlias(+isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
                 },
-                testMixedOptionals: function bjs_testMixedOptionals(firstName, lastName, age, active) {
+                testMixedOptionals: function bjs_TestModule_testMixedOptionals(firstName, lastName, age, active) {
                     const isSome = firstName != null;
                     let result, result1;
                     if (isSome) {
@@ -965,7 +965,7 @@ export async function createInstantiator(options, swift) {
                         result3 = 0;
                     }
                     const isSome2 = age != null;
-                    instance.exports.bjs_testMixedOptionals(+isSome, result, result1, +isSome1, result2, result3, +isSome2, isSome2 ? age : 0, active);
+                    instance.exports.bjs_TestModule_testMixedOptionals(+isSome, result, result1, +isSome1, result2, result3, +isSome2, isSome2 ? age : 0, active);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveParameters.js
@@ -227,8 +227,8 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                check: function bjs_check(a, b, c, d, e) {
-                    instance.exports.bjs_check(a, b, c, d, e);
+                check: function bjs_TestModule_check(a, b, c, d, e) {
+                    instance.exports.bjs_TestModule_check(a, b, c, d, e);
                 },
             };
             _exports = exports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PrimitiveReturn.js
@@ -238,24 +238,24 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                checkInt: function bjs_checkInt() {
-                    const ret = instance.exports.bjs_checkInt();
+                checkInt: function bjs_TestModule_checkInt() {
+                    const ret = instance.exports.bjs_TestModule_checkInt();
                     return ret;
                 },
-                checkUInt: function bjs_checkUInt() {
-                    const ret = instance.exports.bjs_checkUInt();
+                checkUInt: function bjs_TestModule_checkUInt() {
+                    const ret = instance.exports.bjs_TestModule_checkUInt();
                     return ret >>> 0;
                 },
-                checkFloat: function bjs_checkFloat() {
-                    const ret = instance.exports.bjs_checkFloat();
+                checkFloat: function bjs_TestModule_checkFloat() {
+                    const ret = instance.exports.bjs_TestModule_checkFloat();
                     return ret;
                 },
-                checkDouble: function bjs_checkDouble() {
-                    const ret = instance.exports.bjs_checkDouble();
+                checkDouble: function bjs_TestModule_checkDouble() {
+                    const ret = instance.exports.bjs_TestModule_checkDouble();
                     return ret;
                 },
-                checkBool: function bjs_checkBool() {
-                    const ret = instance.exports.bjs_checkBool();
+                checkBool: function bjs_TestModule_checkBool() {
+                    const ret = instance.exports.bjs_TestModule_checkBool();
                     return ret !== 0;
                 },
             };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/PropertyTypes.js
@@ -207,7 +207,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_PropertyHolder_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_PropertyHolder_wrap"] = function(pointer) {
                 const obj = _exports['PropertyHolder'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -279,51 +279,51 @@ export async function createInstantiator(options, swift) {
             }
             class PropertyHolder extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PropertyHolder_deinit, PropertyHolder.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_PropertyHolder_deinit, PropertyHolder.prototype, null);
                 }
 
                 constructor(intValue, floatValue, doubleValue, boolValue, stringValue, jsObject) {
                     const stringValueBytes = textEncoder.encode(stringValue);
                     const stringValueId = swift.memory.retain(stringValueBytes);
-                    const ret = instance.exports.bjs_PropertyHolder_init(intValue, floatValue, doubleValue, boolValue, stringValueId, stringValueBytes.length, swift.memory.retain(jsObject));
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_init(intValue, floatValue, doubleValue, boolValue, stringValueId, stringValueBytes.length, swift.memory.retain(jsObject));
                     return PropertyHolder.__construct(ret);
                 }
                 getAllValues() {
-                    instance.exports.bjs_PropertyHolder_getAllValues(this.pointer);
+                    instance.exports.bjs_TestModule_PropertyHolder_getAllValues(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 get intValue() {
-                    const ret = instance.exports.bjs_PropertyHolder_intValue_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_intValue_get(this.pointer);
                     return ret;
                 }
                 set intValue(value) {
-                    instance.exports.bjs_PropertyHolder_intValue_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_PropertyHolder_intValue_set(this.pointer, value);
                 }
                 get floatValue() {
-                    const ret = instance.exports.bjs_PropertyHolder_floatValue_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_floatValue_get(this.pointer);
                     return ret;
                 }
                 set floatValue(value) {
-                    instance.exports.bjs_PropertyHolder_floatValue_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_PropertyHolder_floatValue_set(this.pointer, value);
                 }
                 get doubleValue() {
-                    const ret = instance.exports.bjs_PropertyHolder_doubleValue_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_doubleValue_get(this.pointer);
                     return ret;
                 }
                 set doubleValue(value) {
-                    instance.exports.bjs_PropertyHolder_doubleValue_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_PropertyHolder_doubleValue_set(this.pointer, value);
                 }
                 get boolValue() {
-                    const ret = instance.exports.bjs_PropertyHolder_boolValue_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_boolValue_get(this.pointer);
                     return ret !== 0;
                 }
                 set boolValue(value) {
-                    instance.exports.bjs_PropertyHolder_boolValue_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_PropertyHolder_boolValue_set(this.pointer, value);
                 }
                 get stringValue() {
-                    instance.exports.bjs_PropertyHolder_stringValue_get(this.pointer);
+                    instance.exports.bjs_TestModule_PropertyHolder_stringValue_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -331,48 +331,48 @@ export async function createInstantiator(options, swift) {
                 set stringValue(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_PropertyHolder_stringValue_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_PropertyHolder_stringValue_set(this.pointer, valueId, valueBytes.length);
                 }
                 get readonlyInt() {
-                    const ret = instance.exports.bjs_PropertyHolder_readonlyInt_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_readonlyInt_get(this.pointer);
                     return ret;
                 }
                 get readonlyFloat() {
-                    const ret = instance.exports.bjs_PropertyHolder_readonlyFloat_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_readonlyFloat_get(this.pointer);
                     return ret;
                 }
                 get readonlyDouble() {
-                    const ret = instance.exports.bjs_PropertyHolder_readonlyDouble_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_readonlyDouble_get(this.pointer);
                     return ret;
                 }
                 get readonlyBool() {
-                    const ret = instance.exports.bjs_PropertyHolder_readonlyBool_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_readonlyBool_get(this.pointer);
                     return ret !== 0;
                 }
                 get readonlyString() {
-                    instance.exports.bjs_PropertyHolder_readonlyString_get(this.pointer);
+                    instance.exports.bjs_TestModule_PropertyHolder_readonlyString_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 get jsObject() {
-                    const ret = instance.exports.bjs_PropertyHolder_jsObject_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_jsObject_get(this.pointer);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 }
                 set jsObject(value) {
-                    instance.exports.bjs_PropertyHolder_jsObject_set(this.pointer, swift.memory.retain(value));
+                    instance.exports.bjs_TestModule_PropertyHolder_jsObject_set(this.pointer, swift.memory.retain(value));
                 }
                 get sibling() {
-                    const ret = instance.exports.bjs_PropertyHolder_sibling_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_sibling_get(this.pointer);
                     return PropertyHolder.__construct(ret);
                 }
                 set sibling(value) {
-                    instance.exports.bjs_PropertyHolder_sibling_set(this.pointer, value.pointer);
+                    instance.exports.bjs_TestModule_PropertyHolder_sibling_set(this.pointer, value.pointer);
                 }
                 get lazyValue() {
-                    instance.exports.bjs_PropertyHolder_lazyValue_get(this.pointer);
+                    instance.exports.bjs_TestModule_PropertyHolder_lazyValue_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -380,14 +380,14 @@ export async function createInstantiator(options, swift) {
                 set lazyValue(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_PropertyHolder_lazyValue_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_PropertyHolder_lazyValue_set(this.pointer, valueId, valueBytes.length);
                 }
                 get computedReadonly() {
-                    const ret = instance.exports.bjs_PropertyHolder_computedReadonly_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_computedReadonly_get(this.pointer);
                     return ret;
                 }
                 get computedReadWrite() {
-                    instance.exports.bjs_PropertyHolder_computedReadWrite_get(this.pointer);
+                    instance.exports.bjs_TestModule_PropertyHolder_computedReadWrite_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -395,25 +395,25 @@ export async function createInstantiator(options, swift) {
                 set computedReadWrite(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_PropertyHolder_computedReadWrite_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_PropertyHolder_computedReadWrite_set(this.pointer, valueId, valueBytes.length);
                 }
                 get observedProperty() {
-                    const ret = instance.exports.bjs_PropertyHolder_observedProperty_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_PropertyHolder_observedProperty_get(this.pointer);
                     return ret;
                 }
                 set observedProperty(value) {
-                    instance.exports.bjs_PropertyHolder_observedProperty_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_PropertyHolder_observedProperty_set(this.pointer, value);
                 }
             }
             const exports = {
-                createPropertyHolder: function bjs_createPropertyHolder(intValue, floatValue, doubleValue, boolValue, stringValue, jsObject) {
+                createPropertyHolder: function bjs_TestModule_createPropertyHolder(intValue, floatValue, doubleValue, boolValue, stringValue, jsObject) {
                     const stringValueBytes = textEncoder.encode(stringValue);
                     const stringValueId = swift.memory.retain(stringValueBytes);
-                    const ret = instance.exports.bjs_createPropertyHolder(intValue, floatValue, doubleValue, boolValue, stringValueId, stringValueBytes.length, swift.memory.retain(jsObject));
+                    const ret = instance.exports.bjs_TestModule_createPropertyHolder(intValue, floatValue, doubleValue, boolValue, stringValueId, stringValueBytes.length, swift.memory.retain(jsObject));
                     return PropertyHolder.__construct(ret);
                 },
-                testPropertyHolder: function bjs_testPropertyHolder(holder) {
-                    instance.exports.bjs_testPropertyHolder(holder.pointer);
+                testPropertyHolder: function bjs_TestModule_testPropertyHolder(holder) {
+                    instance.exports.bjs_TestModule_testPropertyHolder(holder.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Protocol.js
@@ -55,7 +55,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createResultValuesHelpers = () => ({
+    const __bjs_createTestModule_ResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -264,15 +264,15 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_DelegateManager_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_DelegateManager_wrap"] = function(pointer) {
                 const obj = _exports['DelegateManager'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_Helper_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Helper_wrap"] = function(pointer) {
                 const obj = _exports['Helper'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_MyViewController_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_MyViewController_wrap"] = function(pointer) {
                 const obj = _exports['MyViewController'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -366,7 +366,7 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_MyViewControllerDelegate_result_get"] = function bjs_MyViewControllerDelegate_result_get(self) {
                 try {
                     let ret = swift.memory.getObject(self).result;
-                    const caseId = enumHelpers.Result.lower(ret);
+                    const caseId = enumHelpers.TestModule_Result.lower(ret);
                     return caseId;
                 } catch (error) {
                     setException(error);
@@ -374,7 +374,7 @@ export async function createInstantiator(options, swift) {
             }
             TestModule["bjs_MyViewControllerDelegate_result_set"] = function bjs_MyViewControllerDelegate_result_set(self, value) {
                 try {
-                    const enumValue = enumHelpers.Result.lift(value);
+                    const enumValue = enumHelpers.TestModule_Result.lift(value);
                     swift.memory.getObject(self).result = enumValue;
                 } catch (error) {
                     setException(error);
@@ -385,7 +385,7 @@ export async function createInstantiator(options, swift) {
                     let ret = swift.memory.getObject(self).optionalResult;
                     const isSome = ret != null;
                     if (isSome) {
-                        const caseId = enumHelpers.Result.lower(ret);
+                        const caseId = enumHelpers.TestModule_Result.lower(ret);
                         return caseId;
                     } else {
                         return -1;
@@ -398,7 +398,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     let optResult;
                     if (valueIsSome) {
-                        const enumValue = enumHelpers.Result.lift(valueCaseId);
+                        const enumValue = enumHelpers.TestModule_Result.lift(valueCaseId);
                         optResult = enumValue;
                     } else {
                         optResult = null;
@@ -556,7 +556,7 @@ export async function createInstantiator(options, swift) {
             }
             TestModule["bjs_MyViewControllerDelegate_handleResult"] = function bjs_MyViewControllerDelegate_handleResult(self, result) {
                 try {
-                    const enumValue = enumHelpers.Result.lift(result);
+                    const enumValue = enumHelpers.TestModule_Result.lift(result);
                     swift.memory.getObject(self).handleResult(enumValue);
                 } catch (error) {
                     setException(error);
@@ -565,7 +565,7 @@ export async function createInstantiator(options, swift) {
             TestModule["bjs_MyViewControllerDelegate_getResult"] = function bjs_MyViewControllerDelegate_getResult(self) {
                 try {
                     let ret = swift.memory.getObject(self).getResult();
-                    const caseId = enumHelpers.Result.lower(ret);
+                    const caseId = enumHelpers.TestModule_Result.lower(ret);
                     return caseId;
                 } catch (error) {
                     setException(error);
@@ -639,43 +639,43 @@ export async function createInstantiator(options, swift) {
             }
             class Helper extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Helper_deinit, Helper.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Helper_deinit, Helper.prototype, null);
                 }
 
                 constructor(value) {
-                    const ret = instance.exports.bjs_Helper_init(value);
+                    const ret = instance.exports.bjs_TestModule_Helper_init(value);
                     return Helper.__construct(ret);
                 }
                 increment() {
-                    instance.exports.bjs_Helper_increment(this.pointer);
+                    instance.exports.bjs_TestModule_Helper_increment(this.pointer);
                 }
                 get value() {
-                    const ret = instance.exports.bjs_Helper_value_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_Helper_value_get(this.pointer);
                     return ret;
                 }
                 set value(value) {
-                    instance.exports.bjs_Helper_value_set(this.pointer, value);
+                    instance.exports.bjs_TestModule_Helper_value_set(this.pointer, value);
                 }
             }
             class MyViewController extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_MyViewController_deinit, MyViewController.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_MyViewController_deinit, MyViewController.prototype, null);
                 }
 
                 constructor(delegate) {
-                    const ret = instance.exports.bjs_MyViewController_init(swift.memory.retain(delegate));
+                    const ret = instance.exports.bjs_TestModule_MyViewController_init(swift.memory.retain(delegate));
                     return MyViewController.__construct(ret);
                 }
                 triggerEvent() {
-                    instance.exports.bjs_MyViewController_triggerEvent(this.pointer);
+                    instance.exports.bjs_TestModule_MyViewController_triggerEvent(this.pointer);
                 }
                 updateValue(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_MyViewController_updateValue(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_MyViewController_updateValue(this.pointer, valueId, valueBytes.length);
                 }
                 updateCount(count) {
-                    const ret = instance.exports.bjs_MyViewController_updateCount(this.pointer, count);
+                    const ret = instance.exports.bjs_TestModule_MyViewController_updateCount(this.pointer, count);
                     return ret !== 0;
                 }
                 updateLabel(prefix, suffix) {
@@ -683,26 +683,26 @@ export async function createInstantiator(options, swift) {
                     const prefixId = swift.memory.retain(prefixBytes);
                     const suffixBytes = textEncoder.encode(suffix);
                     const suffixId = swift.memory.retain(suffixBytes);
-                    instance.exports.bjs_MyViewController_updateLabel(this.pointer, prefixId, prefixBytes.length, suffixId, suffixBytes.length);
+                    instance.exports.bjs_TestModule_MyViewController_updateLabel(this.pointer, prefixId, prefixBytes.length, suffixId, suffixBytes.length);
                 }
                 checkEvenCount() {
-                    const ret = instance.exports.bjs_MyViewController_checkEvenCount(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_MyViewController_checkEvenCount(this.pointer);
                     return ret !== 0;
                 }
                 sendHelper(helper) {
-                    instance.exports.bjs_MyViewController_sendHelper(this.pointer, helper.pointer);
+                    instance.exports.bjs_TestModule_MyViewController_sendHelper(this.pointer, helper.pointer);
                 }
                 get delegate() {
-                    const ret = instance.exports.bjs_MyViewController_delegate_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_MyViewController_delegate_get(this.pointer);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 }
                 set delegate(value) {
-                    instance.exports.bjs_MyViewController_delegate_set(this.pointer, swift.memory.retain(value));
+                    instance.exports.bjs_TestModule_MyViewController_delegate_set(this.pointer, swift.memory.retain(value));
                 }
                 get secondDelegate() {
-                    instance.exports.bjs_MyViewController_secondDelegate_get(this.pointer);
+                    instance.exports.bjs_TestModule_MyViewController_secondDelegate_get(this.pointer);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -715,12 +715,12 @@ export async function createInstantiator(options, swift) {
                     } else {
                         result = 0;
                     }
-                    instance.exports.bjs_MyViewController_secondDelegate_set(this.pointer, +isSome, result);
+                    instance.exports.bjs_TestModule_MyViewController_secondDelegate_set(this.pointer, +isSome, result);
                 }
             }
             class DelegateManager extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_DelegateManager_deinit, DelegateManager.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_DelegateManager_deinit, DelegateManager.prototype, null);
                 }
 
                 constructor(delegates) {
@@ -729,14 +729,14 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(objId);
                     }
                     i32Stack.push(delegates.length);
-                    const ret = instance.exports.bjs_DelegateManager_init();
+                    const ret = instance.exports.bjs_TestModule_DelegateManager_init();
                     return DelegateManager.__construct(ret);
                 }
                 notifyAll() {
-                    instance.exports.bjs_DelegateManager_notifyAll(this.pointer);
+                    instance.exports.bjs_TestModule_DelegateManager_notifyAll(this.pointer);
                 }
                 get delegates() {
-                    instance.exports.bjs_DelegateManager_delegates_get(this.pointer);
+                    instance.exports.bjs_TestModule_DelegateManager_delegates_get(this.pointer);
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -759,10 +759,10 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(objId);
                     }
                     i32Stack.push(value.length);
-                    instance.exports.bjs_DelegateManager_delegates_set(this.pointer);
+                    instance.exports.bjs_TestModule_DelegateManager_delegates_set(this.pointer);
                 }
                 get delegatesByName() {
-                    instance.exports.bjs_DelegateManager_delegatesByName_get(this.pointer);
+                    instance.exports.bjs_TestModule_DelegateManager_delegatesByName_get(this.pointer);
                     const dictLen = i32Stack.pop();
                     const dictResult = {};
                     for (let i = 0; i < dictLen; i++) {
@@ -786,20 +786,20 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(objId);
                     }
                     i32Stack.push(entries.length);
-                    instance.exports.bjs_DelegateManager_delegatesByName_set(this.pointer);
+                    instance.exports.bjs_TestModule_DelegateManager_delegatesByName_set(this.pointer);
                 }
             }
-            const ResultHelpers = __bjs_createResultValuesHelpers();
-            enumHelpers.Result = ResultHelpers;
+            const TestModule_ResultHelpers = __bjs_createTestModule_ResultHelpers();
+            enumHelpers.TestModule_Result = TestModule_ResultHelpers;
 
             const exports = {
-                processDelegates: function bjs_processDelegates(delegates) {
+                processDelegates: function bjs_TestModule_processDelegates(delegates) {
                     for (const elem of delegates) {
                         const objId = swift.memory.retain(elem);
                         i32Stack.push(objId);
                     }
                     i32Stack.push(delegates.length);
-                    instance.exports.bjs_processDelegates();
+                    instance.exports.bjs_TestModule_processDelegates();
                     const arrayLen = i32Stack.pop();
                     let arrayResult;
                     if (arrayLen === -1) {
@@ -816,7 +816,7 @@ export async function createInstantiator(options, swift) {
                     }
                     return arrayResult;
                 },
-                processDelegatesByName: function bjs_processDelegatesByName(delegates) {
+                processDelegatesByName: function bjs_TestModule_processDelegatesByName(delegates) {
                     const entries = Object.entries(delegates);
                     for (const entry of entries) {
                         const [key, value] = entry;
@@ -828,7 +828,7 @@ export async function createInstantiator(options, swift) {
                         i32Stack.push(objId);
                     }
                     i32Stack.push(entries.length);
-                    instance.exports.bjs_processDelegatesByName();
+                    instance.exports.bjs_TestModule_processDelegatesByName();
                     const dictLen = i32Stack.pop();
                     const dictResult = {};
                     for (let i = 0; i < dictLen; i++) {

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ProtocolInClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/ProtocolInClosure.js
@@ -232,7 +232,7 @@ export async function createInstantiator(options, swift) {
                 const func = swift.memory.getObject(funcRef);
                 func.__unregister();
             }
-            bjs["invoke_js_callback_TestModule_10TestModule10RenderableP_10RenderableP"] = function(callbackId, param0) {
+            bjs["invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP"] = function(callbackId, param0) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback(swift.memory.getObject(param0));
@@ -242,9 +242,9 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModule10RenderableP_10RenderableP = function(param0) {
-                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModule10RenderableP_10RenderableP(boxPtr, swift.memory.retain(param0));
+            bjs["make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP = function(param0) {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP(boxPtr, swift.memory.retain(param0));
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     if (tmpRetException) {
@@ -255,9 +255,9 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret1;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule10RenderableP_10RenderableP);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule21TestModule_RenderableP_21TestModule_RenderableP);
             }
-            bjs["invoke_js_callback_TestModule_10TestModule10RenderableP_SS"] = function(callbackId, param0) {
+            bjs["invoke_js_callback_TestModule_10TestModule21TestModule_RenderableP_SS"] = function(callbackId, param0) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback(swift.memory.getObject(param0));
@@ -267,9 +267,9 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModule10RenderableP_SS"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModule10RenderableP_SS = function(param0) {
-                    instance.exports.invoke_swift_closure_TestModule_10TestModule10RenderableP_SS(boxPtr, swift.memory.retain(param0));
+            bjs["make_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModule21TestModule_RenderableP_SS = function(param0) {
+                    instance.exports.invoke_swift_closure_TestModule_10TestModule21TestModule_RenderableP_SS(boxPtr, swift.memory.retain(param0));
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     if (tmpRetException) {
@@ -280,9 +280,9 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule10RenderableP_SS);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule21TestModule_RenderableP_SS);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq10RenderableP_SS"] = function(callbackId, param0IsSome, param0ObjectId) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq21TestModule_RenderableP_SS"] = function(callbackId, param0IsSome, param0ObjectId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback(param0IsSome ? swift.memory.getObject(param0ObjectId) : null);
@@ -292,8 +292,8 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModuleSq10RenderableP_SS"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleSq10RenderableP_SS = function(param0) {
+            bjs["make_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS = function(param0) {
                     const isSome = param0 != null;
                     let result;
                     if (isSome) {
@@ -301,7 +301,7 @@ export async function createInstantiator(options, swift) {
                     } else {
                         result = 0;
                     }
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq10RenderableP_SS(boxPtr, +isSome, result);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS(boxPtr, +isSome, result);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     if (tmpRetException) {
@@ -312,9 +312,9 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq10RenderableP_SS);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq21TestModule_RenderableP_SS);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuley_10RenderableP"] = function(callbackId) {
+            bjs["invoke_js_callback_TestModule_10TestModuley_21TestModule_RenderableP"] = function(callbackId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback();
@@ -324,9 +324,9 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModuley_10RenderableP"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuley_10RenderableP = function() {
-                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuley_10RenderableP(boxPtr);
+            bjs["make_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuley_21TestModule_RenderableP = function() {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuley_21TestModule_RenderableP(boxPtr);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     if (tmpRetException) {
@@ -337,13 +337,13 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret1;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuley_10RenderableP);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuley_21TestModule_RenderableP);
             }
             // Wrapper functions for module: TestModule
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Widget_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Widget_wrap"] = function(pointer) {
                 const obj = _exports['Widget'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -425,17 +425,17 @@ export async function createInstantiator(options, swift) {
             }
             class Widget extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Widget_deinit, Widget.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Widget_deinit, Widget.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_Widget_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_Widget_init(nameId, nameBytes.length);
                     return Widget.__construct(ret);
                 }
                 get name() {
-                    instance.exports.bjs_Widget_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_Widget_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -443,31 +443,31 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_Widget_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_Widget_name_set(this.pointer, valueId, valueBytes.length);
                 }
             }
             const exports = {
-                processRenderable: function bjs_processRenderable(item, transform) {
+                processRenderable: function bjs_TestModule_processRenderable(item, transform) {
                     const callbackId = swift.memory.retain(transform);
-                    instance.exports.bjs_processRenderable(swift.memory.retain(item), callbackId);
+                    instance.exports.bjs_TestModule_processRenderable(swift.memory.retain(item), callbackId);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 },
-                makeRenderableFactory: function bjs_makeRenderableFactory(defaultName) {
+                makeRenderableFactory: function bjs_TestModule_makeRenderableFactory(defaultName) {
                     const defaultNameBytes = textEncoder.encode(defaultName);
                     const defaultNameId = swift.memory.retain(defaultNameBytes);
-                    const ret = instance.exports.bjs_makeRenderableFactory(defaultNameId, defaultNameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_makeRenderableFactory(defaultNameId, defaultNameBytes.length);
                     return swift.memory.getObject(ret);
                 },
-                roundtripRenderable: function bjs_roundtripRenderable(callback) {
+                roundtripRenderable: function bjs_TestModule_roundtripRenderable(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripRenderable(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripRenderable(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                processOptionalRenderable: function bjs_processOptionalRenderable(callback) {
+                processOptionalRenderable: function bjs_TestModule_processOptionalRenderable(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    instance.exports.bjs_processOptionalRenderable(callbackId);
+                    instance.exports.bjs_TestModule_processOptionalRenderable(callbackId);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SameNamedTypesAcrossModules.d.ts
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SameNamedTypesAcrossModules.d.ts
@@ -1,0 +1,50 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const ValidationValues: {
+    readonly Tag: {
+        readonly Valid: 0;
+        readonly Invalid: 1;
+    };
+};
+
+export type ValidationTag =
+  { tag: typeof ValidationValues.Tag.Valid } | { tag: typeof ValidationValues.Tag.Invalid; reason: string }
+
+export interface Point {
+    x: number;
+    y: number;
+}
+export type ValidationObject = typeof ValidationValues;
+
+export namespace Inner {
+    export interface Point {
+        x: number;
+        y: number;
+    }
+}
+export type Exports = {
+    run(point: Point, validation: ValidationTag): Point;
+    Validation: ValidationObject
+    Inner: {
+        run(): void;
+        Point: {
+            init(x: number, y: number): Point;
+        },
+    },
+    Point: {
+        init(x: number, y: number): Point;
+    },
+}
+export type Imports = {
+}
+export function createInstantiator(options: {
+    imports: Imports;
+}, swift: any): Promise<{
+    addImports: (importObject: WebAssembly.Imports) => void;
+    setInstance: (instance: WebAssembly.Instance) => void;
+    createExports: (instance: WebAssembly.Instance) => Exports;
+}>;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SameNamedTypesAcrossModules.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SameNamedTypesAcrossModules.js
@@ -1,0 +1,333 @@
+// NOTICE: This is auto-generated code by BridgeJS from JavaScriptKit,
+// DO NOT EDIT.
+//
+// To update this file, just rebuild your project or run
+// `swift package bridge-js`.
+
+export const ValidationValues = {
+    Tag: {
+        Valid: 0,
+        Invalid: 1,
+    },
+};
+export async function createInstantiator(options, swift) {
+    let instance;
+    let memory;
+    let setException;
+    let decodeString;
+    const textDecoder = new TextDecoder("utf-8");
+    const textEncoder = new TextEncoder("utf-8");
+    let tmpRetString;
+    let tmpRetBytes;
+    let tmpRetException;
+    let tmpRetOptionalBool;
+    let tmpRetOptionalInt;
+    let tmpRetOptionalFloat;
+    let tmpRetOptionalDouble;
+    let tmpRetOptionalHeapObject;
+    let strStack = [];
+    let i32Stack = [];
+    let i64Stack = [];
+    let f32Stack = [];
+    let f64Stack = [];
+    let ptrStack = [];
+    let taStack = [];
+    const enumHelpers = {};
+    const structHelpers = {};
+
+    let _exports = null;
+    let bjs = null;
+    const __bjs_createModuleA_PointHelpers = () => ({
+        lower: (value) => {
+            f64Stack.push(value.x);
+            f64Stack.push(value.y);
+        },
+        lift: () => {
+            const f64 = f64Stack.pop();
+            const f641 = f64Stack.pop();
+            return { x: f641, y: f64 };
+        }
+    });
+    const __bjs_createModuleB_PointHelpers = () => ({
+        lower: (value) => {
+            f64Stack.push(value.x);
+            f64Stack.push(value.y);
+        },
+        lift: () => {
+            const f64 = f64Stack.pop();
+            const f641 = f64Stack.pop();
+            return { x: f641, y: f64 };
+        }
+    });
+    const __bjs_createModuleA_ValidationHelpers = () => ({
+        lower: (value) => {
+            const enumTag = value.tag;
+            switch (enumTag) {
+                case ValidationValues.Tag.Valid: {
+                    return ValidationValues.Tag.Valid;
+                }
+                case ValidationValues.Tag.Invalid: {
+                    const bytes = textEncoder.encode(value.reason);
+                    const id = swift.memory.retain(bytes);
+                    i32Stack.push(bytes.length);
+                    i32Stack.push(id);
+                    return ValidationValues.Tag.Invalid;
+                }
+                default: throw new Error("Unknown ValidationValues tag: " + String(enumTag));
+            }
+        },
+        lift: (tag) => {
+            tag = tag | 0;
+            switch (tag) {
+                case ValidationValues.Tag.Valid: return { tag: ValidationValues.Tag.Valid };
+                case ValidationValues.Tag.Invalid: {
+                    const string = strStack.pop();
+                    return { tag: ValidationValues.Tag.Invalid, reason: string };
+                }
+                default: throw new Error("Unknown ValidationValues tag returned from Swift: " + String(tag));
+            }
+        }
+    });
+
+    return {
+        /**
+         * @param {WebAssembly.Imports} importObject
+         */
+        addImports: (importObject, importsContext) => {
+            bjs = {};
+            importObject["bjs"] = bjs;
+            bjs["swift_js_return_string"] = function(ptr, len) {
+                tmpRetString = decodeString(ptr, len);
+            }
+            bjs["swift_js_init_memory"] = function(sourceId, bytesPtr) {
+                const source = swift.memory.getObject(sourceId);
+                swift.memory.release(sourceId);
+                const bytes = new Uint8Array(memory.buffer, bytesPtr >>> 0);
+                bytes.set(source);
+            }
+            bjs["swift_js_make_js_string"] = function(ptr, len) {
+                return swift.memory.retain(decodeString(ptr, len));
+            }
+            bjs["swift_js_init_memory_with_result"] = function(ptr, len) {
+                const target = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0);
+                target.set(tmpRetBytes);
+                tmpRetBytes = undefined;
+            }
+            bjs["swift_js_throw"] = function(id) {
+                tmpRetException = swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_retain"] = function(id) {
+                return swift.memory.retainByRef(id);
+            }
+            bjs["swift_js_release"] = function(id) {
+                swift.memory.release(id);
+            }
+            bjs["swift_js_push_i32"] = function(v) {
+                i32Stack.push(v | 0);
+            }
+            bjs["swift_js_push_f32"] = function(v) {
+                f32Stack.push(Math.fround(v));
+            }
+            bjs["swift_js_push_f64"] = function(v) {
+                f64Stack.push(v);
+            }
+            bjs["swift_js_push_string"] = function(ptr, len) {
+                const value = decodeString(ptr, len);
+                strStack.push(value);
+            }
+            bjs["swift_js_pop_i32"] = function() {
+                return i32Stack.pop();
+            }
+            bjs["swift_js_pop_f32"] = function() {
+                return f32Stack.pop();
+            }
+            bjs["swift_js_pop_f64"] = function() {
+                return f64Stack.pop();
+            }
+            bjs["swift_js_push_pointer"] = function(pointer) {
+                ptrStack.push(pointer);
+            }
+            bjs["swift_js_pop_pointer"] = function() {
+                return ptrStack.pop();
+            }
+            bjs["swift_js_push_i64"] = function(v) {
+                i64Stack.push(v);
+            }
+            bjs["swift_js_pop_i64"] = function() {
+                return i64Stack.pop();
+            }
+            const taCtors = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array];
+            bjs["swift_js_push_typed_array"] = function(kind, ptr, count) {
+                const Ctor = taCtors[kind];
+                const byteLen = count * Ctor.BYTES_PER_ELEMENT;
+                const copy = memory.buffer.slice(ptr, ptr + byteLen);
+                taStack.push(Array.from(new Ctor(copy)));
+            }
+            bjs["swift_js_struct_lower_ModuleA_Point"] = function(objectId) {
+                structHelpers.ModuleA_Point.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_ModuleA_Point"] = function() {
+                const value = structHelpers.ModuleA_Point.lift();
+                return swift.memory.retain(value);
+            }
+            bjs["swift_js_struct_lower_ModuleB_Point"] = function(objectId) {
+                structHelpers.ModuleB_Point.lower(swift.memory.getObject(objectId));
+            }
+            bjs["swift_js_struct_lift_ModuleB_Point"] = function() {
+                const value = structHelpers.ModuleB_Point.lift();
+                return swift.memory.retain(value);
+            }
+            const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
+            bjs["swift_js_make_promise"] = function() {
+                let resolve, reject;
+                const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+                promise[__bjs_promiseSettlers] = { resolve, reject };
+                return swift.memory.retain(promise);
+            }
+            bjs["swift_js_return_optional_bool"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalBool = null;
+                } else {
+                    tmpRetOptionalBool = value !== 0;
+                }
+            }
+            bjs["swift_js_return_optional_int"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalInt = null;
+                } else {
+                    tmpRetOptionalInt = value | 0;
+                }
+            }
+            bjs["swift_js_return_optional_float"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalFloat = null;
+                } else {
+                    tmpRetOptionalFloat = Math.fround(value);
+                }
+            }
+            bjs["swift_js_return_optional_double"] = function(isSome, value) {
+                if (isSome === 0) {
+                    tmpRetOptionalDouble = null;
+                } else {
+                    tmpRetOptionalDouble = value;
+                }
+            }
+            bjs["swift_js_return_optional_string"] = function(isSome, ptr, len) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = decodeString(ptr, len);
+                }
+            }
+            bjs["swift_js_return_optional_object"] = function(isSome, objectId) {
+                if (isSome === 0) {
+                    tmpRetString = null;
+                } else {
+                    tmpRetString = swift.memory.getObject(objectId);
+                }
+            }
+            bjs["swift_js_return_optional_heap_object"] = function(isSome, pointer) {
+                if (isSome === 0) {
+                    tmpRetOptionalHeapObject = null;
+                } else {
+                    tmpRetOptionalHeapObject = pointer;
+                }
+            }
+            bjs["swift_js_get_optional_int_presence"] = function() {
+                return tmpRetOptionalInt != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_int_value"] = function() {
+                const value = tmpRetOptionalInt;
+                tmpRetOptionalInt = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_string"] = function() {
+                const str = tmpRetString;
+                tmpRetString = undefined;
+                if (str == null) {
+                    return -1;
+                } else {
+                    const bytes = textEncoder.encode(str);
+                    tmpRetBytes = bytes;
+                    return bytes.length;
+                }
+            }
+            bjs["swift_js_get_optional_float_presence"] = function() {
+                return tmpRetOptionalFloat != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_float_value"] = function() {
+                const value = tmpRetOptionalFloat;
+                tmpRetOptionalFloat = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_double_presence"] = function() {
+                return tmpRetOptionalDouble != null ? 1 : 0;
+            }
+            bjs["swift_js_get_optional_double_value"] = function() {
+                const value = tmpRetOptionalDouble;
+                tmpRetOptionalDouble = undefined;
+                return value;
+            }
+            bjs["swift_js_get_optional_heap_object_pointer"] = function() {
+                const pointer = tmpRetOptionalHeapObject;
+                tmpRetOptionalHeapObject = undefined;
+                return pointer || 0;
+            }
+            bjs["swift_js_closure_unregister"] = function(funcRef) {}
+        },
+        setInstance: (i) => {
+            instance = i;
+            memory = instance.exports.memory;
+
+            decodeString = (ptr, len) => { const bytes = new Uint8Array(memory.buffer, ptr >>> 0, len >>> 0); return textDecoder.decode(bytes); }
+
+            setException = (error) => {
+                instance.exports._swift_js_exception.value = swift.memory.retain(error)
+            }
+        },
+        /** @param {WebAssembly.Instance} instance */
+        createExports: (instance) => {
+            const js = swift.memory.heap;
+            const ModuleA_PointHelpers = __bjs_createModuleA_PointHelpers();
+            structHelpers.ModuleA_Point = ModuleA_PointHelpers;
+
+            const ModuleB_PointHelpers = __bjs_createModuleB_PointHelpers();
+            structHelpers.ModuleB_Point = ModuleB_PointHelpers;
+
+            const ModuleA_ValidationHelpers = __bjs_createModuleA_ValidationHelpers();
+            enumHelpers.ModuleA_Validation = ModuleA_ValidationHelpers;
+
+            const exports = {
+                run: function bjs_ModuleA_run(point, validation) {
+                    structHelpers.ModuleA_Point.lower(point);
+                    const validationCaseId = enumHelpers.ModuleA_Validation.lower(validation);
+                    instance.exports.bjs_ModuleA_run(validationCaseId);
+                    const structValue = structHelpers.ModuleA_Point.lift();
+                    return structValue;
+                },
+                Validation: ValidationValues,
+                Inner: {
+                    run: function bjs_ModuleB_Inner_run() {
+                        instance.exports.bjs_ModuleB_Inner_run();
+                    },
+                    Point: {
+                        init: function(x, y) {
+                            instance.exports.bjs_ModuleB_Point_init(x, y);
+                            const structValue = structHelpers.ModuleB_Point.lift();
+                            return structValue;
+                        },
+                    },
+                },
+                Point: {
+                    init: function(x, y) {
+                        instance.exports.bjs_ModuleA_Point_init(x, y);
+                        const structValue = structHelpers.ModuleA_Point.lift();
+                        return structValue;
+                    },
+                },
+            };
+            _exports = exports;
+            return exports;
+        },
+    }
+}

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.Global.js
@@ -42,7 +42,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createAPIResultValuesHelpers = () => ({
+    const __bjs_createTestModule_APIResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -251,7 +251,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_MathUtils_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_MathUtils_wrap"] = function(pointer) {
                 const obj = _exports['MathUtils'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -323,36 +323,36 @@ export async function createInstantiator(options, swift) {
             }
             class MathUtils extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_MathUtils_deinit, MathUtils.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_MathUtils_deinit, MathUtils.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_MathUtils_init();
+                    const ret = instance.exports.bjs_TestModule_MathUtils_init();
                     return MathUtils.__construct(ret);
                 }
                 static subtract(a, b) {
-                    const ret = instance.exports.bjs_MathUtils_static_subtract(a, b);
+                    const ret = instance.exports.bjs_TestModule_MathUtils_static_subtract(a, b);
                     return ret;
                 }
                 static add(a, b) {
-                    const ret = instance.exports.bjs_MathUtils_static_add(a, b);
+                    const ret = instance.exports.bjs_TestModule_MathUtils_static_add(a, b);
                     return ret;
                 }
                 multiply(x, y) {
-                    const ret = instance.exports.bjs_MathUtils_multiply(this.pointer, x, y);
+                    const ret = instance.exports.bjs_TestModule_MathUtils_multiply(this.pointer, x, y);
                     return ret;
                 }
                 static divide(a, b) {
-                    const ret = instance.exports.bjs_MathUtils_static_divide(a, b);
+                    const ret = instance.exports.bjs_TestModule_MathUtils_static_divide(a, b);
                     return ret;
                 }
                 static get pi() {
-                    const ret = instance.exports.bjs_MathUtils_static_pi_get();
+                    const ret = instance.exports.bjs_TestModule_MathUtils_static_pi_get();
                     return ret;
                 }
             }
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers();
-            enumHelpers.APIResult = APIResultHelpers;
+            const TestModule_APIResultHelpers = __bjs_createTestModule_APIResultHelpers();
+            enumHelpers.TestModule_APIResult = TestModule_APIResultHelpers;
 
             if (typeof globalThis.Utils === 'undefined') {
                 globalThis.Utils = {};
@@ -364,15 +364,15 @@ export async function createInstantiator(options, swift) {
                 Calculator: {
                     ...CalculatorValues,
                     square: function(value) {
-                        const ret = instance.exports.bjs_Calculator_static_square(value);
+                        const ret = instance.exports.bjs_TestModule_Calculator_static_square(value);
                         return ret;
                     },
                     cube: function(value) {
-                        const ret = instance.exports.bjs_Calculator_static_cube(value);
+                        const ret = instance.exports.bjs_TestModule_Calculator_static_cube(value);
                         return ret;
                     },
                     get version() {
-                        instance.exports.bjs_Calculator_static_version_get();
+                        instance.exports.bjs_TestModule_Calculator_static_version_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -381,19 +381,19 @@ export async function createInstantiator(options, swift) {
                 APIResult: {
                     ...APIResultValues,
                     roundtrip: function(value) {
-                        const valueCaseId = enumHelpers.APIResult.lower(value);
-                        instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
-                        const ret = enumHelpers.APIResult.lift(i32Stack.pop());
+                        const valueCaseId = enumHelpers.TestModule_APIResult.lower(value);
+                        instance.exports.bjs_TestModule_APIResult_static_roundtrip(valueCaseId);
+                        const ret = enumHelpers.TestModule_APIResult.lift(i32Stack.pop());
                         return ret;
                     }
                 },
                 MathUtils,
                 Utils: {
                     String: {
-                        uppercase: function bjs_Utils_String_static_uppercase(text) {
+                        uppercase: function bjs_TestModule_Utils_String_static_uppercase(text) {
                             const textBytes = textEncoder.encode(text);
                             const textId = swift.memory.retain(textBytes);
-                            instance.exports.bjs_Utils_String_static_uppercase(textId, textBytes.length);
+                            instance.exports.bjs_TestModule_Utils_String_static_uppercase(textId, textBytes.length);
                             const ret = tmpRetString;
                             tmpRetString = undefined;
                             return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticFunctions.js
@@ -42,7 +42,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createAPIResultValuesHelpers = () => ({
+    const __bjs_createTestModule_APIResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -251,7 +251,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_MathUtils_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_MathUtils_wrap"] = function(pointer) {
                 const obj = _exports['MathUtils'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -323,50 +323,50 @@ export async function createInstantiator(options, swift) {
             }
             class MathUtils extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_MathUtils_deinit, MathUtils.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_MathUtils_deinit, MathUtils.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_MathUtils_init();
+                    const ret = instance.exports.bjs_TestModule_MathUtils_init();
                     return MathUtils.__construct(ret);
                 }
                 static subtract(a, b) {
-                    const ret = instance.exports.bjs_MathUtils_static_subtract(a, b);
+                    const ret = instance.exports.bjs_TestModule_MathUtils_static_subtract(a, b);
                     return ret;
                 }
                 static add(a, b) {
-                    const ret = instance.exports.bjs_MathUtils_static_add(a, b);
+                    const ret = instance.exports.bjs_TestModule_MathUtils_static_add(a, b);
                     return ret;
                 }
                 multiply(x, y) {
-                    const ret = instance.exports.bjs_MathUtils_multiply(this.pointer, x, y);
+                    const ret = instance.exports.bjs_TestModule_MathUtils_multiply(this.pointer, x, y);
                     return ret;
                 }
                 static divide(a, b) {
-                    const ret = instance.exports.bjs_MathUtils_static_divide(a, b);
+                    const ret = instance.exports.bjs_TestModule_MathUtils_static_divide(a, b);
                     return ret;
                 }
                 static get pi() {
-                    const ret = instance.exports.bjs_MathUtils_static_pi_get();
+                    const ret = instance.exports.bjs_TestModule_MathUtils_static_pi_get();
                     return ret;
                 }
             }
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers();
-            enumHelpers.APIResult = APIResultHelpers;
+            const TestModule_APIResultHelpers = __bjs_createTestModule_APIResultHelpers();
+            enumHelpers.TestModule_APIResult = TestModule_APIResultHelpers;
 
             const exports = {
                 Calculator: {
                     ...CalculatorValues,
                     square: function(value) {
-                        const ret = instance.exports.bjs_Calculator_static_square(value);
+                        const ret = instance.exports.bjs_TestModule_Calculator_static_square(value);
                         return ret;
                     },
                     cube: function(value) {
-                        const ret = instance.exports.bjs_Calculator_static_cube(value);
+                        const ret = instance.exports.bjs_TestModule_Calculator_static_cube(value);
                         return ret;
                     },
                     get version() {
-                        instance.exports.bjs_Calculator_static_version_get();
+                        instance.exports.bjs_TestModule_Calculator_static_version_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -375,19 +375,19 @@ export async function createInstantiator(options, swift) {
                 APIResult: {
                     ...APIResultValues,
                     roundtrip: function(value) {
-                        const valueCaseId = enumHelpers.APIResult.lower(value);
-                        instance.exports.bjs_APIResult_static_roundtrip(valueCaseId);
-                        const ret = enumHelpers.APIResult.lift(i32Stack.pop());
+                        const valueCaseId = enumHelpers.TestModule_APIResult.lower(value);
+                        instance.exports.bjs_TestModule_APIResult_static_roundtrip(valueCaseId);
+                        const ret = enumHelpers.TestModule_APIResult.lift(i32Stack.pop());
                         return ret;
                     }
                 },
                 MathUtils,
                 Utils: {
                     String: {
-                        uppercase: function bjs_Utils_String_static_uppercase(text) {
+                        uppercase: function bjs_TestModule_Utils_String_static_uppercase(text) {
                             const textBytes = textEncoder.encode(text);
                             const textId = swift.memory.retain(textBytes);
-                            instance.exports.bjs_Utils_String_static_uppercase(textId, textBytes.length);
+                            instance.exports.bjs_TestModule_Utils_String_static_uppercase(textId, textBytes.length);
                             const ret = tmpRetString;
                             tmpRetString = undefined;
                             return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.Global.js
@@ -212,7 +212,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_PropertyClass_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_PropertyClass_wrap"] = function(pointer) {
                 const obj = _exports['PropertyClass'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -284,37 +284,37 @@ export async function createInstantiator(options, swift) {
             }
             class PropertyClass extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PropertyClass_deinit, PropertyClass.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_PropertyClass_deinit, PropertyClass.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_PropertyClass_init();
+                    const ret = instance.exports.bjs_TestModule_PropertyClass_init();
                     return PropertyClass.__construct(ret);
                 }
                 static get staticConstant() {
-                    instance.exports.bjs_PropertyClass_static_staticConstant_get();
+                    instance.exports.bjs_TestModule_PropertyClass_static_staticConstant_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 static get staticVariable() {
-                    const ret = instance.exports.bjs_PropertyClass_static_staticVariable_get();
+                    const ret = instance.exports.bjs_TestModule_PropertyClass_static_staticVariable_get();
                     return ret;
                 }
                 static set staticVariable(value) {
-                    instance.exports.bjs_PropertyClass_static_staticVariable_set(value);
+                    instance.exports.bjs_TestModule_PropertyClass_static_staticVariable_set(value);
                 }
                 static get jsObjectProperty() {
-                    const ret = instance.exports.bjs_PropertyClass_static_jsObjectProperty_get();
+                    const ret = instance.exports.bjs_TestModule_PropertyClass_static_jsObjectProperty_get();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 }
                 static set jsObjectProperty(value) {
-                    instance.exports.bjs_PropertyClass_static_jsObjectProperty_set(swift.memory.retain(value));
+                    instance.exports.bjs_TestModule_PropertyClass_static_jsObjectProperty_set(swift.memory.retain(value));
                 }
                 static get classVariable() {
-                    instance.exports.bjs_PropertyClass_static_classVariable_get();
+                    instance.exports.bjs_TestModule_PropertyClass_static_classVariable_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -322,10 +322,10 @@ export async function createInstantiator(options, swift) {
                 static set classVariable(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_PropertyClass_static_classVariable_set(valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_PropertyClass_static_classVariable_set(valueId, valueBytes.length);
                 }
                 static get computedProperty() {
-                    instance.exports.bjs_PropertyClass_static_computedProperty_get();
+                    instance.exports.bjs_TestModule_PropertyClass_static_computedProperty_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -333,14 +333,14 @@ export async function createInstantiator(options, swift) {
                 static set computedProperty(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_PropertyClass_static_computedProperty_set(valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_PropertyClass_static_computedProperty_set(valueId, valueBytes.length);
                 }
                 static get readOnlyComputed() {
-                    const ret = instance.exports.bjs_PropertyClass_static_readOnlyComputed_get();
+                    const ret = instance.exports.bjs_TestModule_PropertyClass_static_readOnlyComputed_get();
                     return ret;
                 }
                 static get optionalProperty() {
-                    instance.exports.bjs_PropertyClass_static_optionalProperty_get();
+                    instance.exports.bjs_TestModule_PropertyClass_static_optionalProperty_get();
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -357,7 +357,7 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_PropertyClass_static_optionalProperty_set(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_PropertyClass_static_optionalProperty_set(+isSome, result, result1);
                 }
             }
             if (typeof globalThis.PropertyNamespace === 'undefined') {
@@ -370,7 +370,7 @@ export async function createInstantiator(options, swift) {
                 PropertyEnum: {
                     ...PropertyEnumValues,
                     get enumProperty() {
-                        instance.exports.bjs_PropertyEnum_static_enumProperty_get();
+                        instance.exports.bjs_TestModule_PropertyEnum_static_enumProperty_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -378,14 +378,14 @@ export async function createInstantiator(options, swift) {
                     set enumProperty(value) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
-                        instance.exports.bjs_PropertyEnum_static_enumProperty_set(valueId, valueBytes.length);
+                        instance.exports.bjs_TestModule_PropertyEnum_static_enumProperty_set(valueId, valueBytes.length);
                     },
                     get enumConstant() {
-                        const ret = instance.exports.bjs_PropertyEnum_static_enumConstant_get();
+                        const ret = instance.exports.bjs_TestModule_PropertyEnum_static_enumConstant_get();
                         return ret;
                     },
                     get computedEnum() {
-                        instance.exports.bjs_PropertyEnum_static_computedEnum_get();
+                        instance.exports.bjs_TestModule_PropertyEnum_static_computedEnum_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -393,13 +393,13 @@ export async function createInstantiator(options, swift) {
                     set computedEnum(value) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
-                        instance.exports.bjs_PropertyEnum_static_computedEnum_set(valueId, valueBytes.length);
+                        instance.exports.bjs_TestModule_PropertyEnum_static_computedEnum_set(valueId, valueBytes.length);
                     }
                 },
                 PropertyClass,
                 PropertyNamespace: {
                     get namespaceProperty() {
-                        instance.exports.bjs_PropertyNamespace_static_namespaceProperty_get();
+                        instance.exports.bjs_TestModule_PropertyNamespace_static_namespaceProperty_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -407,34 +407,34 @@ export async function createInstantiator(options, swift) {
                     set namespaceProperty(value) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
-                        instance.exports.bjs_PropertyNamespace_static_namespaceProperty_set(valueId, valueBytes.length);
+                        instance.exports.bjs_TestModule_PropertyNamespace_static_namespaceProperty_set(valueId, valueBytes.length);
                     },
                     get namespaceConstant() {
-                        instance.exports.bjs_PropertyNamespace_static_namespaceConstant_get();
+                        instance.exports.bjs_TestModule_PropertyNamespace_static_namespaceConstant_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
                     },
                     Nested: {
                         get nestedProperty() {
-                            const ret = instance.exports.bjs_PropertyNamespace_Nested_static_nestedProperty_get();
+                            const ret = instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_get();
                             return ret;
                         },
                         set nestedProperty(value) {
-                            instance.exports.bjs_PropertyNamespace_Nested_static_nestedProperty_set(value);
+                            instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_set(value);
                         },
                         get nestedConstant() {
-                            instance.exports.bjs_PropertyNamespace_Nested_static_nestedConstant_get();
+                            instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedConstant_get();
                             const ret = tmpRetString;
                             tmpRetString = undefined;
                             return ret;
                         },
                         get nestedDouble() {
-                            const ret = instance.exports.bjs_PropertyNamespace_Nested_static_nestedDouble_get();
+                            const ret = instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_get();
                             return ret;
                         },
                         set nestedDouble(value) {
-                            instance.exports.bjs_PropertyNamespace_Nested_static_nestedDouble_set(value);
+                            instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_set(value);
                         },
                     },
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StaticProperties.js
@@ -212,7 +212,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_PropertyClass_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_PropertyClass_wrap"] = function(pointer) {
                 const obj = _exports['PropertyClass'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -284,37 +284,37 @@ export async function createInstantiator(options, swift) {
             }
             class PropertyClass extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PropertyClass_deinit, PropertyClass.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_PropertyClass_deinit, PropertyClass.prototype, null);
                 }
 
                 constructor() {
-                    const ret = instance.exports.bjs_PropertyClass_init();
+                    const ret = instance.exports.bjs_TestModule_PropertyClass_init();
                     return PropertyClass.__construct(ret);
                 }
                 static get staticConstant() {
-                    instance.exports.bjs_PropertyClass_static_staticConstant_get();
+                    instance.exports.bjs_TestModule_PropertyClass_static_staticConstant_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 static get staticVariable() {
-                    const ret = instance.exports.bjs_PropertyClass_static_staticVariable_get();
+                    const ret = instance.exports.bjs_TestModule_PropertyClass_static_staticVariable_get();
                     return ret;
                 }
                 static set staticVariable(value) {
-                    instance.exports.bjs_PropertyClass_static_staticVariable_set(value);
+                    instance.exports.bjs_TestModule_PropertyClass_static_staticVariable_set(value);
                 }
                 static get jsObjectProperty() {
-                    const ret = instance.exports.bjs_PropertyClass_static_jsObjectProperty_get();
+                    const ret = instance.exports.bjs_TestModule_PropertyClass_static_jsObjectProperty_get();
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 }
                 static set jsObjectProperty(value) {
-                    instance.exports.bjs_PropertyClass_static_jsObjectProperty_set(swift.memory.retain(value));
+                    instance.exports.bjs_TestModule_PropertyClass_static_jsObjectProperty_set(swift.memory.retain(value));
                 }
                 static get classVariable() {
-                    instance.exports.bjs_PropertyClass_static_classVariable_get();
+                    instance.exports.bjs_TestModule_PropertyClass_static_classVariable_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -322,10 +322,10 @@ export async function createInstantiator(options, swift) {
                 static set classVariable(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_PropertyClass_static_classVariable_set(valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_PropertyClass_static_classVariable_set(valueId, valueBytes.length);
                 }
                 static get computedProperty() {
-                    instance.exports.bjs_PropertyClass_static_computedProperty_get();
+                    instance.exports.bjs_TestModule_PropertyClass_static_computedProperty_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -333,14 +333,14 @@ export async function createInstantiator(options, swift) {
                 static set computedProperty(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_PropertyClass_static_computedProperty_set(valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_PropertyClass_static_computedProperty_set(valueId, valueBytes.length);
                 }
                 static get readOnlyComputed() {
-                    const ret = instance.exports.bjs_PropertyClass_static_readOnlyComputed_get();
+                    const ret = instance.exports.bjs_TestModule_PropertyClass_static_readOnlyComputed_get();
                     return ret;
                 }
                 static get optionalProperty() {
-                    instance.exports.bjs_PropertyClass_static_optionalProperty_get();
+                    instance.exports.bjs_TestModule_PropertyClass_static_optionalProperty_get();
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     return optResult;
@@ -357,14 +357,14 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.bjs_PropertyClass_static_optionalProperty_set(+isSome, result, result1);
+                    instance.exports.bjs_TestModule_PropertyClass_static_optionalProperty_set(+isSome, result, result1);
                 }
             }
             const exports = {
                 PropertyEnum: {
                     ...PropertyEnumValues,
                     get enumProperty() {
-                        instance.exports.bjs_PropertyEnum_static_enumProperty_get();
+                        instance.exports.bjs_TestModule_PropertyEnum_static_enumProperty_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -372,14 +372,14 @@ export async function createInstantiator(options, swift) {
                     set enumProperty(value) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
-                        instance.exports.bjs_PropertyEnum_static_enumProperty_set(valueId, valueBytes.length);
+                        instance.exports.bjs_TestModule_PropertyEnum_static_enumProperty_set(valueId, valueBytes.length);
                     },
                     get enumConstant() {
-                        const ret = instance.exports.bjs_PropertyEnum_static_enumConstant_get();
+                        const ret = instance.exports.bjs_TestModule_PropertyEnum_static_enumConstant_get();
                         return ret;
                     },
                     get computedEnum() {
-                        instance.exports.bjs_PropertyEnum_static_computedEnum_get();
+                        instance.exports.bjs_TestModule_PropertyEnum_static_computedEnum_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -387,13 +387,13 @@ export async function createInstantiator(options, swift) {
                     set computedEnum(value) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
-                        instance.exports.bjs_PropertyEnum_static_computedEnum_set(valueId, valueBytes.length);
+                        instance.exports.bjs_TestModule_PropertyEnum_static_computedEnum_set(valueId, valueBytes.length);
                     }
                 },
                 PropertyClass,
                 PropertyNamespace: {
                     get namespaceProperty() {
-                        instance.exports.bjs_PropertyNamespace_static_namespaceProperty_get();
+                        instance.exports.bjs_TestModule_PropertyNamespace_static_namespaceProperty_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -401,34 +401,34 @@ export async function createInstantiator(options, swift) {
                     set namespaceProperty(value) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
-                        instance.exports.bjs_PropertyNamespace_static_namespaceProperty_set(valueId, valueBytes.length);
+                        instance.exports.bjs_TestModule_PropertyNamespace_static_namespaceProperty_set(valueId, valueBytes.length);
                     },
                     get namespaceConstant() {
-                        instance.exports.bjs_PropertyNamespace_static_namespaceConstant_get();
+                        instance.exports.bjs_TestModule_PropertyNamespace_static_namespaceConstant_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
                     },
                     Nested: {
                         get nestedProperty() {
-                            const ret = instance.exports.bjs_PropertyNamespace_Nested_static_nestedProperty_get();
+                            const ret = instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_get();
                             return ret;
                         },
                         set nestedProperty(value) {
-                            instance.exports.bjs_PropertyNamespace_Nested_static_nestedProperty_set(value);
+                            instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedProperty_set(value);
                         },
                         get nestedConstant() {
-                            instance.exports.bjs_PropertyNamespace_Nested_static_nestedConstant_get();
+                            instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedConstant_get();
                             const ret = tmpRetString;
                             tmpRetString = undefined;
                             return ret;
                         },
                         get nestedDouble() {
-                            const ret = instance.exports.bjs_PropertyNamespace_Nested_static_nestedDouble_get();
+                            const ret = instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_get();
                             return ret;
                         },
                         set nestedDouble(value) {
-                            instance.exports.bjs_PropertyNamespace_Nested_static_nestedDouble_set(value);
+                            instance.exports.bjs_TestModule_PropertyNamespace_Nested_static_nestedDouble_set(value);
                         },
                     },
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringParameter.js
@@ -236,15 +236,15 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                checkString: function bjs_checkString(a) {
+                checkString: function bjs_TestModule_checkString(a) {
                     const aBytes = textEncoder.encode(a);
                     const aId = swift.memory.retain(aBytes);
-                    instance.exports.bjs_checkString(aId, aBytes.length);
+                    instance.exports.bjs_TestModule_checkString(aId, aBytes.length);
                 },
-                roundtripString: function bjs_roundtripString(a) {
+                roundtripString: function bjs_TestModule_roundtripString(a) {
                     const aBytes = textEncoder.encode(a);
                     const aId = swift.memory.retain(aBytes);
-                    instance.exports.bjs_roundtripString(aId, aBytes.length);
+                    instance.exports.bjs_TestModule_roundtripString(aId, aBytes.length);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StringReturn.js
@@ -229,8 +229,8 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                checkString: function bjs_checkString() {
-                    instance.exports.bjs_checkString();
+                checkString: function bjs_TestModule_checkString() {
+                    instance.exports.bjs_TestModule_checkString();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StructWithNestedTypes.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/StructWithNestedTypes.js
@@ -46,7 +46,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createShapeHelpers = () => ({
+    const __bjs_createTestModule_ShapeHelpers = () => ({
         lower: (value) => {
             const bytes = textEncoder.encode(value.label);
             const id = swift.memory.retain(bytes);
@@ -58,7 +58,7 @@ export async function createInstantiator(options, swift) {
             return { label: string };
         }
     });
-    const __bjs_createWidgetHelpers = () => ({
+    const __bjs_createTestModule_WidgetHelpers = () => ({
         lower: (value) => {
             const bytes = textEncoder.encode(value.name);
             const id = swift.memory.retain(bytes);
@@ -70,7 +70,7 @@ export async function createInstantiator(options, swift) {
             return { name: string };
         }
     });
-    const __bjs_createWidget_LayoutHelpers = () => ({
+    const __bjs_createTestModule_Widget_LayoutHelpers = () => ({
         lower: (value) => {
             i32Stack.push((value.padding | 0));
         },
@@ -79,7 +79,7 @@ export async function createInstantiator(options, swift) {
             return { padding: int };
         }
     });
-    const __bjs_createWidget_BoundsHelpers = () => ({
+    const __bjs_createTestModule_Widget_BoundsHelpers = () => ({
         lower: (value) => {
             i32Stack.push((value.width | 0));
             i32Stack.push((value.height | 0));
@@ -165,32 +165,32 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_Shape"] = function(objectId) {
-                structHelpers.Shape.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Shape"] = function(objectId) {
+                structHelpers.TestModule_Shape.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Shape"] = function() {
-                const value = structHelpers.Shape.lift();
+            bjs["swift_js_struct_lift_TestModule_Shape"] = function() {
+                const value = structHelpers.TestModule_Shape.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Widget"] = function(objectId) {
-                structHelpers.Widget.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Widget"] = function(objectId) {
+                structHelpers.TestModule_Widget.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Widget"] = function() {
-                const value = structHelpers.Widget.lift();
+            bjs["swift_js_struct_lift_TestModule_Widget"] = function() {
+                const value = structHelpers.TestModule_Widget.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Widget_Layout"] = function(objectId) {
-                structHelpers.Widget_Layout.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Widget_Layout"] = function(objectId) {
+                structHelpers.TestModule_Widget_Layout.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Widget_Layout"] = function() {
-                const value = structHelpers.Widget_Layout.lift();
+            bjs["swift_js_struct_lift_TestModule_Widget_Layout"] = function() {
+                const value = structHelpers.TestModule_Widget_Layout.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Widget_Bounds"] = function(objectId) {
-                structHelpers.Widget_Bounds.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Widget_Bounds"] = function(objectId) {
+                structHelpers.TestModule_Widget_Bounds.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Widget_Bounds"] = function() {
-                const value = structHelpers.Widget_Bounds.lift();
+            bjs["swift_js_struct_lift_TestModule_Widget_Bounds"] = function() {
+                const value = structHelpers.TestModule_Widget_Bounds.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -304,25 +304,25 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const ShapeHelpers = __bjs_createShapeHelpers();
-            structHelpers.Shape = ShapeHelpers;
+            const TestModule_ShapeHelpers = __bjs_createTestModule_ShapeHelpers();
+            structHelpers.TestModule_Shape = TestModule_ShapeHelpers;
 
-            const WidgetHelpers = __bjs_createWidgetHelpers();
-            structHelpers.Widget = WidgetHelpers;
+            const TestModule_WidgetHelpers = __bjs_createTestModule_WidgetHelpers();
+            structHelpers.TestModule_Widget = TestModule_WidgetHelpers;
 
-            const Widget_LayoutHelpers = __bjs_createWidget_LayoutHelpers();
-            structHelpers.Widget_Layout = Widget_LayoutHelpers;
+            const TestModule_Widget_LayoutHelpers = __bjs_createTestModule_Widget_LayoutHelpers();
+            structHelpers.TestModule_Widget_Layout = TestModule_Widget_LayoutHelpers;
 
-            const Widget_BoundsHelpers = __bjs_createWidget_BoundsHelpers();
-            structHelpers.Widget_Bounds = Widget_BoundsHelpers;
+            const TestModule_Widget_BoundsHelpers = __bjs_createTestModule_Widget_BoundsHelpers();
+            structHelpers.TestModule_Widget_Bounds = TestModule_Widget_BoundsHelpers;
 
             const exports = {
                 Shape: {
                     init: function(label) {
                         const labelBytes = textEncoder.encode(label);
                         const labelId = swift.memory.retain(labelBytes);
-                        instance.exports.bjs_Shape_init(labelId, labelBytes.length);
-                        const structValue = structHelpers.Shape.lift();
+                        instance.exports.bjs_TestModule_Shape_init(labelId, labelBytes.length);
+                        const structValue = structHelpers.TestModule_Shape.lift();
                         return structValue;
                     },
                     Kind: KindValues,
@@ -331,24 +331,24 @@ export async function createInstantiator(options, swift) {
                     init: function(name) {
                         const nameBytes = textEncoder.encode(name);
                         const nameId = swift.memory.retain(nameBytes);
-                        instance.exports.bjs_Widget_init(nameId, nameBytes.length);
-                        const structValue = structHelpers.Widget.lift();
+                        instance.exports.bjs_TestModule_Widget_init(nameId, nameBytes.length);
+                        const structValue = structHelpers.TestModule_Widget.lift();
                         return structValue;
                     },
                     Variant: VariantValues,
                     Bounds: {
                         init: function(width, height) {
-                            instance.exports.bjs_Widget_Bounds_init(width, height);
-                            const structValue = structHelpers.Widget_Bounds.lift();
+                            instance.exports.bjs_TestModule_Widget_Bounds_init(width, height);
+                            const structValue = structHelpers.TestModule_Widget_Bounds.lift();
                             return structValue;
                         },
                         get dimensions() {
-                            const ret = instance.exports.bjs_Widget_Bounds_static_dimensions_get();
+                            const ret = instance.exports.bjs_TestModule_Widget_Bounds_static_dimensions_get();
                             return ret;
                         },
                         zero: function() {
-                            instance.exports.bjs_Widget_Bounds_static_zero();
-                            const structValue = structHelpers.Widget_Bounds.lift();
+                            instance.exports.bjs_TestModule_Widget_Bounds_static_zero();
+                            const structValue = structHelpers.TestModule_Widget_Bounds.lift();
                             return structValue;
                         },
                     },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClass.js
@@ -208,15 +208,15 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Greeter_wrap"] = function(pointer) {
                 const obj = _exports['Greeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_PackageGreeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_PackageGreeter_wrap"] = function(pointer) {
                 const obj = _exports['PackageGreeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_PublicGreeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_PublicGreeter_wrap"] = function(pointer) {
                 const obj = _exports['PublicGreeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -307,17 +307,17 @@ export async function createInstantiator(options, swift) {
             }
             class Greeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Greeter_deinit, Greeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Greeter_deinit, Greeter.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_Greeter_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_Greeter_init(nameId, nameBytes.length);
                     return Greeter.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs_Greeter_greet(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -325,22 +325,22 @@ export async function createInstantiator(options, swift) {
                 changeName(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    instance.exports.bjs_Greeter_changeName(this.pointer, nameId, nameBytes.length);
+                    instance.exports.bjs_TestModule_Greeter_changeName(this.pointer, nameId, nameBytes.length);
                 }
                 greetEnthusiastically() {
-                    instance.exports.bjs_Greeter_greetEnthusiastically(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_greetEnthusiastically(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 static greetAnonymously() {
-                    instance.exports.bjs_Greeter_static_greetAnonymously();
+                    instance.exports.bjs_TestModule_Greeter_static_greetAnonymously();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 get name() {
-                    instance.exports.bjs_Greeter_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -348,14 +348,14 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_Greeter_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_Greeter_name_set(this.pointer, valueId, valueBytes.length);
                 }
                 get nameCount() {
-                    const ret = instance.exports.bjs_Greeter_nameCount_get(this.pointer);
+                    const ret = instance.exports.bjs_TestModule_Greeter_nameCount_get(this.pointer);
                     return ret;
                 }
                 static get defaultGreeting() {
-                    instance.exports.bjs_Greeter_static_defaultGreeting_get();
+                    instance.exports.bjs_TestModule_Greeter_static_defaultGreeting_get();
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -363,19 +363,19 @@ export async function createInstantiator(options, swift) {
             }
             class PublicGreeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PublicGreeter_deinit, PublicGreeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_PublicGreeter_deinit, PublicGreeter.prototype, null);
                 }
 
             }
             class PackageGreeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_PackageGreeter_deinit, PackageGreeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_PackageGreeter_deinit, PackageGreeter.prototype, null);
                 }
 
             }
             const exports = {
-                takeGreeter: function bjs_takeGreeter(greeter) {
-                    instance.exports.bjs_takeGreeter(greeter.pointer);
+                takeGreeter: function bjs_TestModule_takeGreeter(greeter) {
+                    instance.exports.bjs_TestModule_takeGreeter(greeter.pointer);
                 },
                 Greeter,
                 PackageGreeter,

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosure.js
@@ -175,7 +175,7 @@ export async function createInstantiator(options, swift) {
         return swift.memory.retain(real);
     };
 
-    const __bjs_createAnimalHelpers = () => ({
+    const __bjs_createTestModule_AnimalHelpers = () => ({
         lower: (value) => {
             const bytes = textEncoder.encode(value.type);
             const id = swift.memory.retain(bytes);
@@ -187,7 +187,7 @@ export async function createInstantiator(options, swift) {
             return { type: string };
         }
     });
-    const __bjs_createAPIResultValuesHelpers = () => ({
+    const __bjs_createTestModule_APIResultHelpers = () => ({
         lower: (value) => {
             const enumTag = value.tag;
             switch (enumTag) {
@@ -323,11 +323,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_Animal"] = function(objectId) {
-                structHelpers.Animal.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Animal"] = function(objectId) {
+                structHelpers.TestModule_Animal.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Animal"] = function() {
-                const value = structHelpers.Animal.lift();
+            bjs["swift_js_struct_lift_TestModule_Animal"] = function() {
+                const value = structHelpers.TestModule_Animal.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -345,7 +345,7 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_6AnimalV"] = function(promise, value) {
+            bjs["promise_resolve_TestModule_17TestModule_AnimalV"] = function(promise, value) {
                 try {
                     const value1 = swift.memory.getObject(value);
                     swift.memory.release(value);
@@ -354,9 +354,9 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["promise_resolve_TestModule_9APIResultO"] = function(promise, value) {
+            bjs["promise_resolve_TestModule_20TestModule_APIResultO"] = function(promise, value) {
                 try {
-                    const enumValue = enumHelpers.APIResult.lift(value);
+                    const enumValue = enumHelpers.TestModule_APIResult.lift(value);
                     swift.memory.getObject(promise)[__bjs_promiseSettlers].resolve(enumValue);
                 } catch (error) {
                     setException(error);
@@ -464,30 +464,7 @@ export async function createInstantiator(options, swift) {
                 const func = swift.memory.getObject(funcRef);
                 func.__unregister();
             }
-            bjs["invoke_js_callback_TestModule_10TestModule10HttpStatusO_10HttpStatusO"] = function(callbackId, param0) {
-                try {
-                    const callback = swift.memory.getObject(callbackId);
-                    let ret = callback(param0);
-                    return ret;
-                } catch (error) {
-                    setException(error);
-                    return 0
-                }
-            }
-            bjs["make_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO = function(param0) {
-                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO(boxPtr, param0);
-                    if (tmpRetException) {
-                        const error = swift.memory.getObject(tmpRetException);
-                        swift.memory.release(tmpRetException);
-                        tmpRetException = undefined;
-                        throw error;
-                    }
-                    return ret;
-                };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule10HttpStatusO_10HttpStatusO);
-            }
-            bjs["invoke_js_callback_TestModule_10TestModule5ThemeO_5ThemeO"] = function(callbackId, param0Bytes, param0Count) {
+            bjs["invoke_js_callback_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO"] = function(callbackId, param0Bytes, param0Count) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     const string = decodeString(param0Bytes, param0Count);
@@ -498,11 +475,11 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModule5ThemeO_5ThemeO = function(param0) {
+            bjs["make_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO = function(param0) {
                     const param0Bytes = textEncoder.encode(param0);
                     const param0Id = swift.memory.retain(param0Bytes);
-                    instance.exports.invoke_swift_closure_TestModule_10TestModule5ThemeO_5ThemeO(boxPtr, param0Id, param0Bytes.length);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO(boxPtr, param0Id, param0Bytes.length);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     if (tmpRetException) {
@@ -513,23 +490,23 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule5ThemeO_5ThemeO);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule16TestModule_ThemeO_16TestModule_ThemeO);
             }
-            bjs["invoke_js_callback_TestModule_10TestModule6AnimalV_6AnimalV"] = function(callbackId) {
+            bjs["invoke_js_callback_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV"] = function(callbackId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    const structValue = structHelpers.Animal.lift();
+                    const structValue = structHelpers.TestModule_Animal.lift();
                     let ret = callback(structValue);
-                    structHelpers.Animal.lower(ret);
+                    structHelpers.TestModule_Animal.lower(ret);
                 } catch (error) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModule6AnimalV_6AnimalV = function(param0) {
-                    structHelpers.Animal.lower(param0);
-                    instance.exports.invoke_swift_closure_TestModule_10TestModule6AnimalV_6AnimalV(boxPtr);
-                    const structValue = structHelpers.Animal.lift();
+            bjs["make_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV = function(param0) {
+                    structHelpers.TestModule_Animal.lower(param0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV(boxPtr);
+                    const structValue = structHelpers.TestModule_Animal.lift();
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -538,9 +515,9 @@ export async function createInstantiator(options, swift) {
                     }
                     return structValue;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule6AnimalV_6AnimalV);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule17TestModule_AnimalV_17TestModule_AnimalV);
             }
-            bjs["invoke_js_callback_TestModule_10TestModule6PersonC_6PersonC"] = function(callbackId, param0) {
+            bjs["invoke_js_callback_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC"] = function(callbackId, param0) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback(_exports['Person'].__construct(param0));
@@ -550,9 +527,9 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModule6PersonC_6PersonC"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModule6PersonC_6PersonC = function(param0) {
-                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModule6PersonC_6PersonC(boxPtr, param0.pointer);
+            bjs["make_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC = function(param0) {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC(boxPtr, param0.pointer);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -561,24 +538,24 @@ export async function createInstantiator(options, swift) {
                     }
                     return _exports['Person'].__construct(ret);
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule6PersonC_6PersonC);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule17TestModule_PersonC_17TestModule_PersonC);
             }
-            bjs["invoke_js_callback_TestModule_10TestModule9APIResultO_9APIResultO"] = function(callbackId, param0) {
+            bjs["invoke_js_callback_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO"] = function(callbackId, param0) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    const enumValue = enumHelpers.APIResult.lift(param0);
+                    const enumValue = enumHelpers.TestModule_APIResult.lift(param0);
                     let ret = callback(enumValue);
-                    const caseId = enumHelpers.APIResult.lower(ret);
+                    const caseId = enumHelpers.TestModule_APIResult.lower(ret);
                     return caseId;
                 } catch (error) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModule9APIResultO_9APIResultO = function(param0) {
-                    const param0CaseId = enumHelpers.APIResult.lower(param0);
-                    instance.exports.invoke_swift_closure_TestModule_10TestModule9APIResultO_9APIResultO(boxPtr, param0CaseId);
-                    const ret = enumHelpers.APIResult.lift(i32Stack.pop());
+            bjs["make_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO = function(param0) {
+                    const param0CaseId = enumHelpers.TestModule_APIResult.lower(param0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO(boxPtr, param0CaseId);
+                    const ret = enumHelpers.TestModule_APIResult.lift(i32Stack.pop());
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -587,9 +564,9 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule9APIResultO_9APIResultO);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule20TestModule_APIResultO_20TestModule_APIResultO);
             }
-            bjs["invoke_js_callback_TestModule_10TestModule9DirectionO_9DirectionO"] = function(callbackId, param0) {
+            bjs["invoke_js_callback_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO"] = function(callbackId, param0) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback(param0);
@@ -599,9 +576,9 @@ export async function createInstantiator(options, swift) {
                     return 0
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModule9DirectionO_9DirectionO = function(param0) {
-                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModule9DirectionO_9DirectionO(boxPtr, param0);
+            bjs["make_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO = function(param0) {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO(boxPtr, param0);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -610,7 +587,30 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule9DirectionO_9DirectionO);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule20TestModule_DirectionO_20TestModule_DirectionO);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO"] = function(callbackId, param0) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    let ret = callback(param0);
+                    return ret;
+                } catch (error) {
+                    setException(error);
+                    return 0
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO = function(param0) {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO(boxPtr, param0);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return ret;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModule21TestModule_HttpStatusO_21TestModule_HttpStatusO);
             }
             bjs["invoke_js_callback_TestModule_10TestModuleKSS_Sb"] = function(callbackId, param0Bytes, param0Count) {
                 try {
@@ -784,33 +784,7 @@ export async function createInstantiator(options, swift) {
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSi_Si);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO"] = function(callbackId, param0IsSome, param0WrappedValue) {
-                try {
-                    const callback = swift.memory.getObject(callbackId);
-                    let ret = callback(param0IsSome ? param0WrappedValue : null);
-                    const isSome = ret != null;
-                    bjs["swift_js_return_optional_int"](isSome ? 1 : 0, isSome ? (ret | 0) : 0);
-                } catch (error) {
-                    setException(error);
-                }
-            }
-            bjs["make_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO = function(param0) {
-                    const isSome = param0 != null;
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO(boxPtr, +isSome, isSome ? param0 : 0);
-                    const optResult = tmpRetOptionalInt;
-                    tmpRetOptionalInt = undefined;
-                    if (tmpRetException) {
-                        const error = swift.memory.getObject(tmpRetException);
-                        swift.memory.release(tmpRetException);
-                        tmpRetException = undefined;
-                        throw error;
-                    }
-                    return optResult;
-                };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq10HttpStatusO_Sq10HttpStatusO);
-            }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO"] = function(callbackId, param0IsSome, param0Bytes, param0Count) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO"] = function(callbackId, param0IsSome, param0Bytes, param0Count) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let optResult;
@@ -827,8 +801,8 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO = function(param0) {
+            bjs["make_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO = function(param0) {
                     const isSome = param0 != null;
                     let result, result1;
                     if (isSome) {
@@ -840,7 +814,7 @@ export async function createInstantiator(options, swift) {
                         result = 0;
                         result1 = 0;
                     }
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO(boxPtr, +isSome, result, result1);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO(boxPtr, +isSome, result, result1);
                     const optResult = tmpRetString;
                     tmpRetString = undefined;
                     if (tmpRetException) {
@@ -851,14 +825,14 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq5ThemeO_Sq5ThemeO);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq16TestModule_ThemeO_Sq16TestModule_ThemeO);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV"] = function(callbackId, param0) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV"] = function(callbackId, param0) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let optResult;
                     if (param0) {
-                        const struct = structHelpers.Animal.lift();
+                        const struct = structHelpers.TestModule_Animal.lift();
                         optResult = struct;
                     } else {
                         optResult = null;
@@ -866,23 +840,23 @@ export async function createInstantiator(options, swift) {
                     let ret = callback(optResult);
                     const isSome = ret != null;
                     if (isSome) {
-                        structHelpers.Animal.lower(ret);
+                        structHelpers.TestModule_Animal.lower(ret);
                     }
                     i32Stack.push(isSome ? 1 : 0);
                 } catch (error) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV = function(param0) {
+            bjs["make_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV = function(param0) {
                     const isSome = param0 != null;
                     if (isSome) {
-                        structHelpers.Animal.lower(param0);
+                        structHelpers.TestModule_Animal.lower(param0);
                     }
                     i32Stack.push(+isSome);
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV(boxPtr);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV(boxPtr);
                     const isSome1 = i32Stack.pop();
-                    const optResult = isSome1 ? structHelpers.Animal.lift() : null;
+                    const optResult = isSome1 ? structHelpers.TestModule_Animal.lift() : null;
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -891,9 +865,9 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq6AnimalV_Sq6AnimalV);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq17TestModule_AnimalV_Sq17TestModule_AnimalV);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq6PersonC_Sq6PersonC"] = function(callbackId, param0IsSome, param0Pointer) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC"] = function(callbackId, param0IsSome, param0Pointer) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback(param0IsSome ? _exports['Person'].__construct(param0Pointer) : null);
@@ -903,8 +877,8 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC = function(param0) {
+            bjs["make_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC = function(param0) {
                     const isSome = param0 != null;
                     let result;
                     if (isSome) {
@@ -912,7 +886,7 @@ export async function createInstantiator(options, swift) {
                     } else {
                         result = 0;
                     }
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC(boxPtr, +isSome, result);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC(boxPtr, +isSome, result);
                     const pointer = tmpRetOptionalHeapObject;
                     tmpRetOptionalHeapObject = undefined;
                     const optResult = pointer === null ? null : _exports['Person'].__construct(pointer);
@@ -924,14 +898,14 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq6PersonC_Sq6PersonC);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq17TestModule_PersonC_Sq17TestModule_PersonC);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO"] = function(callbackId, param0IsSome, param0CaseId) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO"] = function(callbackId, param0IsSome, param0CaseId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let optResult;
                     if (param0IsSome) {
-                        const enumValue = enumHelpers.APIResult.lift(param0CaseId);
+                        const enumValue = enumHelpers.TestModule_APIResult.lift(param0CaseId);
                         optResult = enumValue;
                     } else {
                         optResult = null;
@@ -939,7 +913,7 @@ export async function createInstantiator(options, swift) {
                     let ret = callback(optResult);
                     const isSome = ret != null;
                     if (isSome) {
-                        const caseId = enumHelpers.APIResult.lower(ret);
+                        const caseId = enumHelpers.TestModule_APIResult.lower(ret);
                         return caseId;
                     } else {
                         return -1;
@@ -948,19 +922,19 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO = function(param0) {
+            bjs["make_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO = function(param0) {
                     const isSome = param0 != null;
                     let result;
                     if (isSome) {
-                        const param0CaseId = enumHelpers.APIResult.lower(param0);
+                        const param0CaseId = enumHelpers.TestModule_APIResult.lower(param0);
                         result = param0CaseId;
                     } else {
                         result = 0;
                     }
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO(boxPtr, +isSome, result);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO(boxPtr, +isSome, result);
                     const tag = i32Stack.pop();
-                    const optResult = tag === -1 ? null : enumHelpers.APIResult.lift(tag);
+                    const optResult = tag === -1 ? null : enumHelpers.TestModule_APIResult.lift(tag);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -969,9 +943,9 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq9APIResultO_Sq9APIResultO);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq20TestModule_APIResultO_Sq20TestModule_APIResultO);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO"] = function(callbackId, param0IsSome, param0WrappedValue) {
+            bjs["invoke_js_callback_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO"] = function(callbackId, param0IsSome, param0WrappedValue) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
                     let ret = callback(param0IsSome ? param0WrappedValue : null);
@@ -981,10 +955,10 @@ export async function createInstantiator(options, swift) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO = function(param0) {
+            bjs["make_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO = function(param0) {
                     const isSome = param0 != null;
-                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO(boxPtr, +isSome, isSome ? param0 : 0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO(boxPtr, +isSome, isSome ? param0 : 0);
                     const optResult = tmpRetOptionalInt;
                     tmpRetOptionalInt = undefined;
                     if (tmpRetException) {
@@ -995,7 +969,33 @@ export async function createInstantiator(options, swift) {
                     }
                     return optResult;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq9DirectionO_Sq9DirectionO);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq20TestModule_DirectionO_Sq20TestModule_DirectionO);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO"] = function(callbackId, param0IsSome, param0WrappedValue) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    let ret = callback(param0IsSome ? param0WrappedValue : null);
+                    const isSome = ret != null;
+                    bjs["swift_js_return_optional_int"](isSome ? 1 : 0, isSome ? (ret | 0) : 0);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO = function(param0) {
+                    const isSome = param0 != null;
+                    instance.exports.invoke_swift_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO(boxPtr, +isSome, isSome ? param0 : 0);
+                    const optResult = tmpRetOptionalInt;
+                    tmpRetOptionalInt = undefined;
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                    return optResult;
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleSq21TestModule_HttpStatusO_Sq21TestModule_HttpStatusO);
             }
             bjs["invoke_js_callback_TestModule_10TestModuleSqSS_SqSS"] = function(callbackId, param0IsSome, param0Bytes, param0Count) {
                 try {
@@ -1168,15 +1168,15 @@ export async function createInstantiator(options, swift) {
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaKSS_SS);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleYaKSb_9APIResultO"] = function(resolveRef, rejectRef, callbackId, param0) {
+            bjs["invoke_js_callback_TestModule_10TestModuleYaKSb_20TestModule_APIResultO"] = function(resolveRef, rejectRef, callbackId, param0) {
                 const resolve = swift.memory.getObject(resolveRef);
                 const reject = swift.memory.getObject(rejectRef);
                 const callback = swift.memory.getObject(callbackId);
                 callback(param0 !== 0).then(resolve, reject);
             }
-            bjs["make_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleYaKSb_9APIResultO = function(param0) {
-                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleYaKSb_9APIResultO(boxPtr, param0);
+            bjs["make_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO = function(param0) {
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO(boxPtr, param0);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     if (tmpRetException) {
@@ -1187,25 +1187,25 @@ export async function createInstantiator(options, swift) {
                     }
                     return ret1;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaKSb_9APIResultO);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaKSb_20TestModule_APIResultO);
             }
-            bjs["invoke_js_callback_TestModule_10TestModuleYaSS_6AnimalV"] = function(resolveRef, rejectRef, callbackId, param0Bytes, param0Count) {
+            bjs["invoke_js_callback_TestModule_10TestModuleYaSS_17TestModule_AnimalV"] = function(resolveRef, rejectRef, callbackId, param0Bytes, param0Count) {
                 const resolve = swift.memory.getObject(resolveRef);
                 const reject = swift.memory.getObject(rejectRef);
                 const callback = swift.memory.getObject(callbackId);
                 const string = decodeString(param0Bytes, param0Count);
                 callback(string).then(resolve, reject);
             }
-            bjs["make_swift_closure_TestModule_10TestModuleYaSS_6AnimalV"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModuleYaSS_6AnimalV = function(param0) {
+            bjs["make_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV = function(param0) {
                     const param0Bytes = textEncoder.encode(param0);
                     const param0Id = swift.memory.retain(param0Bytes);
-                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleYaSS_6AnimalV(boxPtr, param0Id, param0Bytes.length);
+                    const ret = instance.exports.invoke_swift_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV(boxPtr, param0Id, param0Bytes.length);
                     const ret1 = swift.memory.getObject(ret);
                     swift.memory.release(ret);
                     return ret1;
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaSS_6AnimalV);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaSS_17TestModule_AnimalV);
             }
             bjs["invoke_js_callback_TestModule_10TestModuleYaSS_SS"] = function(resolveRef, rejectRef, callbackId, param0Bytes, param0Count) {
                 const resolve = swift.memory.getObject(resolveRef);
@@ -1225,19 +1225,19 @@ export async function createInstantiator(options, swift) {
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModuleYaSS_SS);
             }
-            bjs["invoke_js_callback_TestModule_10TestModules6AnimalV_y"] = function(callbackId) {
+            bjs["invoke_js_callback_TestModule_10TestModules17TestModule_AnimalV_y"] = function(callbackId) {
                 try {
                     const callback = swift.memory.getObject(callbackId);
-                    const structValue = structHelpers.Animal.lift();
+                    const structValue = structHelpers.TestModule_Animal.lift();
                     callback(structValue);
                 } catch (error) {
                     setException(error);
                 }
             }
-            bjs["make_swift_closure_TestModule_10TestModules6AnimalV_y"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModules6AnimalV_y = function(param0) {
-                    structHelpers.Animal.lower(param0);
-                    instance.exports.invoke_swift_closure_TestModule_10TestModules6AnimalV_y(boxPtr);
+            bjs["make_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModules17TestModule_AnimalV_y = function(param0) {
+                    structHelpers.TestModule_Animal.lower(param0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModules17TestModule_AnimalV_y(boxPtr);
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);
@@ -1245,7 +1245,29 @@ export async function createInstantiator(options, swift) {
                         throw error;
                     }
                 };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModules6AnimalV_y);
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModules17TestModule_AnimalV_y);
+            }
+            bjs["invoke_js_callback_TestModule_10TestModules20TestModule_APIResultO_y"] = function(callbackId, param0) {
+                try {
+                    const callback = swift.memory.getObject(callbackId);
+                    const enumValue = enumHelpers.TestModule_APIResult.lift(param0);
+                    callback(enumValue);
+                } catch (error) {
+                    setException(error);
+                }
+            }
+            bjs["make_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y"] = function(boxPtr, file, line) {
+                const lower_closure_TestModule_10TestModules20TestModule_APIResultO_y = function(param0) {
+                    const param0CaseId = enumHelpers.TestModule_APIResult.lower(param0);
+                    instance.exports.invoke_swift_closure_TestModule_10TestModules20TestModule_APIResultO_y(boxPtr, param0CaseId);
+                    if (tmpRetException) {
+                        const error = swift.memory.getObject(tmpRetException);
+                        swift.memory.release(tmpRetException);
+                        tmpRetException = undefined;
+                        throw error;
+                    }
+                };
+                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModules20TestModule_APIResultO_y);
             }
             bjs["invoke_js_callback_TestModule_10TestModules7JSValueV_y"] = function(callbackId, param0Kind, param0Payload1, param0Payload2) {
                 try {
@@ -1268,28 +1290,6 @@ export async function createInstantiator(options, swift) {
                     }
                 };
                 return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModules7JSValueV_y);
-            }
-            bjs["invoke_js_callback_TestModule_10TestModules9APIResultO_y"] = function(callbackId, param0) {
-                try {
-                    const callback = swift.memory.getObject(callbackId);
-                    const enumValue = enumHelpers.APIResult.lift(param0);
-                    callback(enumValue);
-                } catch (error) {
-                    setException(error);
-                }
-            }
-            bjs["make_swift_closure_TestModule_10TestModules9APIResultO_y"] = function(boxPtr, file, line) {
-                const lower_closure_TestModule_10TestModules9APIResultO_y = function(param0) {
-                    const param0CaseId = enumHelpers.APIResult.lower(param0);
-                    instance.exports.invoke_swift_closure_TestModule_10TestModules9APIResultO_y(boxPtr, param0CaseId);
-                    if (tmpRetException) {
-                        const error = swift.memory.getObject(tmpRetException);
-                        swift.memory.release(tmpRetException);
-                        tmpRetException = undefined;
-                        throw error;
-                    }
-                };
-                return makeClosure(boxPtr, file, line, lower_closure_TestModule_10TestModules9APIResultO_y);
             }
             bjs["invoke_js_callback_TestModule_10TestModulesSS_y"] = function(callbackId, param0Bytes, param0Count) {
                 try {
@@ -1318,11 +1318,11 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Person_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Person_wrap"] = function(pointer) {
                 const obj = _exports['Person'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
-            importObject["TestModule"]["bjs_TestProcessor_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_TestProcessor_wrap"] = function(pointer) {
                 const obj = _exports['TestProcessor'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -1394,171 +1394,171 @@ export async function createInstantiator(options, swift) {
             }
             class Person extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Person_deinit, Person.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Person_deinit, Person.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_Person_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_Person_init(nameId, nameBytes.length);
                     return Person.__construct(ret);
                 }
             }
             class TestProcessor extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestProcessor_deinit, TestProcessor.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_TestProcessor_deinit, TestProcessor.prototype, null);
                 }
 
                 constructor(transform) {
                     const callbackId = swift.memory.retain(transform);
-                    const ret = instance.exports.bjs_TestProcessor_init(callbackId);
+                    const ret = instance.exports.bjs_TestModule_TestProcessor_init(callbackId);
                     return TestProcessor.__construct(ret);
                 }
             }
-            const AnimalHelpers = __bjs_createAnimalHelpers();
-            structHelpers.Animal = AnimalHelpers;
+            const TestModule_AnimalHelpers = __bjs_createTestModule_AnimalHelpers();
+            structHelpers.TestModule_Animal = TestModule_AnimalHelpers;
 
-            const APIResultHelpers = __bjs_createAPIResultValuesHelpers();
-            enumHelpers.APIResult = APIResultHelpers;
+            const TestModule_APIResultHelpers = __bjs_createTestModule_APIResultHelpers();
+            enumHelpers.TestModule_APIResult = TestModule_APIResultHelpers;
 
             const exports = {
-                roundtripAnimal: function bjs_roundtripAnimal(animalClosure) {
+                roundtripAnimal: function bjs_TestModule_roundtripAnimal(animalClosure) {
                     const callbackId = swift.memory.retain(animalClosure);
-                    const ret = instance.exports.bjs_roundtripAnimal(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripAnimal(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalAnimal: function bjs_roundtripOptionalAnimal(animalClosure) {
+                roundtripOptionalAnimal: function bjs_TestModule_roundtripOptionalAnimal(animalClosure) {
                     const callbackId = swift.memory.retain(animalClosure);
-                    const ret = instance.exports.bjs_roundtripOptionalAnimal(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalAnimal(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripString: function bjs_roundtripString(stringClosure) {
+                roundtripString: function bjs_TestModule_roundtripString(stringClosure) {
                     const callbackId = swift.memory.retain(stringClosure);
-                    const ret = instance.exports.bjs_roundtripString(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripString(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripInt: function bjs_roundtripInt(intClosure) {
+                roundtripInt: function bjs_TestModule_roundtripInt(intClosure) {
                     const callbackId = swift.memory.retain(intClosure);
-                    const ret = instance.exports.bjs_roundtripInt(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripInt(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripBool: function bjs_roundtripBool(boolClosure) {
+                roundtripBool: function bjs_TestModule_roundtripBool(boolClosure) {
                     const callbackId = swift.memory.retain(boolClosure);
-                    const ret = instance.exports.bjs_roundtripBool(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripBool(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripFloat: function bjs_roundtripFloat(floatClosure) {
+                roundtripFloat: function bjs_TestModule_roundtripFloat(floatClosure) {
                     const callbackId = swift.memory.retain(floatClosure);
-                    const ret = instance.exports.bjs_roundtripFloat(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripFloat(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripDouble: function bjs_roundtripDouble(doubleClosure) {
+                roundtripDouble: function bjs_TestModule_roundtripDouble(doubleClosure) {
                     const callbackId = swift.memory.retain(doubleClosure);
-                    const ret = instance.exports.bjs_roundtripDouble(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripDouble(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalString: function bjs_roundtripOptionalString(stringClosure) {
+                roundtripOptionalString: function bjs_TestModule_roundtripOptionalString(stringClosure) {
                     const callbackId = swift.memory.retain(stringClosure);
-                    const ret = instance.exports.bjs_roundtripOptionalString(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalString(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalInt: function bjs_roundtripOptionalInt(intClosure) {
+                roundtripOptionalInt: function bjs_TestModule_roundtripOptionalInt(intClosure) {
                     const callbackId = swift.memory.retain(intClosure);
-                    const ret = instance.exports.bjs_roundtripOptionalInt(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalInt(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalBool: function bjs_roundtripOptionalBool(boolClosure) {
+                roundtripOptionalBool: function bjs_TestModule_roundtripOptionalBool(boolClosure) {
                     const callbackId = swift.memory.retain(boolClosure);
-                    const ret = instance.exports.bjs_roundtripOptionalBool(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalBool(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalFloat: function bjs_roundtripOptionalFloat(floatClosure) {
+                roundtripOptionalFloat: function bjs_TestModule_roundtripOptionalFloat(floatClosure) {
                     const callbackId = swift.memory.retain(floatClosure);
-                    const ret = instance.exports.bjs_roundtripOptionalFloat(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalFloat(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalDouble: function bjs_roundtripOptionalDouble(doubleClosure) {
+                roundtripOptionalDouble: function bjs_TestModule_roundtripOptionalDouble(doubleClosure) {
                     const callbackId = swift.memory.retain(doubleClosure);
-                    const ret = instance.exports.bjs_roundtripOptionalDouble(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalDouble(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripPerson: function bjs_roundtripPerson(personClosure) {
+                roundtripPerson: function bjs_TestModule_roundtripPerson(personClosure) {
                     const callbackId = swift.memory.retain(personClosure);
-                    const ret = instance.exports.bjs_roundtripPerson(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripPerson(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalPerson: function bjs_roundtripOptionalPerson(personClosure) {
+                roundtripOptionalPerson: function bjs_TestModule_roundtripOptionalPerson(personClosure) {
                     const callbackId = swift.memory.retain(personClosure);
-                    const ret = instance.exports.bjs_roundtripOptionalPerson(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalPerson(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                makeThrowingParser: function bjs_makeThrowingParser() {
-                    const ret = instance.exports.bjs_makeThrowingParser();
+                makeThrowingParser: function bjs_TestModule_makeThrowingParser() {
+                    const ret = instance.exports.bjs_TestModule_makeThrowingParser();
                     return swift.memory.getObject(ret);
                 },
-                validateWith: function bjs_validateWith(validate) {
+                validateWith: function bjs_TestModule_validateWith(validate) {
                     const callbackId = swift.memory.retain(validate);
-                    instance.exports.bjs_validateWith(callbackId);
+                    instance.exports.bjs_TestModule_validateWith(callbackId);
                 },
-                makeFetcher: function bjs_makeFetcher() {
-                    const ret = instance.exports.bjs_makeFetcher();
+                makeFetcher: function bjs_TestModule_makeFetcher() {
+                    const ret = instance.exports.bjs_TestModule_makeFetcher();
                     return swift.memory.getObject(ret);
                 },
-                makeAsyncEcho: function bjs_makeAsyncEcho() {
-                    const ret = instance.exports.bjs_makeAsyncEcho();
+                makeAsyncEcho: function bjs_TestModule_makeAsyncEcho() {
+                    const ret = instance.exports.bjs_TestModule_makeAsyncEcho();
                     return swift.memory.getObject(ret);
                 },
-                makeAnimalLoader: function bjs_makeAnimalLoader() {
-                    const ret = instance.exports.bjs_makeAnimalLoader();
+                makeAnimalLoader: function bjs_TestModule_makeAnimalLoader() {
+                    const ret = instance.exports.bjs_TestModule_makeAnimalLoader();
                     return swift.memory.getObject(ret);
                 },
-                makeResultLoader: function bjs_makeResultLoader() {
-                    const ret = instance.exports.bjs_makeResultLoader();
+                makeResultLoader: function bjs_TestModule_makeResultLoader() {
+                    const ret = instance.exports.bjs_TestModule_makeResultLoader();
                     return swift.memory.getObject(ret);
                 },
-                roundtripDirection: function bjs_roundtripDirection(callback) {
+                roundtripDirection: function bjs_TestModule_roundtripDirection(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripDirection(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripDirection(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripTheme: function bjs_roundtripTheme(callback) {
+                roundtripTheme: function bjs_TestModule_roundtripTheme(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripTheme(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripTheme(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripHttpStatus: function bjs_roundtripHttpStatus(callback) {
+                roundtripHttpStatus: function bjs_TestModule_roundtripHttpStatus(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripHttpStatus(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripHttpStatus(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripAPIResult: function bjs_roundtripAPIResult(callback) {
+                roundtripAPIResult: function bjs_TestModule_roundtripAPIResult(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripAPIResult(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripAPIResult(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalDirection: function bjs_roundtripOptionalDirection(callback) {
+                roundtripOptionalDirection: function bjs_TestModule_roundtripOptionalDirection(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripOptionalDirection(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalDirection(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalTheme: function bjs_roundtripOptionalTheme(callback) {
+                roundtripOptionalTheme: function bjs_TestModule_roundtripOptionalTheme(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripOptionalTheme(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalTheme(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalHttpStatus: function bjs_roundtripOptionalHttpStatus(callback) {
+                roundtripOptionalHttpStatus: function bjs_TestModule_roundtripOptionalHttpStatus(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripOptionalHttpStatus(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalHttpStatus(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalAPIResult: function bjs_roundtripOptionalAPIResult(callback) {
+                roundtripOptionalAPIResult: function bjs_TestModule_roundtripOptionalAPIResult(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripOptionalAPIResult(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalAPIResult(callbackId);
                     return swift.memory.getObject(ret);
                 },
-                roundtripOptionalDirection: function bjs_roundtripOptionalDirection(callback) {
+                roundtripOptionalDirection: function bjs_TestModule_roundtripOptionalDirection(callback) {
                     const callbackId = swift.memory.retain(callback);
-                    const ret = instance.exports.bjs_roundtripOptionalDirection(callbackId);
+                    const ret = instance.exports.bjs_TestModule_roundtripOptionalDirection(callbackId);
                     return swift.memory.getObject(ret);
                 },
                 Direction: DirectionValues,
@@ -1569,8 +1569,8 @@ export async function createInstantiator(options, swift) {
                     init: function(type) {
                         const typeBytes = textEncoder.encode(type);
                         const typeId = swift.memory.retain(typeBytes);
-                        instance.exports.bjs_Animal_init(typeId, typeBytes.length);
-                        const structValue = structHelpers.Animal.lift();
+                        instance.exports.bjs_TestModule_Animal_init(typeId, typeBytes.length);
+                        const structValue = structHelpers.TestModule_Animal.lift();
                         return structValue;
                     },
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftClosureImports.js
@@ -493,13 +493,13 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                runValidator: function bjs_runValidator(cb) {
+                runValidator: function bjs_TestModule_runValidator(cb) {
                     const callbackId = swift.memory.retain(cb);
-                    instance.exports.bjs_runValidator(callbackId);
+                    instance.exports.bjs_TestModule_runValidator(callbackId);
                 },
-                loadEach: function bjs_loadEach(fetch) {
+                loadEach: function bjs_TestModule_loadEach(fetch) {
                     const callbackId = swift.memory.retain(fetch);
-                    instance.exports.bjs_loadEach(callbackId);
+                    instance.exports.bjs_TestModule_loadEach(callbackId);
                 },
             };
             _exports = exports;

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStruct.js
@@ -36,7 +36,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createDataPointHelpers = () => ({
+    const __bjs_createTestModule_DataPointHelpers = () => ({
         lower: (value) => {
             f64Stack.push(value.x);
             f64Stack.push(value.y);
@@ -78,7 +78,7 @@ export async function createInstantiator(options, swift) {
             return { x: f641, y: f64, label: string, optCount: optValue1, optFlag: optValue };
         }
     });
-    const __bjs_createAddressHelpers = () => ({
+    const __bjs_createTestModule_AddressHelpers = () => ({
         lower: (value) => {
             const bytes = textEncoder.encode(value.street);
             const id = swift.memory.retain(bytes);
@@ -108,14 +108,14 @@ export async function createInstantiator(options, swift) {
             return { street: string1, city: string, zipCode: optValue };
         }
     });
-    const __bjs_createPersonHelpers = () => ({
+    const __bjs_createTestModule_PersonHelpers = () => ({
         lower: (value) => {
             const bytes = textEncoder.encode(value.name);
             const id = swift.memory.retain(bytes);
             i32Stack.push(bytes.length);
             i32Stack.push(id);
             i32Stack.push((value.age | 0));
-            structHelpers.Address.lower(value.address);
+            structHelpers.TestModule_Address.lower(value.address);
             const isSome = value.email != null ? 1 : 0;
             if (isSome) {
                 const bytes1 = textEncoder.encode(value.email);
@@ -134,13 +134,13 @@ export async function createInstantiator(options, swift) {
                 const string = strStack.pop();
                 optValue = string;
             }
-            const struct = structHelpers.Address.lift();
+            const struct = structHelpers.TestModule_Address.lift();
             const int = i32Stack.pop();
             const string1 = strStack.pop();
             return { name: string1, age: int, address: struct, email: optValue };
         }
     });
-    const __bjs_createSessionHelpers = () => ({
+    const __bjs_createTestModule_SessionHelpers = () => ({
         lower: (value) => {
             i32Stack.push((value.id | 0));
             ptrStack.push(value.owner.pointer);
@@ -152,7 +152,7 @@ export async function createInstantiator(options, swift) {
             return { id: int, owner: obj };
         }
     });
-    const __bjs_createMeasurementHelpers = () => ({
+    const __bjs_createTestModule_MeasurementHelpers = () => ({
         lower: (value) => {
             f64Stack.push(value.value);
             f32Stack.push(Math.fround(value.precision));
@@ -176,14 +176,14 @@ export async function createInstantiator(options, swift) {
             return { value: f64, precision: rawValue1, optionalPrecision: optValue };
         }
     });
-    const __bjs_createConfigStructHelpers = () => ({
+    const __bjs_createTestModule_ConfigStructHelpers = () => ({
         lower: (value) => {
         },
         lift: () => {
             return {  };
         }
     });
-    const __bjs_createContainerHelpers = () => ({
+    const __bjs_createTestModule_ContainerHelpers = () => ({
         lower: (value) => {
             let id;
             if (value.object != null) {
@@ -221,7 +221,7 @@ export async function createInstantiator(options, swift) {
             return { object: value, optionalObject: optValue };
         }
     });
-    const __bjs_createVector2DHelpers = () => ({
+    const __bjs_createTestModule_Vector2DHelpers = () => ({
         lower: (value) => {
             f64Stack.push(value.dx);
             f64Stack.push(value.dy);
@@ -231,14 +231,14 @@ export async function createInstantiator(options, swift) {
             const f641 = f64Stack.pop();
             const instance1 = { dx: f641, dy: f64 };
             instance1.magnitude = function() {
-                structHelpers.Vector2D.lower(this);
-                const ret = instance.exports.bjs_Vector2D_magnitude();
+                structHelpers.TestModule_Vector2D.lower(this);
+                const ret = instance.exports.bjs_TestModule_Vector2D_magnitude();
                 return ret;
             }.bind(instance1);
             instance1.scaled = function(factor) {
-                structHelpers.Vector2D.lower(this);
-                const ret = instance.exports.bjs_Vector2D_scaled(factor);
-                const structValue = structHelpers.Vector2D.lift();
+                structHelpers.TestModule_Vector2D.lower(this);
+                const ret = instance.exports.bjs_TestModule_Vector2D_scaled(factor);
+                const structValue = structHelpers.TestModule_Vector2D.lift();
                 return structValue;
             }.bind(instance1);
             return instance1;
@@ -319,60 +319,60 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_DataPoint"] = function(objectId) {
-                structHelpers.DataPoint.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_DataPoint"] = function(objectId) {
+                structHelpers.TestModule_DataPoint.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_DataPoint"] = function() {
-                const value = structHelpers.DataPoint.lift();
+            bjs["swift_js_struct_lift_TestModule_DataPoint"] = function() {
+                const value = structHelpers.TestModule_DataPoint.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Address"] = function(objectId) {
-                structHelpers.Address.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Address"] = function(objectId) {
+                structHelpers.TestModule_Address.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Address"] = function() {
-                const value = structHelpers.Address.lift();
+            bjs["swift_js_struct_lift_TestModule_Address"] = function() {
+                const value = structHelpers.TestModule_Address.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Person"] = function(objectId) {
-                structHelpers.Person.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Person"] = function(objectId) {
+                structHelpers.TestModule_Person.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Person"] = function() {
-                const value = structHelpers.Person.lift();
+            bjs["swift_js_struct_lift_TestModule_Person"] = function() {
+                const value = structHelpers.TestModule_Person.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Session"] = function(objectId) {
-                structHelpers.Session.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Session"] = function(objectId) {
+                structHelpers.TestModule_Session.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Session"] = function() {
-                const value = structHelpers.Session.lift();
+            bjs["swift_js_struct_lift_TestModule_Session"] = function() {
+                const value = structHelpers.TestModule_Session.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Measurement"] = function(objectId) {
-                structHelpers.Measurement.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Measurement"] = function(objectId) {
+                structHelpers.TestModule_Measurement.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Measurement"] = function() {
-                const value = structHelpers.Measurement.lift();
+            bjs["swift_js_struct_lift_TestModule_Measurement"] = function() {
+                const value = structHelpers.TestModule_Measurement.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_ConfigStruct"] = function(objectId) {
-                structHelpers.ConfigStruct.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_ConfigStruct"] = function(objectId) {
+                structHelpers.TestModule_ConfigStruct.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_ConfigStruct"] = function() {
-                const value = structHelpers.ConfigStruct.lift();
+            bjs["swift_js_struct_lift_TestModule_ConfigStruct"] = function() {
+                const value = structHelpers.TestModule_ConfigStruct.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Container"] = function(objectId) {
-                structHelpers.Container.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Container"] = function(objectId) {
+                structHelpers.TestModule_Container.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Container"] = function() {
-                const value = structHelpers.Container.lift();
+            bjs["swift_js_struct_lift_TestModule_Container"] = function() {
+                const value = structHelpers.TestModule_Container.lift();
                 return swift.memory.retain(value);
             }
-            bjs["swift_js_struct_lower_Vector2D"] = function(objectId) {
-                structHelpers.Vector2D.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Vector2D"] = function(objectId) {
+                structHelpers.TestModule_Vector2D.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Vector2D"] = function() {
-                const value = structHelpers.Vector2D.lift();
+            bjs["swift_js_struct_lift_TestModule_Vector2D"] = function() {
+                const value = structHelpers.TestModule_Vector2D.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -476,7 +476,7 @@ export async function createInstantiator(options, swift) {
             if (!importObject["TestModule"]) {
                 importObject["TestModule"] = {};
             }
-            importObject["TestModule"]["bjs_Greeter_wrap"] = function(pointer) {
+            importObject["TestModule"]["bjs_TestModule_Greeter_wrap"] = function(pointer) {
                 const obj = _exports['Greeter'].__construct(pointer);
                 return swift.memory.retain(obj);
             };
@@ -548,23 +548,23 @@ export async function createInstantiator(options, swift) {
             }
             class Greeter extends SwiftHeapObject {
                 static __construct(ptr) {
-                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_Greeter_deinit, Greeter.prototype, null);
+                    return SwiftHeapObject.__wrap(ptr, instance.exports.bjs_TestModule_Greeter_deinit, Greeter.prototype, null);
                 }
 
                 constructor(name) {
                     const nameBytes = textEncoder.encode(name);
                     const nameId = swift.memory.retain(nameBytes);
-                    const ret = instance.exports.bjs_Greeter_init(nameId, nameBytes.length);
+                    const ret = instance.exports.bjs_TestModule_Greeter_init(nameId, nameBytes.length);
                     return Greeter.__construct(ret);
                 }
                 greet() {
-                    instance.exports.bjs_Greeter_greet(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_greet(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
                 }
                 get name() {
-                    instance.exports.bjs_Greeter_name_get(this.pointer);
+                    instance.exports.bjs_TestModule_Greeter_name_get(this.pointer);
                     const ret = tmpRetString;
                     tmpRetString = undefined;
                     return ret;
@@ -572,54 +572,54 @@ export async function createInstantiator(options, swift) {
                 set name(value) {
                     const valueBytes = textEncoder.encode(value);
                     const valueId = swift.memory.retain(valueBytes);
-                    instance.exports.bjs_Greeter_name_set(this.pointer, valueId, valueBytes.length);
+                    instance.exports.bjs_TestModule_Greeter_name_set(this.pointer, valueId, valueBytes.length);
                 }
             }
-            const DataPointHelpers = __bjs_createDataPointHelpers();
-            structHelpers.DataPoint = DataPointHelpers;
+            const TestModule_DataPointHelpers = __bjs_createTestModule_DataPointHelpers();
+            structHelpers.TestModule_DataPoint = TestModule_DataPointHelpers;
 
-            const AddressHelpers = __bjs_createAddressHelpers();
-            structHelpers.Address = AddressHelpers;
+            const TestModule_AddressHelpers = __bjs_createTestModule_AddressHelpers();
+            structHelpers.TestModule_Address = TestModule_AddressHelpers;
 
-            const PersonHelpers = __bjs_createPersonHelpers();
-            structHelpers.Person = PersonHelpers;
+            const TestModule_PersonHelpers = __bjs_createTestModule_PersonHelpers();
+            structHelpers.TestModule_Person = TestModule_PersonHelpers;
 
-            const SessionHelpers = __bjs_createSessionHelpers();
-            structHelpers.Session = SessionHelpers;
+            const TestModule_SessionHelpers = __bjs_createTestModule_SessionHelpers();
+            structHelpers.TestModule_Session = TestModule_SessionHelpers;
 
-            const MeasurementHelpers = __bjs_createMeasurementHelpers();
-            structHelpers.Measurement = MeasurementHelpers;
+            const TestModule_MeasurementHelpers = __bjs_createTestModule_MeasurementHelpers();
+            structHelpers.TestModule_Measurement = TestModule_MeasurementHelpers;
 
-            const ConfigStructHelpers = __bjs_createConfigStructHelpers();
-            structHelpers.ConfigStruct = ConfigStructHelpers;
+            const TestModule_ConfigStructHelpers = __bjs_createTestModule_ConfigStructHelpers();
+            structHelpers.TestModule_ConfigStruct = TestModule_ConfigStructHelpers;
 
-            const ContainerHelpers = __bjs_createContainerHelpers();
-            structHelpers.Container = ContainerHelpers;
+            const TestModule_ContainerHelpers = __bjs_createTestModule_ContainerHelpers();
+            structHelpers.TestModule_Container = TestModule_ContainerHelpers;
 
-            const Vector2DHelpers = __bjs_createVector2DHelpers();
-            structHelpers.Vector2D = Vector2DHelpers;
+            const TestModule_Vector2DHelpers = __bjs_createTestModule_Vector2DHelpers();
+            structHelpers.TestModule_Vector2D = TestModule_Vector2DHelpers;
 
             const exports = {
-                roundtrip: function bjs_roundtrip(session) {
-                    structHelpers.Person.lower(session);
-                    instance.exports.bjs_roundtrip();
-                    const structValue = structHelpers.Person.lift();
+                roundtrip: function bjs_TestModule_roundtrip(session) {
+                    structHelpers.TestModule_Person.lower(session);
+                    instance.exports.bjs_TestModule_roundtrip();
+                    const structValue = structHelpers.TestModule_Person.lift();
                     return structValue;
                 },
-                roundtripContainer: function bjs_roundtripContainer(container) {
-                    structHelpers.Container.lower(container);
-                    instance.exports.bjs_roundtripContainer();
-                    const structValue = structHelpers.Container.lift();
+                roundtripContainer: function bjs_TestModule_roundtripContainer(container) {
+                    structHelpers.TestModule_Container.lower(container);
+                    instance.exports.bjs_TestModule_roundtripContainer();
+                    const structValue = structHelpers.TestModule_Container.lift();
                     return structValue;
                 },
                 Precision: PrecisionValues,
                 ConfigStruct: {
                     get maxRetries() {
-                        const ret = instance.exports.bjs_ConfigStruct_static_maxRetries_get();
+                        const ret = instance.exports.bjs_TestModule_ConfigStruct_static_maxRetries_get();
                         return ret;
                     },
                     get defaultConfig() {
-                        instance.exports.bjs_ConfigStruct_static_defaultConfig_get();
+                        instance.exports.bjs_TestModule_ConfigStruct_static_defaultConfig_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
@@ -627,23 +627,23 @@ export async function createInstantiator(options, swift) {
                     set defaultConfig(value) {
                         const valueBytes = textEncoder.encode(value);
                         const valueId = swift.memory.retain(valueBytes);
-                        instance.exports.bjs_ConfigStruct_static_defaultConfig_set(valueId, valueBytes.length);
+                        instance.exports.bjs_TestModule_ConfigStruct_static_defaultConfig_set(valueId, valueBytes.length);
                     },
                     get timeout() {
-                        const ret = instance.exports.bjs_ConfigStruct_static_timeout_get();
+                        const ret = instance.exports.bjs_TestModule_ConfigStruct_static_timeout_get();
                         return ret;
                     },
                     set timeout(value) {
-                        instance.exports.bjs_ConfigStruct_static_timeout_set(value);
+                        instance.exports.bjs_TestModule_ConfigStruct_static_timeout_set(value);
                     },
                     get computedSetting() {
-                        instance.exports.bjs_ConfigStruct_static_computedSetting_get();
+                        instance.exports.bjs_TestModule_ConfigStruct_static_computedSetting_get();
                         const ret = tmpRetString;
                         tmpRetString = undefined;
                         return ret;
                     },
                     update: function(timeout) {
-                        const ret = instance.exports.bjs_ConfigStruct_static_update(timeout);
+                        const ret = instance.exports.bjs_TestModule_ConfigStruct_static_update(timeout);
                         return ret;
                     },
                 },
@@ -653,17 +653,17 @@ export async function createInstantiator(options, swift) {
                         const labelId = swift.memory.retain(labelBytes);
                         const isSome = optCount != null;
                         const isSome1 = optFlag != null;
-                        instance.exports.bjs_DataPoint_init(x, y, labelId, labelBytes.length, +isSome, isSome ? optCount : 0, +isSome1, isSome1 ? optFlag ? 1 : 0 : 0);
-                        const structValue = structHelpers.DataPoint.lift();
+                        instance.exports.bjs_TestModule_DataPoint_init(x, y, labelId, labelBytes.length, +isSome, isSome ? optCount : 0, +isSome1, isSome1 ? optFlag ? 1 : 0 : 0);
+                        const structValue = structHelpers.TestModule_DataPoint.lift();
                         return structValue;
                     },
                     get dimensions() {
-                        const ret = instance.exports.bjs_DataPoint_static_dimensions_get();
+                        const ret = instance.exports.bjs_TestModule_DataPoint_static_dimensions_get();
                         return ret;
                     },
                     origin: function() {
-                        instance.exports.bjs_DataPoint_static_origin();
-                        const structValue = structHelpers.DataPoint.lift();
+                        instance.exports.bjs_TestModule_DataPoint_static_origin();
+                        const structValue = structHelpers.TestModule_DataPoint.lift();
                         return structValue;
                     },
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/SwiftStructImports.js
@@ -31,7 +31,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createPointHelpers = () => ({
+    const __bjs_createTestModule_PointHelpers = () => ({
         lower: (value) => {
             i32Stack.push((value.x | 0));
             i32Stack.push((value.y | 0));
@@ -118,11 +118,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_Point"] = function(objectId) {
-                structHelpers.Point.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_Point"] = function(objectId) {
+                structHelpers.TestModule_Point.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_Point"] = function() {
-                const value = structHelpers.Point.lift();
+            bjs["swift_js_struct_lift_TestModule_Point"] = function() {
+                const value = structHelpers.TestModule_Point.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -237,7 +237,7 @@ export async function createInstantiator(options, swift) {
                 try {
                     let optResult;
                     if (point) {
-                        const struct = structHelpers.Point.lift();
+                        const struct = structHelpers.TestModule_Point.lift();
                         optResult = struct;
                     } else {
                         optResult = null;
@@ -245,7 +245,7 @@ export async function createInstantiator(options, swift) {
                     let ret = imports.roundTripOptional(optResult);
                     const isSome = ret != null;
                     if (isSome) {
-                        structHelpers.Point.lower(ret);
+                        structHelpers.TestModule_Point.lower(ret);
                     }
                     i32Stack.push(isSome ? 1 : 0);
                 } catch (error) {
@@ -266,8 +266,8 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const PointHelpers = __bjs_createPointHelpers();
-            structHelpers.Point = PointHelpers;
+            const TestModule_PointHelpers = __bjs_createTestModule_PointHelpers();
+            structHelpers.TestModule_Point = TestModule_PointHelpers;
 
             const exports = {
             };

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/Throws.js
@@ -218,8 +218,8 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                throwsSomething: function bjs_throwsSomething() {
-                    instance.exports.bjs_throwsSomething();
+                throwsSomething: function bjs_TestModule_throwsSomething() {
+                    instance.exports.bjs_TestModule_throwsSomething();
                     if (tmpRetException) {
                         const error = swift.memory.getObject(tmpRetException);
                         swift.memory.release(tmpRetException);

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/UnsafePointer.js
@@ -31,7 +31,7 @@ export async function createInstantiator(options, swift) {
 
     let _exports = null;
     let bjs = null;
-    const __bjs_createPointerFieldsHelpers = () => ({
+    const __bjs_createTestModule_PointerFieldsHelpers = () => ({
         lower: (value) => {
             ptrStack.push((value.raw | 0));
             ptrStack.push((value.mutRaw | 0));
@@ -123,11 +123,11 @@ export async function createInstantiator(options, swift) {
                 const copy = memory.buffer.slice(ptr, ptr + byteLen);
                 taStack.push(Array.from(new Ctor(copy)));
             }
-            bjs["swift_js_struct_lower_PointerFields"] = function(objectId) {
-                structHelpers.PointerFields.lower(swift.memory.getObject(objectId));
+            bjs["swift_js_struct_lower_TestModule_PointerFields"] = function(objectId) {
+                structHelpers.TestModule_PointerFields.lower(swift.memory.getObject(objectId));
             }
-            bjs["swift_js_struct_lift_PointerFields"] = function() {
-                const value = structHelpers.PointerFields.lift();
+            bjs["swift_js_struct_lift_TestModule_PointerFields"] = function() {
+                const value = structHelpers.TestModule_PointerFields.lift();
                 return swift.memory.retain(value);
             }
             const __bjs_promiseSettlers = Symbol("JavaScriptKit.promiseSettlers");
@@ -241,55 +241,55 @@ export async function createInstantiator(options, swift) {
         /** @param {WebAssembly.Instance} instance */
         createExports: (instance) => {
             const js = swift.memory.heap;
-            const PointerFieldsHelpers = __bjs_createPointerFieldsHelpers();
-            structHelpers.PointerFields = PointerFieldsHelpers;
+            const TestModule_PointerFieldsHelpers = __bjs_createTestModule_PointerFieldsHelpers();
+            structHelpers.TestModule_PointerFields = TestModule_PointerFieldsHelpers;
 
             const exports = {
-                takeUnsafeRawPointer: function bjs_takeUnsafeRawPointer(p) {
-                    instance.exports.bjs_takeUnsafeRawPointer(p);
+                takeUnsafeRawPointer: function bjs_TestModule_takeUnsafeRawPointer(p) {
+                    instance.exports.bjs_TestModule_takeUnsafeRawPointer(p);
                 },
-                takeUnsafeMutableRawPointer: function bjs_takeUnsafeMutableRawPointer(p) {
-                    instance.exports.bjs_takeUnsafeMutableRawPointer(p);
+                takeUnsafeMutableRawPointer: function bjs_TestModule_takeUnsafeMutableRawPointer(p) {
+                    instance.exports.bjs_TestModule_takeUnsafeMutableRawPointer(p);
                 },
-                takeOpaquePointer: function bjs_takeOpaquePointer(p) {
-                    instance.exports.bjs_takeOpaquePointer(p);
+                takeOpaquePointer: function bjs_TestModule_takeOpaquePointer(p) {
+                    instance.exports.bjs_TestModule_takeOpaquePointer(p);
                 },
-                takeUnsafePointer: function bjs_takeUnsafePointer(p) {
-                    instance.exports.bjs_takeUnsafePointer(p);
+                takeUnsafePointer: function bjs_TestModule_takeUnsafePointer(p) {
+                    instance.exports.bjs_TestModule_takeUnsafePointer(p);
                 },
-                takeUnsafeMutablePointer: function bjs_takeUnsafeMutablePointer(p) {
-                    instance.exports.bjs_takeUnsafeMutablePointer(p);
+                takeUnsafeMutablePointer: function bjs_TestModule_takeUnsafeMutablePointer(p) {
+                    instance.exports.bjs_TestModule_takeUnsafeMutablePointer(p);
                 },
-                returnUnsafeRawPointer: function bjs_returnUnsafeRawPointer() {
-                    const ret = instance.exports.bjs_returnUnsafeRawPointer();
+                returnUnsafeRawPointer: function bjs_TestModule_returnUnsafeRawPointer() {
+                    const ret = instance.exports.bjs_TestModule_returnUnsafeRawPointer();
                     return ret;
                 },
-                returnUnsafeMutableRawPointer: function bjs_returnUnsafeMutableRawPointer() {
-                    const ret = instance.exports.bjs_returnUnsafeMutableRawPointer();
+                returnUnsafeMutableRawPointer: function bjs_TestModule_returnUnsafeMutableRawPointer() {
+                    const ret = instance.exports.bjs_TestModule_returnUnsafeMutableRawPointer();
                     return ret;
                 },
-                returnOpaquePointer: function bjs_returnOpaquePointer() {
-                    const ret = instance.exports.bjs_returnOpaquePointer();
+                returnOpaquePointer: function bjs_TestModule_returnOpaquePointer() {
+                    const ret = instance.exports.bjs_TestModule_returnOpaquePointer();
                     return ret;
                 },
-                returnUnsafePointer: function bjs_returnUnsafePointer() {
-                    const ret = instance.exports.bjs_returnUnsafePointer();
+                returnUnsafePointer: function bjs_TestModule_returnUnsafePointer() {
+                    const ret = instance.exports.bjs_TestModule_returnUnsafePointer();
                     return ret;
                 },
-                returnUnsafeMutablePointer: function bjs_returnUnsafeMutablePointer() {
-                    const ret = instance.exports.bjs_returnUnsafeMutablePointer();
+                returnUnsafeMutablePointer: function bjs_TestModule_returnUnsafeMutablePointer() {
+                    const ret = instance.exports.bjs_TestModule_returnUnsafeMutablePointer();
                     return ret;
                 },
-                roundTripPointerFields: function bjs_roundTripPointerFields(value) {
-                    structHelpers.PointerFields.lower(value);
-                    instance.exports.bjs_roundTripPointerFields();
-                    const structValue = structHelpers.PointerFields.lift();
+                roundTripPointerFields: function bjs_TestModule_roundTripPointerFields(value) {
+                    structHelpers.TestModule_PointerFields.lower(value);
+                    instance.exports.bjs_TestModule_roundTripPointerFields();
+                    const structValue = structHelpers.TestModule_PointerFields.lift();
                     return structValue;
                 },
                 PointerFields: {
                     init: function(raw, mutRaw, opaque, ptr, mutPtr) {
-                        instance.exports.bjs_PointerFields_init(raw, mutRaw, opaque, ptr, mutPtr);
-                        const structValue = structHelpers.PointerFields.lift();
+                        instance.exports.bjs_TestModule_PointerFields_init(raw, mutRaw, opaque, ptr, mutPtr);
+                        const structValue = structHelpers.TestModule_PointerFields.lift();
                         return structValue;
                     },
                 },

--- a/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
+++ b/Plugins/BridgeJS/Tests/BridgeJSToolTests/__Snapshots__/BridgeJSLinkTests/VoidParameterVoidReturn.js
@@ -227,8 +227,8 @@ export async function createInstantiator(options, swift) {
         createExports: (instance) => {
             const js = swift.memory.heap;
             const exports = {
-                check: function bjs_check() {
-                    instance.exports.bjs_check();
+                check: function bjs_TestModule_check() {
+                    instance.exports.bjs_TestModule_check();
                 },
             };
             _exports = exports;

--- a/Tests/BridgeJSGlobalTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSGlobalTests/Generated/BridgeJS.swift
@@ -8,15 +8,15 @@
 
 @_spi(BridgeJS) import JavaScriptKit
 
-extension GlobalNetworking.API.CallMethod: _BridgedSwiftCaseEnum {
+extension BridgeJSGlobalTests.GlobalNetworking.API.CallMethod: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> GlobalNetworking.API.CallMethod {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSGlobalTests.GlobalNetworking.API.CallMethod {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> GlobalNetworking.API.CallMethod {
-        return GlobalNetworking.API.CallMethod(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSGlobalTests.GlobalNetworking.API.CallMethod {
+        return BridgeJSGlobalTests.GlobalNetworking.API.CallMethod(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -51,21 +51,21 @@ extension GlobalNetworking.API.CallMethod: _BridgedSwiftCaseEnum {
     }
 }
 
-extension GlobalConfiguration.PublicLogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSGlobalTests.GlobalConfiguration.PublicLogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension GlobalConfiguration.AvailablePort: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSGlobalTests.GlobalConfiguration.AvailablePort: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Internal.SupportedServerMethod: _BridgedSwiftCaseEnum {
+extension BridgeJSGlobalTests.Internal.SupportedServerMethod: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Internal.SupportedServerMethod {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSGlobalTests.Internal.SupportedServerMethod {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Internal.SupportedServerMethod {
-        return Internal.SupportedServerMethod(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSGlobalTests.Internal.SupportedServerMethod {
+        return BridgeJSGlobalTests.Internal.SupportedServerMethod(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -92,265 +92,265 @@ extension Internal.SupportedServerMethod: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_GlobalStaticPropertyNamespace_static_namespaceProperty_get")
-@_cdecl("bjs_GlobalStaticPropertyNamespace_static_namespaceProperty_get")
-public func _bjs_GlobalStaticPropertyNamespace_static_namespaceProperty_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_static_namespaceProperty_get")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_static_namespaceProperty_get")
+public func _bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_static_namespaceProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = GlobalStaticPropertyNamespace.namespaceProperty
+    let ret = BridgeJSGlobalTests.GlobalStaticPropertyNamespace.namespaceProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalStaticPropertyNamespace_static_namespaceProperty_set")
-@_cdecl("bjs_GlobalStaticPropertyNamespace_static_namespaceProperty_set")
-public func _bjs_GlobalStaticPropertyNamespace_static_namespaceProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_static_namespaceProperty_set")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_static_namespaceProperty_set")
+public func _bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_static_namespaceProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    GlobalStaticPropertyNamespace.namespaceProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSGlobalTests.GlobalStaticPropertyNamespace.namespaceProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalStaticPropertyNamespace_static_namespaceConstant_get")
-@_cdecl("bjs_GlobalStaticPropertyNamespace_static_namespaceConstant_get")
-public func _bjs_GlobalStaticPropertyNamespace_static_namespaceConstant_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_static_namespaceConstant_get")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_static_namespaceConstant_get")
+public func _bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_static_namespaceConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = GlobalStaticPropertyNamespace.namespaceConstant
+    let ret = BridgeJSGlobalTests.GlobalStaticPropertyNamespace.namespaceConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_get")
-@_cdecl("bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_get")
-public func _bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_get")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_get")
+public func _bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_get() -> Int32 {
     #if arch(wasm32)
-    let ret = GlobalStaticPropertyNamespace.NestedProperties.nestedProperty
+    let ret = BridgeJSGlobalTests.GlobalStaticPropertyNamespace.NestedProperties.nestedProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_set")
-@_cdecl("bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_set")
-public func _bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_set")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_set")
+public func _bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedProperty_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    GlobalStaticPropertyNamespace.NestedProperties.nestedProperty = Int.bridgeJSLiftParameter(value)
+    BridgeJSGlobalTests.GlobalStaticPropertyNamespace.NestedProperties.nestedProperty = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedConstant_get")
-@_cdecl("bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedConstant_get")
-public func _bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedConstant_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedConstant_get")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedConstant_get")
+public func _bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = GlobalStaticPropertyNamespace.NestedProperties.nestedConstant
+    let ret = BridgeJSGlobalTests.GlobalStaticPropertyNamespace.NestedProperties.nestedConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_get")
-@_cdecl("bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_get")
-public func _bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_get() -> Float64 {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_get")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_get")
+public func _bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_get() -> Float64 {
     #if arch(wasm32)
-    let ret = GlobalStaticPropertyNamespace.NestedProperties.nestedDouble
+    let ret = BridgeJSGlobalTests.GlobalStaticPropertyNamespace.NestedProperties.nestedDouble
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_set")
-@_cdecl("bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_set")
-public func _bjs_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_set(_ value: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_set")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_set")
+public func _bjs_BridgeJSGlobalTests_GlobalStaticPropertyNamespace_NestedProperties_static_nestedDouble_set(_ value: Float64) -> Void {
     #if arch(wasm32)
-    GlobalStaticPropertyNamespace.NestedProperties.nestedDouble = Double.bridgeJSLiftParameter(value)
+    BridgeJSGlobalTests.GlobalStaticPropertyNamespace.NestedProperties.nestedDouble = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalNetworking_API_TestHTTPServer_init")
-@_cdecl("bjs_GlobalNetworking_API_TestHTTPServer_init")
-public func _bjs_GlobalNetworking_API_TestHTTPServer_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_init")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_init")
+public func _bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = GlobalNetworking.API.TestHTTPServer()
+    let ret = BridgeJSGlobalTests.GlobalNetworking.API.TestHTTPServer()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalNetworking_API_TestHTTPServer_call")
-@_cdecl("bjs_GlobalNetworking_API_TestHTTPServer_call")
-public func _bjs_GlobalNetworking_API_TestHTTPServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_call")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_call")
+public func _bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
     #if arch(wasm32)
-    GlobalNetworking.API.TestHTTPServer.bridgeJSLiftParameter(_self).call(_: GlobalNetworking.API.CallMethod.bridgeJSLiftParameter(method))
+    BridgeJSGlobalTests.GlobalNetworking.API.TestHTTPServer.bridgeJSLiftParameter(_self).call(_: BridgeJSGlobalTests.GlobalNetworking.API.CallMethod.bridgeJSLiftParameter(method))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalNetworking_API_TestHTTPServer_deinit")
-@_cdecl("bjs_GlobalNetworking_API_TestHTTPServer_deinit")
-public func _bjs_GlobalNetworking_API_TestHTTPServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_deinit")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_deinit")
+public func _bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<GlobalNetworking.API.TestHTTPServer>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSGlobalTests.GlobalNetworking.API.TestHTTPServer>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension GlobalNetworking.API.TestHTTPServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSGlobalTests.GlobalNetworking.API.TestHTTPServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_GlobalNetworking_API_TestHTTPServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_GlobalNetworking_API_TestHTTPServer_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSGlobalTests", name: "bjs_GlobalNetworking_API_TestHTTPServer_wrap")
-fileprivate func _bjs_GlobalNetworking_API_TestHTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSGlobalTests", name: "bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_wrap")
+fileprivate func _bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_GlobalNetworking_API_TestHTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_GlobalNetworking_API_TestHTTPServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_GlobalNetworking_API_TestHTTPServer_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_init")
-@_cdecl("bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_init")
-public func _bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_Internal_TestInternalServer_init")
+@_cdecl("bjs_BridgeJSGlobalTests_Internal_TestInternalServer_init")
+public func _bjs_BridgeJSGlobalTests_Internal_TestInternalServer_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Internal.TestInternalServer()
+    let ret = BridgeJSGlobalTests.Internal.TestInternalServer()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_call")
-@_cdecl("bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_call")
-public func _bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_Internal_TestInternalServer_call")
+@_cdecl("bjs_BridgeJSGlobalTests_Internal_TestInternalServer_call")
+public func _bjs_BridgeJSGlobalTests_Internal_TestInternalServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
     #if arch(wasm32)
-    Internal.TestInternalServer.bridgeJSLiftParameter(_self).call(_: Internal.SupportedServerMethod.bridgeJSLiftParameter(method))
+    BridgeJSGlobalTests.Internal.TestInternalServer.bridgeJSLiftParameter(_self).call(_: BridgeJSGlobalTests.Internal.SupportedServerMethod.bridgeJSLiftParameter(method))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_deinit")
-@_cdecl("bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_deinit")
-public func _bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_Internal_TestInternalServer_deinit")
+@_cdecl("bjs_BridgeJSGlobalTests_Internal_TestInternalServer_deinit")
+public func _bjs_BridgeJSGlobalTests_Internal_TestInternalServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Internal.TestInternalServer>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSGlobalTests.Internal.TestInternalServer>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Internal.TestInternalServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSGlobalTests.Internal.TestInternalServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSGlobalTests_Internal_TestInternalServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSGlobalTests_Internal_TestInternalServer_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSGlobalTests", name: "bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_wrap")
-fileprivate func _bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSGlobalTests", name: "bjs_BridgeJSGlobalTests_Internal_TestInternalServer_wrap")
+fileprivate func _bjs_BridgeJSGlobalTests_Internal_TestInternalServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSGlobalTests_Internal_TestInternalServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSGlobalTests_Internal_TestInternalServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSGlobalTests_Internal_TestInternalServer_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_GlobalUtils_PublicConverter_init")
-@_cdecl("bjs_GlobalUtils_PublicConverter_init")
-public func _bjs_GlobalUtils_PublicConverter_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_init")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_init")
+public func _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = GlobalUtils.PublicConverter()
+    let ret = BridgeJSGlobalTests.GlobalUtils.PublicConverter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalUtils_PublicConverter_toString")
-@_cdecl("bjs_GlobalUtils_PublicConverter_toString")
-public func _bjs_GlobalUtils_PublicConverter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_toString")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_toString")
+public func _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = GlobalUtils.PublicConverter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
+    let ret = BridgeJSGlobalTests.GlobalUtils.PublicConverter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalUtils_PublicConverter_precision_get")
-@_cdecl("bjs_GlobalUtils_PublicConverter_precision_get")
-public func _bjs_GlobalUtils_PublicConverter_precision_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_precision_get")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_precision_get")
+public func _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_precision_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = GlobalUtils.PublicConverter.bridgeJSLiftParameter(_self).precision
+    let ret = BridgeJSGlobalTests.GlobalUtils.PublicConverter.bridgeJSLiftParameter(_self).precision
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalUtils_PublicConverter_precision_set")
-@_cdecl("bjs_GlobalUtils_PublicConverter_precision_set")
-public func _bjs_GlobalUtils_PublicConverter_precision_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_precision_set")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_precision_set")
+public func _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_precision_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    GlobalUtils.PublicConverter.bridgeJSLiftParameter(_self).precision = Int.bridgeJSLiftParameter(value)
+    BridgeJSGlobalTests.GlobalUtils.PublicConverter.bridgeJSLiftParameter(_self).precision = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_GlobalUtils_PublicConverter_deinit")
-@_cdecl("bjs_GlobalUtils_PublicConverter_deinit")
-public func _bjs_GlobalUtils_PublicConverter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_deinit")
+@_cdecl("bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_deinit")
+public func _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<GlobalUtils.PublicConverter>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSGlobalTests.GlobalUtils.PublicConverter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension GlobalUtils.PublicConverter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSGlobalTests.GlobalUtils.PublicConverter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_GlobalUtils_PublicConverter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_GlobalUtils_PublicConverter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSGlobalTests", name: "bjs_GlobalUtils_PublicConverter_wrap")
-fileprivate func _bjs_GlobalUtils_PublicConverter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSGlobalTests", name: "bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_wrap")
+fileprivate func _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_GlobalUtils_PublicConverter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_GlobalUtils_PublicConverter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_GlobalUtils_PublicConverter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_wrap_extern(pointer)
 }

--- a/Tests/BridgeJSGlobalTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSGlobalTests/Generated/JavaScript/BridgeJS.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_GlobalNetworking_API_TestHTTPServer_init",
+          "abiName" : "bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18,7 +18,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_GlobalNetworking_API_TestHTTPServer_call",
+            "abiName" : "bjs_BridgeJSGlobalTests_GlobalNetworking_API_TestHTTPServer_call",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -35,7 +35,7 @@
                 "name" : "method",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "GlobalNetworking.API.CallMethod"
+                    "_0" : "BridgeJSGlobalTests.GlobalNetworking.API.CallMethod"
                   }
                 }
               }
@@ -55,11 +55,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "GlobalNetworking.API.TestHTTPServer"
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalNetworking.API.TestHTTPServer"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_init",
+          "abiName" : "bjs_BridgeJSGlobalTests_Internal_TestInternalServer_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -71,7 +71,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_GlobalNetworking_APIV2_Internal_TestInternalServer_call",
+            "abiName" : "bjs_BridgeJSGlobalTests_Internal_TestInternalServer_call",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -89,7 +89,7 @@
                 "name" : "method",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Internal.SupportedServerMethod"
+                    "_0" : "BridgeJSGlobalTests.Internal.SupportedServerMethod"
                   }
                 }
               }
@@ -110,11 +110,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Internal.TestInternalServer"
+        "swiftCallName" : "BridgeJSGlobalTests.Internal.TestInternalServer"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_GlobalUtils_PublicConverter_init",
+          "abiName" : "bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -126,7 +126,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_GlobalUtils_PublicConverter_toString",
+            "abiName" : "bjs_BridgeJSGlobalTests_GlobalUtils_PublicConverter_toString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -179,7 +179,7 @@
             }
           }
         ],
-        "swiftCallName" : "GlobalUtils.PublicConverter"
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalUtils.PublicConverter"
       }
     ],
     "enums" : [
@@ -195,7 +195,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GlobalNetworking",
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalNetworking",
         "tsFullPath" : "GlobalNetworking"
       },
       {
@@ -213,7 +213,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GlobalNetworking.API",
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalNetworking.API",
         "tsFullPath" : "GlobalNetworking.API"
       },
       {
@@ -255,7 +255,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GlobalNetworking.API.CallMethod",
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalNetworking.API.CallMethod",
         "tsFullPath" : "GlobalNetworking.API.CallMethod"
       },
       {
@@ -270,7 +270,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GlobalConfiguration",
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalConfiguration",
         "tsFullPath" : "GlobalConfiguration"
       },
       {
@@ -316,7 +316,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GlobalConfiguration.PublicLogLevel",
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalConfiguration.PublicLogLevel",
         "tsFullPath" : "GlobalConfiguration.PublicLogLevel"
       },
       {
@@ -355,7 +355,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GlobalConfiguration.AvailablePort",
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalConfiguration.AvailablePort",
         "tsFullPath" : "GlobalConfiguration.AvailablePort"
       },
       {
@@ -374,7 +374,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Internal",
+        "swiftCallName" : "BridgeJSGlobalTests.Internal",
         "tsFullPath" : "GlobalNetworking.APIV2.Internal"
       },
       {
@@ -405,7 +405,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Internal.SupportedServerMethod",
+        "swiftCallName" : "BridgeJSGlobalTests.Internal.SupportedServerMethod",
         "tsFullPath" : "GlobalNetworking.APIV2.Internal.SupportedServerMethod"
       },
       {
@@ -427,7 +427,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GlobalStaticPropertyNamespace"
+                "_0" : "BridgeJSGlobalTests.GlobalStaticPropertyNamespace"
               }
             },
             "type" : {
@@ -445,7 +445,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GlobalStaticPropertyNamespace"
+                "_0" : "BridgeJSGlobalTests.GlobalStaticPropertyNamespace"
               }
             },
             "type" : {
@@ -455,7 +455,7 @@
             }
           }
         ],
-        "swiftCallName" : "GlobalStaticPropertyNamespace",
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalStaticPropertyNamespace",
         "tsFullPath" : "GlobalStaticPropertyNamespace"
       },
       {
@@ -481,7 +481,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GlobalStaticPropertyNamespace.NestedProperties"
+                "_0" : "BridgeJSGlobalTests.GlobalStaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -503,7 +503,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GlobalStaticPropertyNamespace.NestedProperties"
+                "_0" : "BridgeJSGlobalTests.GlobalStaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -522,7 +522,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GlobalStaticPropertyNamespace.NestedProperties"
+                "_0" : "BridgeJSGlobalTests.GlobalStaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -532,7 +532,7 @@
             }
           }
         ],
-        "swiftCallName" : "GlobalStaticPropertyNamespace.NestedProperties",
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalStaticPropertyNamespace.NestedProperties",
         "tsFullPath" : "GlobalStaticPropertyNamespace.NestedProperties"
       },
       {
@@ -547,7 +547,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GlobalUtils",
+        "swiftCallName" : "BridgeJSGlobalTests.GlobalUtils",
         "tsFullPath" : "GlobalUtils"
       }
     ],

--- a/Tests/BridgeJSIdentityTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSIdentityTests/Generated/BridgeJS.swift
@@ -8,9 +8,9 @@
 
 @_spi(BridgeJS) import JavaScriptKit
 
-@_expose(wasm, "bjs_getSharedSubject")
-@_cdecl("bjs_getSharedSubject")
-public func _bjs_getSharedSubject() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_getSharedSubject")
+@_cdecl("bjs_BridgeJSIdentityTests_getSharedSubject")
+public func _bjs_BridgeJSIdentityTests_getSharedSubject() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = getSharedSubject()
     return ret.bridgeJSLowerReturn()
@@ -19,9 +19,9 @@ public func _bjs_getSharedSubject() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_resetSharedSubject")
-@_cdecl("bjs_resetSharedSubject")
-public func _bjs_resetSharedSubject() -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_resetSharedSubject")
+@_cdecl("bjs_BridgeJSIdentityTests_resetSharedSubject")
+public func _bjs_BridgeJSIdentityTests_resetSharedSubject() -> Void {
     #if arch(wasm32)
     resetSharedSubject()
     #else
@@ -29,9 +29,9 @@ public func _bjs_resetSharedSubject() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_getRetainLeakSubject")
-@_cdecl("bjs_getRetainLeakSubject")
-public func _bjs_getRetainLeakSubject() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_getRetainLeakSubject")
+@_cdecl("bjs_BridgeJSIdentityTests_getRetainLeakSubject")
+public func _bjs_BridgeJSIdentityTests_getRetainLeakSubject() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = getRetainLeakSubject()
     return ret.bridgeJSLowerReturn()
@@ -40,9 +40,9 @@ public func _bjs_getRetainLeakSubject() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_resetRetainLeakSubject")
-@_cdecl("bjs_resetRetainLeakSubject")
-public func _bjs_resetRetainLeakSubject() -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_resetRetainLeakSubject")
+@_cdecl("bjs_BridgeJSIdentityTests_resetRetainLeakSubject")
+public func _bjs_BridgeJSIdentityTests_resetRetainLeakSubject() -> Void {
     #if arch(wasm32)
     resetRetainLeakSubject()
     #else
@@ -50,9 +50,9 @@ public func _bjs_resetRetainLeakSubject() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_getRetainLeakDeinits")
-@_cdecl("bjs_getRetainLeakDeinits")
-public func _bjs_getRetainLeakDeinits() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_getRetainLeakDeinits")
+@_cdecl("bjs_BridgeJSIdentityTests_getRetainLeakDeinits")
+public func _bjs_BridgeJSIdentityTests_getRetainLeakDeinits() -> Int32 {
     #if arch(wasm32)
     let ret = getRetainLeakDeinits()
     return ret.bridgeJSLowerReturn()
@@ -61,9 +61,9 @@ public func _bjs_getRetainLeakDeinits() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_resetRetainLeakDeinits")
-@_cdecl("bjs_resetRetainLeakDeinits")
-public func _bjs_resetRetainLeakDeinits() -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_resetRetainLeakDeinits")
+@_cdecl("bjs_BridgeJSIdentityTests_resetRetainLeakDeinits")
+public func _bjs_BridgeJSIdentityTests_resetRetainLeakDeinits() -> Void {
     #if arch(wasm32)
     resetRetainLeakDeinits()
     #else
@@ -71,9 +71,9 @@ public func _bjs_resetRetainLeakDeinits() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_setupArrayPool")
-@_cdecl("bjs_setupArrayPool")
-public func _bjs_setupArrayPool(_ count: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_setupArrayPool")
+@_cdecl("bjs_BridgeJSIdentityTests_setupArrayPool")
+public func _bjs_BridgeJSIdentityTests_setupArrayPool(_ count: Int32) -> Void {
     #if arch(wasm32)
     setupArrayPool(_: Int.bridgeJSLiftParameter(count))
     #else
@@ -81,9 +81,9 @@ public func _bjs_setupArrayPool(_ count: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_getArrayPool")
-@_cdecl("bjs_getArrayPool")
-public func _bjs_getArrayPool() -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_getArrayPool")
+@_cdecl("bjs_BridgeJSIdentityTests_getArrayPool")
+public func _bjs_BridgeJSIdentityTests_getArrayPool() -> Void {
     #if arch(wasm32)
     let ret = getArrayPool()
     ret.bridgeJSStackPush()
@@ -92,9 +92,9 @@ public func _bjs_getArrayPool() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_getArrayPoolElement")
-@_cdecl("bjs_getArrayPoolElement")
-public func _bjs_getArrayPoolElement(_ index: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_getArrayPoolElement")
+@_cdecl("bjs_BridgeJSIdentityTests_getArrayPoolElement")
+public func _bjs_BridgeJSIdentityTests_getArrayPoolElement(_ index: Int32) -> Void {
     #if arch(wasm32)
     let ret = getArrayPoolElement(_: Int.bridgeJSLiftParameter(index))
     return ret.bridgeJSLowerReturn()
@@ -103,9 +103,9 @@ public func _bjs_getArrayPoolElement(_ index: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_getArrayPoolDeinits")
-@_cdecl("bjs_getArrayPoolDeinits")
-public func _bjs_getArrayPoolDeinits() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_getArrayPoolDeinits")
+@_cdecl("bjs_BridgeJSIdentityTests_getArrayPoolDeinits")
+public func _bjs_BridgeJSIdentityTests_getArrayPoolDeinits() -> Int32 {
     #if arch(wasm32)
     let ret = getArrayPoolDeinits()
     return ret.bridgeJSLowerReturn()
@@ -114,9 +114,9 @@ public func _bjs_getArrayPoolDeinits() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_resetArrayPoolDeinits")
-@_cdecl("bjs_resetArrayPoolDeinits")
-public func _bjs_resetArrayPoolDeinits() -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_resetArrayPoolDeinits")
+@_cdecl("bjs_BridgeJSIdentityTests_resetArrayPoolDeinits")
+public func _bjs_BridgeJSIdentityTests_resetArrayPoolDeinits() -> Void {
     #if arch(wasm32)
     resetArrayPoolDeinits()
     #else
@@ -124,9 +124,9 @@ public func _bjs_resetArrayPoolDeinits() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_clearArrayPool")
-@_cdecl("bjs_clearArrayPool")
-public func _bjs_clearArrayPool() -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_clearArrayPool")
+@_cdecl("bjs_BridgeJSIdentityTests_clearArrayPool")
+public func _bjs_BridgeJSIdentityTests_clearArrayPool() -> Void {
     #if arch(wasm32)
     clearArrayPool()
     #else
@@ -134,204 +134,204 @@ public func _bjs_clearArrayPool() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityTestSubject_init")
-@_cdecl("bjs_IdentityTestSubject_init")
-public func _bjs_IdentityTestSubject_init(_ value: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_IdentityTestSubject_init")
+@_cdecl("bjs_BridgeJSIdentityTests_IdentityTestSubject_init")
+public func _bjs_BridgeJSIdentityTests_IdentityTestSubject_init(_ value: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = IdentityTestSubject(value: Int.bridgeJSLiftParameter(value))
+    let ret = BridgeJSIdentityTests.IdentityTestSubject(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityTestSubject_value_get")
-@_cdecl("bjs_IdentityTestSubject_value_get")
-public func _bjs_IdentityTestSubject_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_IdentityTestSubject_value_get")
+@_cdecl("bjs_BridgeJSIdentityTests_IdentityTestSubject_value_get")
+public func _bjs_BridgeJSIdentityTests_IdentityTestSubject_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = IdentityTestSubject.bridgeJSLiftParameter(_self).value
+    let ret = BridgeJSIdentityTests.IdentityTestSubject.bridgeJSLiftParameter(_self).value
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityTestSubject_value_set")
-@_cdecl("bjs_IdentityTestSubject_value_set")
-public func _bjs_IdentityTestSubject_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_IdentityTestSubject_value_set")
+@_cdecl("bjs_BridgeJSIdentityTests_IdentityTestSubject_value_set")
+public func _bjs_BridgeJSIdentityTests_IdentityTestSubject_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    IdentityTestSubject.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
+    BridgeJSIdentityTests.IdentityTestSubject.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityTestSubject_currentValue_get")
-@_cdecl("bjs_IdentityTestSubject_currentValue_get")
-public func _bjs_IdentityTestSubject_currentValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_IdentityTestSubject_currentValue_get")
+@_cdecl("bjs_BridgeJSIdentityTests_IdentityTestSubject_currentValue_get")
+public func _bjs_BridgeJSIdentityTests_IdentityTestSubject_currentValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = IdentityTestSubject.bridgeJSLiftParameter(_self).currentValue
+    let ret = BridgeJSIdentityTests.IdentityTestSubject.bridgeJSLiftParameter(_self).currentValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IdentityTestSubject_deinit")
-@_cdecl("bjs_IdentityTestSubject_deinit")
-public func _bjs_IdentityTestSubject_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_IdentityTestSubject_deinit")
+@_cdecl("bjs_BridgeJSIdentityTests_IdentityTestSubject_deinit")
+public func _bjs_BridgeJSIdentityTests_IdentityTestSubject_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<IdentityTestSubject>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSIdentityTests.IdentityTestSubject>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension IdentityTestSubject: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSIdentityTests.IdentityTestSubject: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_IdentityTestSubject_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSIdentityTests_IdentityTestSubject_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_IdentityTestSubject_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSIdentityTests_IdentityTestSubject_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSIdentityTests", name: "bjs_IdentityTestSubject_wrap")
-fileprivate func _bjs_IdentityTestSubject_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSIdentityTests", name: "bjs_BridgeJSIdentityTests_IdentityTestSubject_wrap")
+fileprivate func _bjs_BridgeJSIdentityTests_IdentityTestSubject_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_IdentityTestSubject_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSIdentityTests_IdentityTestSubject_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_IdentityTestSubject_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_IdentityTestSubject_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSIdentityTests_IdentityTestSubject_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSIdentityTests_IdentityTestSubject_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_RetainLeakSubject_init")
-@_cdecl("bjs_RetainLeakSubject_init")
-public func _bjs_RetainLeakSubject_init(_ tag: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_RetainLeakSubject_init")
+@_cdecl("bjs_BridgeJSIdentityTests_RetainLeakSubject_init")
+public func _bjs_BridgeJSIdentityTests_RetainLeakSubject_init(_ tag: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = RetainLeakSubject(tag: Int.bridgeJSLiftParameter(tag))
+    let ret = BridgeJSIdentityTests.RetainLeakSubject(tag: Int.bridgeJSLiftParameter(tag))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_RetainLeakSubject_tag_get")
-@_cdecl("bjs_RetainLeakSubject_tag_get")
-public func _bjs_RetainLeakSubject_tag_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_RetainLeakSubject_tag_get")
+@_cdecl("bjs_BridgeJSIdentityTests_RetainLeakSubject_tag_get")
+public func _bjs_BridgeJSIdentityTests_RetainLeakSubject_tag_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = RetainLeakSubject.bridgeJSLiftParameter(_self).tag
+    let ret = BridgeJSIdentityTests.RetainLeakSubject.bridgeJSLiftParameter(_self).tag
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_RetainLeakSubject_tag_set")
-@_cdecl("bjs_RetainLeakSubject_tag_set")
-public func _bjs_RetainLeakSubject_tag_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_RetainLeakSubject_tag_set")
+@_cdecl("bjs_BridgeJSIdentityTests_RetainLeakSubject_tag_set")
+public func _bjs_BridgeJSIdentityTests_RetainLeakSubject_tag_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    RetainLeakSubject.bridgeJSLiftParameter(_self).tag = Int.bridgeJSLiftParameter(value)
+    BridgeJSIdentityTests.RetainLeakSubject.bridgeJSLiftParameter(_self).tag = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_RetainLeakSubject_deinit")
-@_cdecl("bjs_RetainLeakSubject_deinit")
-public func _bjs_RetainLeakSubject_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_RetainLeakSubject_deinit")
+@_cdecl("bjs_BridgeJSIdentityTests_RetainLeakSubject_deinit")
+public func _bjs_BridgeJSIdentityTests_RetainLeakSubject_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<RetainLeakSubject>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSIdentityTests.RetainLeakSubject>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension RetainLeakSubject: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSIdentityTests.RetainLeakSubject: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_RetainLeakSubject_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSIdentityTests_RetainLeakSubject_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_RetainLeakSubject_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSIdentityTests_RetainLeakSubject_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSIdentityTests", name: "bjs_RetainLeakSubject_wrap")
-fileprivate func _bjs_RetainLeakSubject_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSIdentityTests", name: "bjs_BridgeJSIdentityTests_RetainLeakSubject_wrap")
+fileprivate func _bjs_BridgeJSIdentityTests_RetainLeakSubject_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_RetainLeakSubject_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSIdentityTests_RetainLeakSubject_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_RetainLeakSubject_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_RetainLeakSubject_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSIdentityTests_RetainLeakSubject_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSIdentityTests_RetainLeakSubject_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ArrayIdentityElement_init")
-@_cdecl("bjs_ArrayIdentityElement_init")
-public func _bjs_ArrayIdentityElement_init(_ tag: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_ArrayIdentityElement_init")
+@_cdecl("bjs_BridgeJSIdentityTests_ArrayIdentityElement_init")
+public func _bjs_BridgeJSIdentityTests_ArrayIdentityElement_init(_ tag: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = ArrayIdentityElement(tag: Int.bridgeJSLiftParameter(tag))
+    let ret = BridgeJSIdentityTests.ArrayIdentityElement(tag: Int.bridgeJSLiftParameter(tag))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayIdentityElement_tag_get")
-@_cdecl("bjs_ArrayIdentityElement_tag_get")
-public func _bjs_ArrayIdentityElement_tag_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_ArrayIdentityElement_tag_get")
+@_cdecl("bjs_BridgeJSIdentityTests_ArrayIdentityElement_tag_get")
+public func _bjs_BridgeJSIdentityTests_ArrayIdentityElement_tag_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = ArrayIdentityElement.bridgeJSLiftParameter(_self).tag
+    let ret = BridgeJSIdentityTests.ArrayIdentityElement.bridgeJSLiftParameter(_self).tag
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayIdentityElement_tag_set")
-@_cdecl("bjs_ArrayIdentityElement_tag_set")
-public func _bjs_ArrayIdentityElement_tag_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_ArrayIdentityElement_tag_set")
+@_cdecl("bjs_BridgeJSIdentityTests_ArrayIdentityElement_tag_set")
+public func _bjs_BridgeJSIdentityTests_ArrayIdentityElement_tag_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    ArrayIdentityElement.bridgeJSLiftParameter(_self).tag = Int.bridgeJSLiftParameter(value)
+    BridgeJSIdentityTests.ArrayIdentityElement.bridgeJSLiftParameter(_self).tag = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayIdentityElement_deinit")
-@_cdecl("bjs_ArrayIdentityElement_deinit")
-public func _bjs_ArrayIdentityElement_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSIdentityTests_ArrayIdentityElement_deinit")
+@_cdecl("bjs_BridgeJSIdentityTests_ArrayIdentityElement_deinit")
+public func _bjs_BridgeJSIdentityTests_ArrayIdentityElement_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ArrayIdentityElement>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSIdentityTests.ArrayIdentityElement>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ArrayIdentityElement: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSIdentityTests.ArrayIdentityElement: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ArrayIdentityElement_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSIdentityTests_ArrayIdentityElement_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ArrayIdentityElement_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSIdentityTests_ArrayIdentityElement_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSIdentityTests", name: "bjs_ArrayIdentityElement_wrap")
-fileprivate func _bjs_ArrayIdentityElement_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSIdentityTests", name: "bjs_BridgeJSIdentityTests_ArrayIdentityElement_wrap")
+fileprivate func _bjs_BridgeJSIdentityTests_ArrayIdentityElement_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ArrayIdentityElement_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSIdentityTests_ArrayIdentityElement_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ArrayIdentityElement_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ArrayIdentityElement_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSIdentityTests_ArrayIdentityElement_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSIdentityTests_ArrayIdentityElement_wrap_extern(pointer)
 }
 
 #if arch(wasm32)

--- a/Tests/BridgeJSIdentityTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSIdentityTests/Generated/JavaScript/BridgeJS.json
@@ -6,7 +6,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_IdentityTestSubject_init",
+          "abiName" : "bjs_BridgeJSIdentityTests_IdentityTestSubject_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -59,11 +59,11 @@
             }
           }
         ],
-        "swiftCallName" : "IdentityTestSubject"
+        "swiftCallName" : "BridgeJSIdentityTests.IdentityTestSubject"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_RetainLeakSubject_init",
+          "abiName" : "bjs_BridgeJSIdentityTests_RetainLeakSubject_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -103,11 +103,11 @@
             }
           }
         ],
-        "swiftCallName" : "RetainLeakSubject"
+        "swiftCallName" : "BridgeJSIdentityTests.RetainLeakSubject"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_ArrayIdentityElement_init",
+          "abiName" : "bjs_BridgeJSIdentityTests_ArrayIdentityElement_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -147,7 +147,7 @@
             }
           }
         ],
-        "swiftCallName" : "ArrayIdentityElement"
+        "swiftCallName" : "BridgeJSIdentityTests.ArrayIdentityElement"
       }
     ],
     "enums" : [
@@ -156,7 +156,7 @@
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_getSharedSubject",
+        "abiName" : "bjs_BridgeJSIdentityTests_getSharedSubject",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -168,12 +168,12 @@
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "IdentityTestSubject"
+            "_0" : "BridgeJSIdentityTests.IdentityTestSubject"
           }
         }
       },
       {
-        "abiName" : "bjs_resetSharedSubject",
+        "abiName" : "bjs_BridgeJSIdentityTests_resetSharedSubject",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -190,7 +190,7 @@
         }
       },
       {
-        "abiName" : "bjs_getRetainLeakSubject",
+        "abiName" : "bjs_BridgeJSIdentityTests_getRetainLeakSubject",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -202,12 +202,12 @@
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "RetainLeakSubject"
+            "_0" : "BridgeJSIdentityTests.RetainLeakSubject"
           }
         }
       },
       {
-        "abiName" : "bjs_resetRetainLeakSubject",
+        "abiName" : "bjs_BridgeJSIdentityTests_resetRetainLeakSubject",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -224,7 +224,7 @@
         }
       },
       {
-        "abiName" : "bjs_getRetainLeakDeinits",
+        "abiName" : "bjs_BridgeJSIdentityTests_getRetainLeakDeinits",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -244,7 +244,7 @@
         }
       },
       {
-        "abiName" : "bjs_resetRetainLeakDeinits",
+        "abiName" : "bjs_BridgeJSIdentityTests_resetRetainLeakDeinits",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -261,7 +261,7 @@
         }
       },
       {
-        "abiName" : "bjs_setupArrayPool",
+        "abiName" : "bjs_BridgeJSIdentityTests_setupArrayPool",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -289,7 +289,7 @@
         }
       },
       {
-        "abiName" : "bjs_getArrayPool",
+        "abiName" : "bjs_BridgeJSIdentityTests_getArrayPool",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -303,14 +303,14 @@
           "array" : {
             "_0" : {
               "swiftHeapObject" : {
-                "_0" : "ArrayIdentityElement"
+                "_0" : "BridgeJSIdentityTests.ArrayIdentityElement"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_getArrayPoolElement",
+        "abiName" : "bjs_BridgeJSIdentityTests_getArrayPoolElement",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -335,7 +335,7 @@
           "nullable" : {
             "_0" : {
               "swiftHeapObject" : {
-                "_0" : "ArrayIdentityElement"
+                "_0" : "BridgeJSIdentityTests.ArrayIdentityElement"
               }
             },
             "_1" : "null"
@@ -343,7 +343,7 @@
         }
       },
       {
-        "abiName" : "bjs_getArrayPoolDeinits",
+        "abiName" : "bjs_BridgeJSIdentityTests_getArrayPoolDeinits",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -363,7 +363,7 @@
         }
       },
       {
-        "abiName" : "bjs_resetArrayPoolDeinits",
+        "abiName" : "bjs_BridgeJSIdentityTests_resetArrayPoolDeinits",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -380,7 +380,7 @@
         }
       },
       {
-        "abiName" : "bjs_clearArrayPool",
+        "abiName" : "bjs_BridgeJSIdentityTests_clearArrayPool",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,

--- a/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
+++ b/Tests/BridgeJSRuntimeTests/Generated/BridgeJS.swift
@@ -9,226 +9,37 @@
 @_spi(BridgeJS) import JavaScriptKit
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si_extern(_ callback: Int32, _ param0: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS_extern(callback, param0Bytes, param0Length)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTests10HttpStatusO_Si {
-    static func bridgeJSLift(_ callbackId: Int32) -> (HttpStatus) -> Int {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0Value = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si(callbackValue, param0Value)
-            return Int.bridgeJSLiftReturn(ret)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (HttpStatus) -> Int {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (HttpStatus) -> Int) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests10HttpStatusO_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(HttpStatus) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(HttpStatus.bridgeJSLiftParameter(param0))
-    return result.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP_extern(_ callback: Int32, _ param0: Int32) -> Int32
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP_extern(callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP {
-    static func bridgeJSLift(_ callbackId: Int32) -> (any DataProcessor) -> any DataProcessor {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP(callbackValue, param0ObjectId)
-            return AnyDataProcessor.bridgeJSLiftReturn(ret)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (any DataProcessor) -> any DataProcessor {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (any DataProcessor) -> any DataProcessor) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(any DataProcessor) -> any DataProcessor>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(AnyDataProcessor.bridgeJSLiftParameter(param0))
-    return (result as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS_extern(callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTests13DataProcessorP_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (any DataProcessor) -> String {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS(callbackValue, param0ObjectId)
-            return String.bridgeJSLiftReturn(ret)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (any DataProcessor) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (any DataProcessor) -> String) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests13DataProcessorP_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(any DataProcessor) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(AnyDataProcessor.bridgeJSLiftParameter(param0))
-    return result.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS_extern(callback, param0Bytes, param0Length)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTests5ThemeO_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Theme) -> String {
+private enum _BJS_Closure_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (BridgeJSRuntimeTests.Theme) -> String {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS(callbackValue, param0Bytes, param0Length)
+                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS(callbackValue, param0Bytes, param0Length)
                 return ret
             }
             let ret = ret0
@@ -240,10 +51,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests5ThemeO_SS {
     }
 }
 
-extension JSTypedClosure where Signature == (Theme) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Theme) -> String) {
+extension JSTypedClosure where Signature == (BridgeJSRuntimeTests.Theme) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (BridgeJSRuntimeTests.Theme) -> String) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS,
             body: body,
             fileID: fileID,
             line: line
@@ -251,12 +62,12 @@ extension JSTypedClosure where Signature == (Theme) -> String {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Theme) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Theme.bridgeJSLiftParameter(param0Bytes, param0Length))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(BridgeJSRuntimeTests.Theme) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(BridgeJSRuntimeTests.Theme.bridgeJSLiftParameter(param0Bytes, param0Length))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -264,37 +75,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5Th
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb_extern(callback, param0Bytes, param0Length)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb_extern(callback, param0Bytes, param0Length)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTests5ThemeO_Sb {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Theme) -> Bool {
+private enum _BJS_Closure_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb {
+    static func bridgeJSLift(_ callbackId: Int32) -> (BridgeJSRuntimeTests.Theme) -> Bool {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb(callbackValue, param0Bytes, param0Length)
+                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb(callbackValue, param0Bytes, param0Length)
                 return ret
             }
             let ret = ret0
@@ -306,10 +117,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests5ThemeO_Sb {
     }
 }
 
-extension JSTypedClosure where Signature == (Theme) -> Bool {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Theme) -> Bool) {
+extension JSTypedClosure where Signature == (BridgeJSRuntimeTests.Theme) -> Bool {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (BridgeJSRuntimeTests.Theme) -> Bool) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb,
             body: body,
             fileID: fileID,
             line: line
@@ -317,12 +128,12 @@ extension JSTypedClosure where Signature == (Theme) -> Bool {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5ThemeO_Sb(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Theme) -> Bool>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Theme.bridgeJSLiftParameter(param0Bytes, param0Length))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(BridgeJSRuntimeTests.Theme) -> Bool>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(BridgeJSRuntimeTests.Theme.bridgeJSLiftParameter(param0Bytes, param0Length))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -330,37 +141,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests5Th
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTests7GreeterC_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Greeter) -> String {
+private enum _BJS_Closure_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (BridgeJSRuntimeTests.Greeter) -> String {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0Pointer = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS(callbackValue, param0Pointer)
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS(callbackValue, param0Pointer)
             return String.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -369,10 +180,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTests7GreeterC_SS {
     }
 }
 
-extension JSTypedClosure where Signature == (Greeter) -> String {
-    public init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Greeter) -> String) {
+extension JSTypedClosure where Signature == (BridgeJSRuntimeTests.Greeter) -> String {
+    public init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (BridgeJSRuntimeTests.Greeter) -> String) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS,
             body: body,
             fileID: fileID,
             line: line
@@ -380,12 +191,390 @@ extension JSTypedClosure where Signature == (Greeter) -> String {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests7GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Greeter) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Greeter.bridgeJSLiftParameter(param0))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(BridgeJSRuntimeTests.Greeter) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(param0))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (BridgeJSRuntimeTests.APIResult) -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0CaseId = param0.bridgeJSLowerParameter()
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS(callbackValue, param0CaseId)
+            return String.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (BridgeJSRuntimeTests.APIResult) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (BridgeJSRuntimeTests.APIResult) -> String) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(BridgeJSRuntimeTests.APIResult) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(BridgeJSRuntimeTests.APIResult.bridgeJSLiftParameter(param0))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (BridgeJSRuntimeTests.Direction) -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0Value = param0.bridgeJSLowerParameter()
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS(callbackValue, param0Value)
+            return String.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (BridgeJSRuntimeTests.Direction) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (BridgeJSRuntimeTests.Direction) -> String) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(BridgeJSRuntimeTests.Direction) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(BridgeJSRuntimeTests.Direction.bridgeJSLiftParameter(param0))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb_extern(_ callback: Int32, _ param0: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb {
+    static func bridgeJSLift(_ callbackId: Int32) -> (BridgeJSRuntimeTests.Direction) -> Bool {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0Value = param0.bridgeJSLowerParameter()
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb(callbackValue, param0Value)
+            return Bool.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (BridgeJSRuntimeTests.Direction) -> Bool {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (BridgeJSRuntimeTests.Direction) -> Bool) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(BridgeJSRuntimeTests.Direction) -> Bool>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(BridgeJSRuntimeTests.Direction.bridgeJSLiftParameter(param0))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si_extern(_ callback: Int32, _ param0: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si {
+    static func bridgeJSLift(_ callbackId: Int32) -> (BridgeJSRuntimeTests.HttpStatus) -> Int {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0Value = param0.bridgeJSLowerParameter()
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si(callbackValue, param0Value)
+            return Int.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (BridgeJSRuntimeTests.HttpStatus) -> Int {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (BridgeJSRuntimeTests.HttpStatus) -> Int) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(BridgeJSRuntimeTests.HttpStatus) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(BridgeJSRuntimeTests.HttpStatus.bridgeJSLiftParameter(param0))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP_extern(_ callback: Int32, _ param0: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP {
+    static func bridgeJSLift(_ callbackId: Int32) -> (any BridgeJSRuntimeTests.DataProcessor) -> any BridgeJSRuntimeTests.DataProcessor {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP(callbackValue, param0ObjectId)
+            return AnyDataProcessor.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (any BridgeJSRuntimeTests.DataProcessor) -> any BridgeJSRuntimeTests.DataProcessor {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (any BridgeJSRuntimeTests.DataProcessor) -> any BridgeJSRuntimeTests.DataProcessor) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(any BridgeJSRuntimeTests.DataProcessor) -> any BridgeJSRuntimeTests.DataProcessor>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(AnyDataProcessor.bridgeJSLiftParameter(param0))
+    return (result as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS(_ callback: Int32, _ param0: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (any BridgeJSRuntimeTests.DataProcessor) -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0ObjectId = (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS(callbackValue, param0ObjectId)
+            return String.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (any BridgeJSRuntimeTests.DataProcessor) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (any BridgeJSRuntimeTests.DataProcessor) -> String) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(any BridgeJSRuntimeTests.DataProcessor) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(AnyDataProcessor.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -456,226 +645,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests8JS
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTests9APIResultO_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (APIResult) -> String {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0CaseId = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS(callbackValue, param0CaseId)
-            return String.bridgeJSLiftReturn(ret)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (APIResult) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (APIResult) -> String) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9APIResultO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(APIResult) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(APIResult.bridgeJSLiftParameter(param0))
-    return result.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS_extern(callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTests9DirectionO_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Direction) -> String {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0Value = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS(callbackValue, param0Value)
-            return String.bridgeJSLiftReturn(ret)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (Direction) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Direction) -> String) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Direction) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Direction.bridgeJSLiftParameter(param0))
-    return result.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb_extern(_ callback: Int32, _ param0: Int32) -> Int32
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb_extern(_ callback: Int32, _ param0: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb(_ callback: Int32, _ param0: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb_extern(callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTests9DirectionO_Sb {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Direction) -> Bool {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let param0Value = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb(callbackValue, param0Value)
-            return Bool.bridgeJSLiftReturn(ret)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (Direction) -> Bool {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Direction) -> Bool) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTests9DirectionO_Sb(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Direction) -> Bool>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Direction.bridgeJSLiftParameter(param0))
-    return result.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(_ callback: Int32, _ param0: UnsafeMutableRawPointer) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(callback, param0)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestsAl7Polygon_Si {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Polygon) -> Int {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si {
+    static func bridgeJSLift(_ callbackId: Int32) -> (BridgeJSRuntimeTests.Polygon) -> Int {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0Pointer = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(callbackValue, param0Pointer)
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si(callbackValue, param0Pointer)
             return Int.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -684,10 +684,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsAl7Polygon_Si {
     }
 }
 
-extension JSTypedClosure where Signature == (Polygon) -> Int {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Polygon) -> Int) {
+extension JSTypedClosure where Signature == (BridgeJSRuntimeTests.Polygon) -> Int {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (BridgeJSRuntimeTests.Polygon) -> Int) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si,
             body: body,
             fileID: fileID,
             line: line
@@ -695,12 +695,12 @@ extension JSTypedClosure where Signature == (Polygon) -> Int {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl7Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si(_ boxPtr: UnsafeMutableRawPointer, _ param0: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Polygon) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Polygon.bridgeJSLiftParameter(param0))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(BridgeJSRuntimeTests.Polygon) -> Int>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(BridgeJSRuntimeTests.Polygon.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -874,41 +874,41 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsKSS
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> UnsafeMutableRawPointer
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> UnsafeMutableRawPointer
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> UnsafeMutableRawPointer {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> UnsafeMutableRawPointer {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> UnsafeMutableRawPointer {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC_extern(callback, param0Bytes, param0Length)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> UnsafeMutableRawPointer {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC_extern(callback, param0Bytes, param0Length)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsSS_7GreeterC {
-    static func bridgeJSLift(_ callbackId: Int32) -> (String) -> Greeter {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC {
+    static func bridgeJSLift(_ callbackId: Int32) -> (String) -> BridgeJSRuntimeTests.Greeter {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC(callbackValue, param0Bytes, param0Length)
+                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC(callbackValue, param0Bytes, param0Length)
                 return ret
             }
             let ret = ret0
-            return Greeter.bridgeJSLiftReturn(ret)
+            return BridgeJSRuntimeTests.Greeter.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -916,10 +916,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSS_7GreeterC {
     }
 }
 
-extension JSTypedClosure where Signature == (String) -> Greeter {
-    public init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) -> Greeter) {
+extension JSTypedClosure where Signature == (String) -> BridgeJSRuntimeTests.Greeter {
+    public init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (String) -> BridgeJSRuntimeTests.Greeter) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC,
             body: body,
             fileID: fileID,
             line: line
@@ -927,11 +927,11 @@ extension JSTypedClosure where Signature == (String) -> Greeter {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_7GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) -> Greeter>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(String) -> BridgeJSRuntimeTests.Greeter>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure(String.bridgeJSLiftParameter(param0Bytes, param0Length))
     return result.bridgeJSLowerReturn()
     #else
@@ -1006,38 +1006,38 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSS_
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV(_ callback: Int32, _ param0: Float64) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV(_ callback: Int32, _ param0: Float64) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_8Vector2DV {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Double) -> Vector2D {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Double) -> BridgeJSRuntimeTests.Vector2D {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV(callbackValue, param0Value)
-            return Vector2D.bridgeJSLiftReturn()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV(callbackValue, param0Value)
+            return BridgeJSRuntimeTests.Vector2D.bridgeJSLiftReturn()
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -1045,10 +1045,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_8Vector2DV {
     }
 }
 
-extension JSTypedClosure where Signature == (Double) -> Vector2D {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) -> Vector2D) {
+extension JSTypedClosure where Signature == (Double) -> BridgeJSRuntimeTests.Vector2D {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) -> BridgeJSRuntimeTests.Vector2D) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV,
             body: body,
             fileID: fileID,
             line: line
@@ -1056,11 +1056,11 @@ extension JSTypedClosure where Signature == (Double) -> Vector2D {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_8Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) -> Vector2D>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) -> BridgeJSRuntimeTests.Vector2D>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure(Double.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
@@ -1132,38 +1132,38 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV_extern(_ callback: Int32, _ param0: Float64) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV(_ callback: Int32, _ param0: Float64) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV(_ callback: Int32, _ param0: Float64) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV_extern(callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_Sq8Vector2DV {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Double) -> Optional<Vector2D> {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Double) -> Optional<BridgeJSRuntimeTests.Vector2D> {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let param0Value = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV(callbackValue, param0Value)
-            return Optional<Vector2D>.bridgeJSLiftReturn()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV(callbackValue, param0Value)
+            return Optional<BridgeJSRuntimeTests.Vector2D>.bridgeJSLiftReturn()
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -1171,10 +1171,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSd_Sq8Vector2DV {
     }
 }
 
-extension JSTypedClosure where Signature == (Double) -> Optional<Vector2D> {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) -> Optional<Vector2D>) {
+extension JSTypedClosure where Signature == (Double) -> Optional<BridgeJSRuntimeTests.Vector2D> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) -> Optional<BridgeJSRuntimeTests.Vector2D>) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV,
             body: body,
             fileID: fileID,
             line: line
@@ -1182,11 +1182,11 @@ extension JSTypedClosure where Signature == (Double) -> Optional<Vector2D> {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq8Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) -> Optional<Vector2D>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) -> Optional<BridgeJSRuntimeTests.Vector2D>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure(Double.bridgeJSLiftParameter(param0))
     return result.bridgeJSLowerReturn()
     #else
@@ -1516,105 +1516,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSi_
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS_extern(callback, param0IsSome, param0ObjectId)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS_extern(callback, param0IsSome, param0Bytes, param0Length)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsSq13DataProcessorP_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<any DataProcessor>) -> String {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let (param0IsSome, param0ObjectId): (Int32, Int32)
-            if let param0 {
-                (param0IsSome, param0ObjectId) = (1, (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
-            } else {
-                (param0IsSome, param0ObjectId) = (0, 0)
-            }
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS(callbackValue, param0IsSome, param0ObjectId)
-            return String.bridgeJSLiftReturn(ret)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (Optional<any DataProcessor>) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<any DataProcessor>) -> String) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq13DataProcessorP_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<any DataProcessor>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<AnyDataProcessor>.bridgeJSLiftParameter(param0IsSome, param0Value))
-    return result.bridgeJSLowerReturn()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS_extern(callback, param0IsSome, param0Bytes, param0Length)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestsSq5ThemeO_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<Theme>) -> String {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<BridgeJSRuntimeTests.Theme>) -> String {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let ret0 = param0.bridgeJSWithLoweredParameter { (param0IsSome, param0Bytes, param0Length) in
-                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS(callbackValue, param0IsSome, param0Bytes, param0Length)
+                let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS(callbackValue, param0IsSome, param0Bytes, param0Length)
                 return ret
             }
             let ret = ret0
@@ -1626,10 +1558,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq5ThemeO_SS {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<Theme>) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<Theme>) -> String) {
+extension JSTypedClosure where Signature == (Optional<BridgeJSRuntimeTests.Theme>) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<BridgeJSRuntimeTests.Theme>) -> String) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS,
             body: body,
             fileID: fileID,
             line: line
@@ -1637,12 +1569,12 @@ extension JSTypedClosure where Signature == (Optional<Theme>) -> String {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5ThemeO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Theme>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Theme>.bridgeJSLiftParameter(param0IsSome, param0Bytes, param0Length))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<BridgeJSRuntimeTests.Theme>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<BridgeJSRuntimeTests.Theme>.bridgeJSLiftParameter(param0IsSome, param0Bytes, param0Length))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -1650,37 +1582,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq5
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS_extern(callback, param0IsSome, param0Pointer)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS_extern(callback, param0IsSome, param0Pointer)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<Greeter>) -> String {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<BridgeJSRuntimeTests.Greeter>) -> String {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Pointer) = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS(callbackValue, param0IsSome, param0Pointer)
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS(callbackValue, param0IsSome, param0Pointer)
             return String.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -1689,10 +1621,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_SS {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<Greeter>) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<Greeter>) -> String) {
+extension JSTypedClosure where Signature == (Optional<BridgeJSRuntimeTests.Greeter>) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<BridgeJSRuntimeTests.Greeter>) -> String) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS,
             body: body,
             fileID: fileID,
             line: line
@@ -1700,12 +1632,12 @@ extension JSTypedClosure where Signature == (Optional<Greeter>) -> String {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Greeter>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Greeter>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<BridgeJSRuntimeTests.Greeter>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(param0IsSome, param0Value))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -1713,38 +1645,38 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC_extern(callback, param0IsSome, param0Pointer)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC(_ callback: Int32, _ param0IsSome: Int32, _ param0Pointer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC_extern(callback, param0IsSome, param0Pointer)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<Greeter>) -> Optional<Greeter> {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<BridgeJSRuntimeTests.Greeter>) -> Optional<BridgeJSRuntimeTests.Greeter> {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Pointer) = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC(callbackValue, param0IsSome, param0Pointer)
-            return Optional<Greeter>.bridgeJSLiftReturn(ret)
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC(callbackValue, param0IsSome, param0Pointer)
+            return Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -1752,10 +1684,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<Greeter>) -> Optional<Greeter> {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<Greeter>) -> Optional<Greeter>) {
+extension JSTypedClosure where Signature == (Optional<BridgeJSRuntimeTests.Greeter>) -> Optional<BridgeJSRuntimeTests.Greeter> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<BridgeJSRuntimeTests.Greeter>) -> Optional<BridgeJSRuntimeTests.Greeter>) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC,
             body: body,
             fileID: fileID,
             line: line
@@ -1763,12 +1695,12 @@ extension JSTypedClosure where Signature == (Optional<Greeter>) -> Optional<Gree
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Greeter>) -> Optional<Greeter>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Greeter>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<BridgeJSRuntimeTests.Greeter>) -> Optional<BridgeJSRuntimeTests.Greeter>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(param0IsSome, param0Value))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -1776,37 +1708,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq7
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS_extern(callback, param0IsSome, param0CaseId)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS_extern(callback, param0IsSome, param0CaseId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsSq9APIResultO_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<APIResult>) -> String {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<BridgeJSRuntimeTests.APIResult>) -> String {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0CaseId) = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS(callbackValue, param0IsSome, param0CaseId)
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS(callbackValue, param0IsSome, param0CaseId)
             return String.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -1815,10 +1747,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq9APIResultO_SS {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<APIResult>) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<APIResult>) -> String) {
+extension JSTypedClosure where Signature == (Optional<BridgeJSRuntimeTests.APIResult>) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<BridgeJSRuntimeTests.APIResult>) -> String) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS,
             body: body,
             fileID: fileID,
             line: line
@@ -1826,12 +1758,12 @@ extension JSTypedClosure where Signature == (Optional<APIResult>) -> String {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9APIResultO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<APIResult>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<APIResult>.bridgeJSLiftParameter(param0IsSome, param0CaseId))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<BridgeJSRuntimeTests.APIResult>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftParameter(param0IsSome, param0CaseId))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -1839,37 +1771,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS_extern(callback, param0IsSome, param0Value)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0Value: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS_extern(callback, param0IsSome, param0Value)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsSq9DirectionO_SS {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<Direction>) -> String {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<BridgeJSRuntimeTests.Direction>) -> String {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0Value) = param0.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS(callbackValue, param0IsSome, param0Value)
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS(callbackValue, param0IsSome, param0Value)
             return String.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -1878,10 +1810,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsSq9DirectionO_SS {
     }
 }
 
-extension JSTypedClosure where Signature == (Optional<Direction>) -> String {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<Direction>) -> String) {
+extension JSTypedClosure where Signature == (Optional<BridgeJSRuntimeTests.Direction>) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<BridgeJSRuntimeTests.Direction>) -> String) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS,
             body: body,
             fileID: fileID,
             line: line
@@ -1889,12 +1821,80 @@ extension JSTypedClosure where Signature == (Optional<Direction>) -> String {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq9DirectionO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<Direction>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    let result = closure(Optional<Direction>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<BridgeJSRuntimeTests.Direction>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<BridgeJSRuntimeTests.Direction>.bridgeJSLiftParameter(param0IsSome, param0Value))
+    return result.bridgeJSLowerReturn()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS(_ callback: Int32, _ param0IsSome: Int32, _ param0ObjectId: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS_extern(callback, param0IsSome, param0ObjectId)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Optional<any BridgeJSRuntimeTests.DataProcessor>) -> String {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let (param0IsSome, param0ObjectId): (Int32, Int32)
+            if let param0 {
+                (param0IsSome, param0ObjectId) = (1, (param0 as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
+            } else {
+                (param0IsSome, param0ObjectId) = (0, 0)
+            }
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS(callbackValue, param0IsSome, param0ObjectId)
+            return String.bridgeJSLiftReturn(ret)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (Optional<any BridgeJSRuntimeTests.DataProcessor>) -> String {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Optional<any BridgeJSRuntimeTests.DataProcessor>) -> String) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0Value: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Optional<any BridgeJSRuntimeTests.DataProcessor>) -> String>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let result = closure(Optional<AnyDataProcessor>.bridgeJSLiftParameter(param0IsSome, param0Value))
     return result.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
@@ -2172,42 +2172,42 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaK
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(resolveRef, rejectRef, callback, param0)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(resolveRef, rejectRef, callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Bool) async throws(JSException) -> AsyncPayloadResult {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Bool) async throws(JSException) -> BridgeJSRuntimeTests.AsyncPayloadResult {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: Bool) async throws(JSException) -> AsyncPayloadResult in
+        return { [callback] (param0: Bool) async throws(JSException) -> BridgeJSRuntimeTests.AsyncPayloadResult in
             #if arch(wasm32)
             let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
-                    JSTypedClosure<(sending AsyncPayloadResult) -> Void>($0)
+                    JSTypedClosure<(sending BridgeJSRuntimeTests.AsyncPayloadResult) -> Void>($0)
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
                 let callbackValue = callback.bridgeJSLowerParameter()
                 let param0Value = param0.bridgeJSLowerParameter()
-                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(resolveRef, rejectRef, callbackValue, param0Value)
+                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO(resolveRef, rejectRef, callbackValue, param0Value)
             }
             return resolved
             #else
@@ -2217,10 +2217,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO {
     }
 }
 
-extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> AsyncPayloadResult {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Bool) async throws(JSException) -> AsyncPayloadResult) {
+extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> BridgeJSRuntimeTests.AsyncPayloadResult {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Bool) async throws(JSException) -> BridgeJSRuntimeTests.AsyncPayloadResult) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO,
             body: body,
             fileID: fileID,
             line: line
@@ -2228,12 +2228,12 @@ extension JSTypedClosure where Signature == (Bool) async throws(JSException) -> 
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Bool) async throws(JSException) -> AsyncPayloadResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    return _bjs_makePromise(resolve: Promise_resolve_18AsyncPayloadResultO, reject: Promise_reject) { () async throws(JSException) -> AsyncPayloadResult in
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Bool) async throws(JSException) -> BridgeJSRuntimeTests.AsyncPayloadResult>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_39BridgeJSRuntimeTests_AsyncPayloadResultO, reject: Promise_reject) { () async throws(JSException) -> BridgeJSRuntimeTests.AsyncPayloadResult in
         return try await closure(Bool.bridgeJSLiftParameter(param0))
     }
     #else
@@ -2313,42 +2313,42 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaS
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV_extern(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(resolveRef, rejectRef, callback, param0)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV(_ resolveRef: Int32, _ rejectRef: Int32, _ callback: Int32, _ param0: Float64) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV_extern(resolveRef, rejectRef, callback, param0)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSd_9DataPointV {
-    static func bridgeJSLift(_ callbackId: Int32) -> (Double) async -> DataPoint {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV {
+    static func bridgeJSLift(_ callbackId: Int32) -> (Double) async -> BridgeJSRuntimeTests.DataPoint {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] (param0: Double) async -> DataPoint in
+        return { [callback] (param0: Double) async -> BridgeJSRuntimeTests.DataPoint in
             #if arch(wasm32)
             let resolved = try! await _bjs_awaitPromise(makeResolveClosure: {
-                    JSTypedClosure<(sending DataPoint) -> Void>($0)
+                    JSTypedClosure<(sending BridgeJSRuntimeTests.DataPoint) -> Void>($0)
                 }, makeRejectClosure: {
                     JSTypedClosure<(sending JSValue) -> Void>($0)
                 }) { resolveRef, rejectRef in
                 let callbackValue = callback.bridgeJSLowerParameter()
                 let param0Value = param0.bridgeJSLowerParameter()
-                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(resolveRef, rejectRef, callbackValue, param0Value)
+                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV(resolveRef, rejectRef, callbackValue, param0Value)
             }
             return resolved
             #else
@@ -2358,10 +2358,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsYaSd_9DataPointV {
     }
 }
 
-extension JSTypedClosure where Signature == (Double) async -> DataPoint {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) async -> DataPoint) {
+extension JSTypedClosure where Signature == (Double) async -> BridgeJSRuntimeTests.DataPoint {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (Double) async -> BridgeJSRuntimeTests.DataPoint) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV,
             body: body,
             fileID: fileID,
             line: line
@@ -2369,76 +2369,14 @@ extension JSTypedClosure where Signature == (Double) async -> DataPoint {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_9DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV(_ boxPtr: UnsafeMutableRawPointer, _ param0: Float64) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) async -> DataPoint>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    return _bjs_makePromise(resolve: Promise_resolve_9DataPointV, reject: Promise_reject) {
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(Double) async -> BridgeJSRuntimeTests.DataPoint>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    return _bjs_makePromise(resolve: Promise_resolve_30BridgeJSRuntimeTests_DataPointV, reject: Promise_reject) {
         return await closure(Double.bridgeJSLiftParameter(param0))
     }
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y_extern(callback, param0Bytes, param0Length)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestss11FeatureFlagO_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending FeatureFlag) -> Void {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
-                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y(callbackValue, param0Bytes, param0Length)
-            }
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (sending FeatureFlag) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending FeatureFlag) -> Void) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11FeatureFlagO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending FeatureFlag) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(FeatureFlag.bridgeJSLiftParameter(param0Bytes, param0Length))
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -2506,37 +2444,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss11
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y_extern(_ callback: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y_extern(_ callback: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y(_ callback: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y_extern(callback)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending AsyncPayloadResult) -> Void {
+private enum _BJS_Closure_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending BridgeJSRuntimeTests.DataPoint) -> Void {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
-            let param0CaseId = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(callbackValue, param0CaseId)
+            let _ = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y(callbackValue)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -2544,10 +2482,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y {
     }
 }
 
-extension JSTypedClosure where Signature == (sending AsyncPayloadResult) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending AsyncPayloadResult) -> Void) {
+extension JSTypedClosure where Signature == (sending BridgeJSRuntimeTests.DataPoint) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending BridgeJSRuntimeTests.DataPoint) -> Void) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y,
             body: body,
             fileID: fileID,
             line: line
@@ -2555,49 +2493,50 @@ extension JSTypedClosure where Signature == (sending AsyncPayloadResult) -> Void
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss18AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss30BridgeJSRuntimeTests_DataPointV_y(_ boxPtr: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending AsyncPayloadResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(AsyncPayloadResult.bridgeJSLiftParameter(param0))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending BridgeJSRuntimeTests.DataPoint) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(BridgeJSRuntimeTests.DataPoint.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y_extern(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(callback, param0)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y(_ callback: Int32, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y_extern(callback, param0Bytes, param0Length)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending AsyncImportedPayloadResult) -> Void {
+private enum _BJS_Closure_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending BridgeJSRuntimeTests.FeatureFlag) -> Void {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
-            let param0CaseId = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(callbackValue, param0CaseId)
+            param0.bridgeJSWithLoweredParameter { (param0Bytes, param0Length) in
+                invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y(callbackValue, param0Bytes, param0Length)
+            }
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -2605,10 +2544,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y
     }
 }
 
-extension JSTypedClosure where Signature == (sending AsyncImportedPayloadResult) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending AsyncImportedPayloadResult) -> Void) {
+extension JSTypedClosure where Signature == (sending BridgeJSRuntimeTests.FeatureFlag) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending BridgeJSRuntimeTests.FeatureFlag) -> Void) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y,
             body: body,
             fileID: fileID,
             line: line
@@ -2616,12 +2555,134 @@ extension JSTypedClosure where Signature == (sending AsyncImportedPayloadResult)
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss32BridgeJSRuntimeTests_FeatureFlagO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0Bytes: Int32, _ param0Length: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending AsyncImportedPayloadResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(AsyncImportedPayloadResult.bridgeJSLiftParameter(param0))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending BridgeJSRuntimeTests.FeatureFlag) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(BridgeJSRuntimeTests.FeatureFlag.bridgeJSLiftParameter(param0Bytes, param0Length))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending BridgeJSRuntimeTests.AsyncPayloadResult) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0CaseId = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y(callbackValue, param0CaseId)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending BridgeJSRuntimeTests.AsyncPayloadResult) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending BridgeJSRuntimeTests.AsyncPayloadResult) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss39BridgeJSRuntimeTests_AsyncPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending BridgeJSRuntimeTests.AsyncPayloadResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(BridgeJSRuntimeTests.AsyncPayloadResult.bridgeJSLiftParameter(param0))
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void
+#else
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0: Int32) -> Void {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y(_ callback: Int32, _ param0: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(callback, param0)
+}
+
+#if arch(wasm32)
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+#else
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    fatalError("Only available on WebAssembly")
+}
+#endif
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(boxPtr, file, line)
+}
+
+private enum _BJS_Closure_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending BridgeJSRuntimeTests.AsyncImportedPayloadResult) -> Void {
+        let callback = JSObject.bridgeJSLiftParameter(callbackId)
+        return { [callback] param0 in
+            #if arch(wasm32)
+            let callbackValue = callback.bridgeJSLowerParameter()
+            let param0CaseId = param0.bridgeJSLowerParameter()
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y(callbackValue, param0CaseId)
+            #else
+            fatalError("Only available on WebAssembly")
+            #endif
+        }
+    }
+}
+
+extension JSTypedClosure where Signature == (sending BridgeJSRuntimeTests.AsyncImportedPayloadResult) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending BridgeJSRuntimeTests.AsyncImportedPayloadResult) -> Void) {
+        self.init(
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y,
+            body: body,
+            fileID: fileID,
+            line: line
+        )
+    }
+}
+
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0: Int32) -> Void {
+    #if arch(wasm32)
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending BridgeJSRuntimeTests.AsyncImportedPayloadResult) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(BridgeJSRuntimeTests.AsyncImportedPayloadResult.bridgeJSLiftParameter(param0))
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -2683,67 +2744,6 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss7J
     #if arch(wasm32)
     let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending JSValue) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     closure(JSValue.bridgeJSLiftParameter(param0Kind, param0Payload1, param0Payload2))
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ callback: Int32) -> Void
-#else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ callback: Int32) -> Void {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ callback: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(callback)
-}
-
-#if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
-#else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    fatalError("Only available on WebAssembly")
-}
-#endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y_extern(boxPtr, file, line)
-}
-
-private enum _BJS_Closure_20BridgeJSRuntimeTestss9DataPointV_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending DataPoint) -> Void {
-        let callback = JSObject.bridgeJSLiftParameter(callbackId)
-        return { [callback] param0 in
-            #if arch(wasm32)
-            let callbackValue = callback.bridgeJSLowerParameter()
-            let _ = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(callbackValue)
-            #else
-            fatalError("Only available on WebAssembly")
-            #endif
-        }
-    }
-}
-
-extension JSTypedClosure where Signature == (sending DataPoint) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending DataPoint) -> Void) {
-        self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y,
-            body: body,
-            fileID: fileID,
-            line: line
-        )
-    }
-}
-
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestss9DataPointV_y(_ boxPtr: UnsafeMutableRawPointer) -> Void {
-    #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending DataPoint) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(DataPoint.bridgeJSLiftParameter())
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -3117,37 +3117,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSd
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(callback, param0IsSome, param0CaseId)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y(_ callback: Int32, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(callback, param0IsSome, param0CaseId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y {
-    static func bridgeJSLift(_ callbackId: Int32) -> (sending Optional<AsyncImportedPayloadResult>) -> Void {
+private enum _BJS_Closure_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y {
+    static func bridgeJSLift(_ callbackId: Int32) -> (sending Optional<BridgeJSRuntimeTests.AsyncImportedPayloadResult>) -> Void {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] param0 in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
             let (param0IsSome, param0CaseId) = param0.bridgeJSLowerParameter()
-            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(callbackValue, param0IsSome, param0CaseId)
+            invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y(callbackValue, param0IsSome, param0CaseId)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -3155,10 +3155,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO
     }
 }
 
-extension JSTypedClosure where Signature == (sending Optional<AsyncImportedPayloadResult>) -> Void {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending Optional<AsyncImportedPayloadResult>) -> Void) {
+extension JSTypedClosure where Signature == (sending Optional<BridgeJSRuntimeTests.AsyncImportedPayloadResult>) -> Void {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping (sending Optional<BridgeJSRuntimeTests.AsyncImportedPayloadResult>) -> Void) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y,
             body: body,
             fileID: fileID,
             line: line
@@ -3166,12 +3166,12 @@ extension JSTypedClosure where Signature == (sending Optional<AsyncImportedPaylo
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq26AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq47BridgeJSRuntimeTests_AsyncImportedPayloadResultO_y(_ boxPtr: UnsafeMutableRawPointer, _ param0IsSome: Int32, _ param0CaseId: Int32) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending Optional<AsyncImportedPayloadResult>) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
-    closure(Optional<AsyncImportedPayloadResult>.bridgeJSLiftParameter(param0IsSome, param0CaseId))
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<(sending Optional<BridgeJSRuntimeTests.AsyncImportedPayloadResult>) -> Void>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    closure(Optional<BridgeJSRuntimeTests.AsyncImportedPayloadResult>.bridgeJSLiftParameter(param0IsSome, param0CaseId))
     #else
     fatalError("Only available on WebAssembly")
     #endif
@@ -3301,36 +3301,36 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestssSq
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP_extern(_ callback: Int32) -> Int32
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP_extern(_ callback: Int32) -> Int32
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP_extern(_ callback: Int32) -> Int32 {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP_extern(_ callback: Int32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP(_ callback: Int32) -> Int32 {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP_extern(callback)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP(_ callback: Int32) -> Int32 {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP_extern(callback)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsy_13DataProcessorP {
-    static func bridgeJSLift(_ callbackId: Int32) -> () -> any DataProcessor {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP {
+    static func bridgeJSLift(_ callbackId: Int32) -> () -> any BridgeJSRuntimeTests.DataProcessor {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP(callbackValue)
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP(callbackValue)
             return AnyDataProcessor.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
@@ -3339,10 +3339,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsy_13DataProcessorP {
     }
 }
 
-extension JSTypedClosure where Signature == () -> any DataProcessor {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping () -> any DataProcessor) {
+extension JSTypedClosure where Signature == () -> any BridgeJSRuntimeTests.DataProcessor {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping () -> any BridgeJSRuntimeTests.DataProcessor) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP,
             body: body,
             fileID: fileID,
             line: line
@@ -3350,11 +3350,11 @@ extension JSTypedClosure where Signature == () -> any DataProcessor {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_13DataProcessorP(_ boxPtr: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP(_ boxPtr: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> any DataProcessor>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> any BridgeJSRuntimeTests.DataProcessor>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure()
     return (result as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn()
     #else
@@ -3425,37 +3425,37 @@ public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_S
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC")
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC_extern(_ callback: Int32) -> UnsafeMutableRawPointer
+@_extern(wasm, module: "bjs", name: "invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC")
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC_extern(_ callback: Int32) -> UnsafeMutableRawPointer
 #else
-fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC_extern(_ callback: Int32) -> UnsafeMutableRawPointer {
+fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC_extern(_ callback: Int32) -> UnsafeMutableRawPointer {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC(_ callback: Int32) -> UnsafeMutableRawPointer {
-    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC_extern(callback)
+@inline(never) fileprivate func invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC(_ callback: Int32) -> UnsafeMutableRawPointer {
+    return invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC_extern(callback)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC")
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
+@_extern(wasm, module: "bjs", name: "make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC")
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32
 #else
-fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC_extern(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
-    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC_extern(boxPtr, file, line)
+@inline(never) fileprivate func make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC(_ boxPtr: UnsafeMutableRawPointer, _ file: UnsafePointer<UInt8>, _ line: UInt32) -> Int32 {
+    return make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC_extern(boxPtr, file, line)
 }
 
-private enum _BJS_Closure_20BridgeJSRuntimeTestsy_Sq7GreeterC {
-    static func bridgeJSLift(_ callbackId: Int32) -> () -> Optional<Greeter> {
+private enum _BJS_Closure_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC {
+    static func bridgeJSLift(_ callbackId: Int32) -> () -> Optional<BridgeJSRuntimeTests.Greeter> {
         let callback = JSObject.bridgeJSLiftParameter(callbackId)
         return { [callback] in
             #if arch(wasm32)
             let callbackValue = callback.bridgeJSLowerParameter()
-            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC(callbackValue)
-            return Optional<Greeter>.bridgeJSLiftReturn(ret)
+            let ret = invoke_js_callback_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC(callbackValue)
+            return Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftReturn(ret)
             #else
             fatalError("Only available on WebAssembly")
             #endif
@@ -3463,10 +3463,10 @@ private enum _BJS_Closure_20BridgeJSRuntimeTestsy_Sq7GreeterC {
     }
 }
 
-extension JSTypedClosure where Signature == () -> Optional<Greeter> {
-    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping () -> Optional<Greeter>) {
+extension JSTypedClosure where Signature == () -> Optional<BridgeJSRuntimeTests.Greeter> {
+    init(fileID: StaticString = #fileID, line: UInt32 = #line, _ body: @escaping () -> Optional<BridgeJSRuntimeTests.Greeter>) {
         self.init(
-            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC,
+            makeClosure: make_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC,
             body: body,
             fileID: fileID,
             line: line
@@ -3474,11 +3474,11 @@ extension JSTypedClosure where Signature == () -> Optional<Greeter> {
     }
 }
 
-@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC")
-@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC")
-public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq7GreeterC(_ boxPtr: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC")
+@_cdecl("invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC")
+public func _invoke_swift_closure_BridgeJSRuntimeTests_20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC(_ boxPtr: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> Optional<Greeter>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
+    let closure = Unmanaged<_BridgeJSTypedClosureBox<() -> Optional<BridgeJSRuntimeTests.Greeter>>>.fromOpaque(boxPtr).takeUnretainedValue().closure
     let result = closure()
     return result.bridgeJSLowerReturn()
     #else
@@ -3627,42 +3627,42 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
         return Bool.bridgeJSLiftReturn(ret)
     }
 
-    func processGreeter(_ greeter: Greeter) -> String {
+    func processGreeter(_ greeter: BridgeJSRuntimeTests.Greeter) -> String {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let greeterPointer = greeter.bridgeJSLowerParameter()
         let ret = _extern_processGreeter(jsObjectValue, greeterPointer)
         return String.bridgeJSLiftReturn(ret)
     }
 
-    func createGreeter() -> Greeter {
+    func createGreeter() -> BridgeJSRuntimeTests.Greeter {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createGreeter(jsObjectValue)
-        return Greeter.bridgeJSLiftReturn(ret)
+        return BridgeJSRuntimeTests.Greeter.bridgeJSLiftReturn(ret)
     }
 
-    func processOptionalGreeter(_ greeter: Optional<Greeter>) -> String {
+    func processOptionalGreeter(_ greeter: Optional<BridgeJSRuntimeTests.Greeter>) -> String {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let (greeterIsSome, greeterPointer) = greeter.bridgeJSLowerParameter()
         let ret = _extern_processOptionalGreeter(jsObjectValue, greeterIsSome, greeterPointer)
         return String.bridgeJSLiftReturn(ret)
     }
 
-    func createOptionalGreeter() -> Optional<Greeter> {
+    func createOptionalGreeter() -> Optional<BridgeJSRuntimeTests.Greeter> {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_createOptionalGreeter(jsObjectValue)
-        return Optional<Greeter>.bridgeJSLiftReturn(ret)
+        return Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftReturn(ret)
     }
 
-    func handleAPIResult(_ result: Optional<APIResult>) -> Void {
+    func handleAPIResult(_ result: Optional<BridgeJSRuntimeTests.APIResult>) -> Void {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let (resultIsSome, resultCaseId) = result.bridgeJSLowerParameter()
         _extern_handleAPIResult(jsObjectValue, resultIsSome, resultCaseId)
     }
 
-    func getAPIResult() -> Optional<APIResult> {
+    func getAPIResult() -> Optional<BridgeJSRuntimeTests.APIResult> {
         let jsObjectValue = jsObject.bridgeJSLowerParameter()
         let ret = _extern_getAPIResult(jsObjectValue)
-        return Optional<APIResult>.bridgeJSLiftReturn(ret)
+        return Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftReturn(ret)
     }
 
     var count: Int {
@@ -3713,11 +3713,11 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
         }
     }
 
-    var direction: Optional<Direction> {
+    var direction: Optional<BridgeJSRuntimeTests.Direction> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_direction_get(jsObjectValue)
-            return Optional<Direction>.bridgeJSLiftReturn(ret)
+            return Optional<BridgeJSRuntimeTests.Direction>.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -3726,11 +3726,11 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
         }
     }
 
-    var optionalTheme: Optional<Theme> {
+    var optionalTheme: Optional<BridgeJSRuntimeTests.Theme> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_optionalTheme_get(jsObjectValue)
-            return Optional<Theme>.bridgeJSLiftReturnFromSideChannel()
+            return Optional<BridgeJSRuntimeTests.Theme>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -3740,11 +3740,11 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
         }
     }
 
-    var httpStatus: Optional<HttpStatus> {
+    var httpStatus: Optional<BridgeJSRuntimeTests.HttpStatus> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             bjs_DataProcessor_httpStatus_get(jsObjectValue)
-            return Optional<HttpStatus>.bridgeJSLiftReturnFromSideChannel()
+            return Optional<BridgeJSRuntimeTests.HttpStatus>.bridgeJSLiftReturnFromSideChannel()
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -3753,11 +3753,11 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
         }
     }
 
-    var apiResult: Optional<APIResult> {
+    var apiResult: Optional<BridgeJSRuntimeTests.APIResult> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_apiResult_get(jsObjectValue)
-            return Optional<APIResult>.bridgeJSLiftReturn(ret)
+            return Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -3766,11 +3766,11 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
         }
     }
 
-    var helper: Greeter {
+    var helper: BridgeJSRuntimeTests.Greeter {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_helper_get(jsObjectValue)
-            return Greeter.bridgeJSLiftReturn(ret)
+            return BridgeJSRuntimeTests.Greeter.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -3779,11 +3779,11 @@ struct AnyDataProcessor: DataProcessor, _BridgedSwiftProtocolWrapper {
         }
     }
 
-    var optionalHelper: Optional<Greeter> {
+    var optionalHelper: Optional<BridgeJSRuntimeTests.Greeter> {
         get {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
             let ret = bjs_DataProcessor_optionalHelper_get(jsObjectValue)
-            return Optional<Greeter>.bridgeJSLiftReturn(ret)
+            return Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftReturn(ret)
         }
         set {
             let jsObjectValue = jsObject.bridgeJSLowerParameter()
@@ -4157,15 +4157,15 @@ fileprivate func bjs_DataProcessor_optionalHelper_set_extern(_ jsObject: Int32, 
     return bjs_DataProcessor_optionalHelper_set_extern(jsObject, newValueIsSome, newValuePointer)
 }
 
-extension Severity: _BridgedSwiftCaseEnum {
+extension BridgeJSRuntimeTests.Severity: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Severity {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSRuntimeTests.Severity {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Severity {
-        return Severity(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSRuntimeTests.Severity {
+        return BridgeJSRuntimeTests.Severity(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -4196,15 +4196,15 @@ extension Severity: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Shape: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Shape {
+extension BridgeJSRuntimeTests.Shape: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.Shape {
         switch caseId {
         case 0:
-            return .polygon(Polygon.bridgeJSStackPop())
+            return .polygon(BridgeJSRuntimeTests.Polygon.bridgeJSStackPop())
         case 1:
             return .empty
         default:
-            fatalError("Unknown Shape case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.Shape case ID: \(caseId)")
         }
     }
 
@@ -4219,15 +4219,15 @@ extension Shape: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension InnerTag: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> InnerTag {
+extension BridgeJSRuntimeTests.InnerTag: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.InnerTag {
         switch caseId {
         case 0:
             return .payload(Int.bridgeJSStackPop())
         case 1:
             return .empty
         default:
-            fatalError("Unknown InnerTag case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.InnerTag case ID: \(caseId)")
         }
     }
 
@@ -4242,220 +4242,220 @@ extension InnerTag: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripIntArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripIntArray")
-public func _bjs_ArraySupportExports_static_roundTripIntArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripIntArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripIntArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripIntArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripIntArray(_: [Int].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripIntArray(_: [Int].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripStringArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripStringArray")
-public func _bjs_ArraySupportExports_static_roundTripStringArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStringArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStringArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStringArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripStringArray(_: [String].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripStringArray(_: [String].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripDoubleArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripDoubleArray")
-public func _bjs_ArraySupportExports_static_roundTripDoubleArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripDoubleArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripDoubleArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripDoubleArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripDoubleArray(_: [Double].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripDoubleArray(_: [Double].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripBoolArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripBoolArray")
-public func _bjs_ArraySupportExports_static_roundTripBoolArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripBoolArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripBoolArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripBoolArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripBoolArray(_: [Bool].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripBoolArray(_: [Bool].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripUnsafeRawPointerArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripUnsafeRawPointerArray")
-public func _bjs_ArraySupportExports_static_roundTripUnsafeRawPointerArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeRawPointerArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeRawPointerArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripUnsafeRawPointerArray(_: [UnsafeRawPointer].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripUnsafeRawPointerArray(_: [UnsafeRawPointer].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripUnsafeMutableRawPointerArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripUnsafeMutableRawPointerArray")
-public func _bjs_ArraySupportExports_static_roundTripUnsafeMutableRawPointerArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeMutableRawPointerArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeMutableRawPointerArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeMutableRawPointerArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripUnsafeMutableRawPointerArray(_: [UnsafeMutableRawPointer].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripUnsafeMutableRawPointerArray(_: [UnsafeMutableRawPointer].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOpaquePointerArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOpaquePointerArray")
-public func _bjs_ArraySupportExports_static_roundTripOpaquePointerArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOpaquePointerArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOpaquePointerArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOpaquePointerArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOpaquePointerArray(_: [OpaquePointer].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOpaquePointerArray(_: [OpaquePointer].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripUnsafePointerArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripUnsafePointerArray")
-public func _bjs_ArraySupportExports_static_roundTripUnsafePointerArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafePointerArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafePointerArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafePointerArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripUnsafePointerArray(_: [UnsafePointer<UInt8>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripUnsafePointerArray(_: [UnsafePointer<UInt8>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripUnsafeMutablePointerArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripUnsafeMutablePointerArray")
-public func _bjs_ArraySupportExports_static_roundTripUnsafeMutablePointerArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeMutablePointerArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeMutablePointerArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeMutablePointerArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripUnsafeMutablePointerArray(_: [UnsafeMutablePointer<UInt8>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripUnsafeMutablePointerArray(_: [UnsafeMutablePointer<UInt8>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripJSValueArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripJSValueArray")
-public func _bjs_ArraySupportExports_static_roundTripJSValueArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSValueArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSValueArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSValueArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripJSValueArray(_: [JSValue].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripJSValueArray(_: [JSValue].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripJSObjectArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripJSObjectArray")
-public func _bjs_ArraySupportExports_static_roundTripJSObjectArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSObjectArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSObjectArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSObjectArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripJSObjectArray(_: [JSObject].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripJSObjectArray(_: [JSObject].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripCaseEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripCaseEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripCaseEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripCaseEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripCaseEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripCaseEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripCaseEnumArray(_: [Direction].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripCaseEnumArray(_: [BridgeJSRuntimeTests.Direction].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripStringRawValueEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripStringRawValueEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripStringRawValueEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStringRawValueEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStringRawValueEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStringRawValueEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripStringRawValueEnumArray(_: [Theme].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripStringRawValueEnumArray(_: [BridgeJSRuntimeTests.Theme].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripIntRawValueEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripIntRawValueEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripIntRawValueEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripIntRawValueEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripIntRawValueEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripIntRawValueEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripIntRawValueEnumArray(_: [HttpStatus].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripIntRawValueEnumArray(_: [BridgeJSRuntimeTests.HttpStatus].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripInt64RawValueEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripInt64RawValueEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripInt64RawValueEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripInt64RawValueEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripInt64RawValueEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripInt64RawValueEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripInt64RawValueEnumArray(_: [FileSize].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripInt64RawValueEnumArray(_: [BridgeJSRuntimeTests.FileSize].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripUInt64RawValueEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripUInt64RawValueEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripUInt64RawValueEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUInt64RawValueEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUInt64RawValueEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUInt64RawValueEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripUInt64RawValueEnumArray(_: [SessionId].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripUInt64RawValueEnumArray(_: [BridgeJSRuntimeTests.SessionId].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripStructArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripStructArray")
-public func _bjs_ArraySupportExports_static_roundTripStructArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStructArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStructArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStructArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripStructArray(_: [DataPoint].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripStructArray(_: [BridgeJSRuntimeTests.DataPoint].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripSwiftClassArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripSwiftClassArray")
-public func _bjs_ArraySupportExports_static_roundTripSwiftClassArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripSwiftClassArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripSwiftClassArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripSwiftClassArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripSwiftClassArray(_: [Greeter].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripSwiftClassArray(_: [BridgeJSRuntimeTests.Greeter].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripNamespacedSwiftClassArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripNamespacedSwiftClassArray")
-public func _bjs_ArraySupportExports_static_roundTripNamespacedSwiftClassArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNamespacedSwiftClassArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNamespacedSwiftClassArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNamespacedSwiftClassArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripNamespacedSwiftClassArray(_: [Utils.Converter].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripNamespacedSwiftClassArray(_: [BridgeJSRuntimeTests.Utils.Converter].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripProtocolArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripProtocolArray")
-public func _bjs_ArraySupportExports_static_roundTripProtocolArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripProtocolArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripProtocolArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripProtocolArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripProtocolArray(_: [AnyArrayElementProtocol].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripProtocolArray(_: [AnyArrayElementProtocol].bridgeJSStackPop())
     for __bjs_elem_ret in ret {
         _swift_js_push_i32((__bjs_elem_ret as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
     }
@@ -4465,269 +4465,269 @@ public func _bjs_ArraySupportExports_static_roundTripProtocolArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripJSClassArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripJSClassArray")
-public func _bjs_ArraySupportExports_static_roundTripJSClassArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSClassArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSClassArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSClassArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripJSClassArray(_: [ArrayElementObject].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripJSClassArray(_: [ArrayElementObject].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalIntArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalIntArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalIntArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalIntArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalIntArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalIntArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalIntArray(_: [Optional<Int>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalIntArray(_: [Optional<Int>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalStringArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalStringArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalStringArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStringArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStringArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStringArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalStringArray(_: [Optional<String>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalStringArray(_: [Optional<String>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalJSObjectArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalJSObjectArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalJSObjectArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalJSObjectArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalJSObjectArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalJSObjectArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalJSObjectArray(_: [Optional<JSObject>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalJSObjectArray(_: [Optional<JSObject>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalCaseEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalCaseEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalCaseEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalCaseEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalCaseEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalCaseEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalCaseEnumArray(_: [Optional<Direction>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalCaseEnumArray(_: [Optional<BridgeJSRuntimeTests.Direction>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalStringRawValueEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalStringRawValueEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalStringRawValueEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStringRawValueEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStringRawValueEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStringRawValueEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalStringRawValueEnumArray(_: [Optional<Theme>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalStringRawValueEnumArray(_: [Optional<BridgeJSRuntimeTests.Theme>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalIntRawValueEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalIntRawValueEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalIntRawValueEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalIntRawValueEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalIntRawValueEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalIntRawValueEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalIntRawValueEnumArray(_: [Optional<HttpStatus>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalIntRawValueEnumArray(_: [Optional<BridgeJSRuntimeTests.HttpStatus>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalInt64RawValueEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalInt64RawValueEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalInt64RawValueEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalInt64RawValueEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalInt64RawValueEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalInt64RawValueEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalInt64RawValueEnumArray(_: [Optional<FileSize>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalInt64RawValueEnumArray(_: [Optional<BridgeJSRuntimeTests.FileSize>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalUInt64RawValueEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalUInt64RawValueEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalUInt64RawValueEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalUInt64RawValueEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalUInt64RawValueEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalUInt64RawValueEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalUInt64RawValueEnumArray(_: [Optional<SessionId>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalUInt64RawValueEnumArray(_: [Optional<BridgeJSRuntimeTests.SessionId>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalStructArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalStructArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalStructArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStructArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStructArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStructArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalStructArray(_: [Optional<DataPoint>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalStructArray(_: [Optional<BridgeJSRuntimeTests.DataPoint>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalSwiftClassArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalSwiftClassArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalSwiftClassArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalSwiftClassArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalSwiftClassArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalSwiftClassArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalSwiftClassArray(_: [Optional<Greeter>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalSwiftClassArray(_: [Optional<BridgeJSRuntimeTests.Greeter>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripOptionalJSClassArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripOptionalJSClassArray")
-public func _bjs_ArraySupportExports_static_roundTripOptionalJSClassArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalJSClassArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalJSClassArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalJSClassArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripOptionalJSClassArray(_: [Optional<ArrayElementObject>].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripOptionalJSClassArray(_: [Optional<ArrayElementObject>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripNestedIntArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripNestedIntArray")
-public func _bjs_ArraySupportExports_static_roundTripNestedIntArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedIntArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedIntArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedIntArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripNestedIntArray(_: [[Int]].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripNestedIntArray(_: [[Int]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripNestedStringArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripNestedStringArray")
-public func _bjs_ArraySupportExports_static_roundTripNestedStringArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedStringArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedStringArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedStringArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripNestedStringArray(_: [[String]].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripNestedStringArray(_: [[String]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripNestedDoubleArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripNestedDoubleArray")
-public func _bjs_ArraySupportExports_static_roundTripNestedDoubleArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedDoubleArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedDoubleArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedDoubleArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripNestedDoubleArray(_: [[Double]].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripNestedDoubleArray(_: [[Double]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripNestedBoolArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripNestedBoolArray")
-public func _bjs_ArraySupportExports_static_roundTripNestedBoolArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedBoolArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedBoolArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedBoolArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripNestedBoolArray(_: [[Bool]].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripNestedBoolArray(_: [[Bool]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripNestedStructArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripNestedStructArray")
-public func _bjs_ArraySupportExports_static_roundTripNestedStructArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedStructArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedStructArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedStructArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripNestedStructArray(_: [[DataPoint]].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripNestedStructArray(_: [[BridgeJSRuntimeTests.DataPoint]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripNestedCaseEnumArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripNestedCaseEnumArray")
-public func _bjs_ArraySupportExports_static_roundTripNestedCaseEnumArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedCaseEnumArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedCaseEnumArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedCaseEnumArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripNestedCaseEnumArray(_: [[Direction]].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripNestedCaseEnumArray(_: [[BridgeJSRuntimeTests.Direction]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_roundTripNestedSwiftClassArray")
-@_cdecl("bjs_ArraySupportExports_static_roundTripNestedSwiftClassArray")
-public func _bjs_ArraySupportExports_static_roundTripNestedSwiftClassArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedSwiftClassArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedSwiftClassArray")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedSwiftClassArray() -> Void {
     #if arch(wasm32)
-    let ret = ArraySupportExports.roundTripNestedSwiftClassArray(_: [[Greeter]].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.roundTripNestedSwiftClassArray(_: [[BridgeJSRuntimeTests.Greeter]].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_multiArrayFirst")
-@_cdecl("bjs_ArraySupportExports_static_multiArrayFirst")
-public func _bjs_ArraySupportExports_static_multiArrayFirst() -> Void {
-    #if arch(wasm32)
-    let _tmp_b = [String].bridgeJSStackPop()
-    let _tmp_a = [Int].bridgeJSStackPop()
-    let ret = ArraySupportExports.multiArrayFirst(_: _tmp_a, _: _tmp_b)
-    ret.bridgeJSStackPush()
-    #else
-    fatalError("Only available on WebAssembly")
-    #endif
-}
-
-@_expose(wasm, "bjs_ArraySupportExports_static_multiArraySecond")
-@_cdecl("bjs_ArraySupportExports_static_multiArraySecond")
-public func _bjs_ArraySupportExports_static_multiArraySecond() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiArrayFirst")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiArrayFirst")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiArrayFirst() -> Void {
     #if arch(wasm32)
     let _tmp_b = [String].bridgeJSStackPop()
     let _tmp_a = [Int].bridgeJSStackPop()
-    let ret = ArraySupportExports.multiArraySecond(_: _tmp_a, _: _tmp_b)
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.multiArrayFirst(_: _tmp_a, _: _tmp_b)
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_multiOptionalArrayFirst")
-@_cdecl("bjs_ArraySupportExports_static_multiOptionalArrayFirst")
-public func _bjs_ArraySupportExports_static_multiOptionalArrayFirst() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiArraySecond")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiArraySecond")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiArraySecond() -> Void {
+    #if arch(wasm32)
+    let _tmp_b = [String].bridgeJSStackPop()
+    let _tmp_a = [Int].bridgeJSStackPop()
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.multiArraySecond(_: _tmp_a, _: _tmp_b)
+    ret.bridgeJSStackPush()
+    #else
+    fatalError("Only available on WebAssembly")
+    #endif
+}
+
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiOptionalArrayFirst")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiOptionalArrayFirst")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiOptionalArrayFirst() -> Void {
     #if arch(wasm32)
     let _tmp_b = Optional<[String]>.bridgeJSLiftParameter()
     let _tmp_a = Optional<[Int]>.bridgeJSLiftParameter()
-    let ret = ArraySupportExports.multiOptionalArrayFirst(_: _tmp_a, _: _tmp_b)
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.multiOptionalArrayFirst(_: _tmp_a, _: _tmp_b)
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArraySupportExports_static_multiOptionalArraySecond")
-@_cdecl("bjs_ArraySupportExports_static_multiOptionalArraySecond")
-public func _bjs_ArraySupportExports_static_multiOptionalArraySecond() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiOptionalArraySecond")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiOptionalArraySecond")
+public func _bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiOptionalArraySecond() -> Void {
     #if arch(wasm32)
     let _tmp_b = Optional<[String]>.bridgeJSLiftParameter()
     let _tmp_a = Optional<[Int]>.bridgeJSLiftParameter()
-    let ret = ArraySupportExports.multiOptionalArraySecond(_: _tmp_a, _: _tmp_b)
+    let ret = BridgeJSRuntimeTests.ArraySupportExports.multiOptionalArraySecond(_: _tmp_a, _: _tmp_b)
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension AsyncImportedPayloadResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AsyncImportedPayloadResult {
+extension BridgeJSRuntimeTests.AsyncImportedPayloadResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.AsyncImportedPayloadResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -4736,7 +4736,7 @@ extension AsyncImportedPayloadResult: _BridgedSwiftAssociatedValueEnum {
         case 2:
             return .idle
         default:
-            fatalError("Unknown AsyncImportedPayloadResult case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.AsyncImportedPayloadResult case ID: \(caseId)")
         }
     }
 
@@ -4754,180 +4754,180 @@ extension AsyncImportedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testStringDefault")
-@_cdecl("bjs_DefaultArgumentExports_static_testStringDefault")
-public func _bjs_DefaultArgumentExports_static_testStringDefault(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testStringDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testStringDefault")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testStringDefault(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testStringDefault(message: String.bridgeJSLiftParameter(messageBytes, messageLength))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testStringDefault(message: String.bridgeJSLiftParameter(messageBytes, messageLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testIntDefault")
-@_cdecl("bjs_DefaultArgumentExports_static_testIntDefault")
-public func _bjs_DefaultArgumentExports_static_testIntDefault(_ count: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testIntDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testIntDefault")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testIntDefault(_ count: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testIntDefault(count: Int.bridgeJSLiftParameter(count))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testIntDefault(count: Int.bridgeJSLiftParameter(count))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testBoolDefault")
-@_cdecl("bjs_DefaultArgumentExports_static_testBoolDefault")
-public func _bjs_DefaultArgumentExports_static_testBoolDefault(_ flag: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testBoolDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testBoolDefault")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testBoolDefault(_ flag: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testBoolDefault(flag: Bool.bridgeJSLiftParameter(flag))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testBoolDefault(flag: Bool.bridgeJSLiftParameter(flag))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testOptionalDefault")
-@_cdecl("bjs_DefaultArgumentExports_static_testOptionalDefault")
-public func _bjs_DefaultArgumentExports_static_testOptionalDefault(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testOptionalDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testOptionalDefault")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testOptionalDefault(_ nameIsSome: Int32, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testOptionalDefault(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testOptionalDefault(name: Optional<String>.bridgeJSLiftParameter(nameIsSome, nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testMultipleDefaults")
-@_cdecl("bjs_DefaultArgumentExports_static_testMultipleDefaults")
-public func _bjs_DefaultArgumentExports_static_testMultipleDefaults(_ titleBytes: Int32, _ titleLength: Int32, _ count: Int32, _ enabled: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testMultipleDefaults")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testMultipleDefaults")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testMultipleDefaults(_ titleBytes: Int32, _ titleLength: Int32, _ count: Int32, _ enabled: Int32) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testMultipleDefaults(title: String.bridgeJSLiftParameter(titleBytes, titleLength), count: Int.bridgeJSLiftParameter(count), enabled: Bool.bridgeJSLiftParameter(enabled))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testMultipleDefaults(title: String.bridgeJSLiftParameter(titleBytes, titleLength), count: Int.bridgeJSLiftParameter(count), enabled: Bool.bridgeJSLiftParameter(enabled))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testSimpleEnumDefault")
-@_cdecl("bjs_DefaultArgumentExports_static_testSimpleEnumDefault")
-public func _bjs_DefaultArgumentExports_static_testSimpleEnumDefault(_ status: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testSimpleEnumDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testSimpleEnumDefault")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testSimpleEnumDefault(_ status: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testSimpleEnumDefault(status: Status.bridgeJSLiftParameter(status))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testSimpleEnumDefault(status: BridgeJSRuntimeTests.Status.bridgeJSLiftParameter(status))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testDirectionDefault")
-@_cdecl("bjs_DefaultArgumentExports_static_testDirectionDefault")
-public func _bjs_DefaultArgumentExports_static_testDirectionDefault(_ direction: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testDirectionDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testDirectionDefault")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testDirectionDefault(_ direction: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testDirectionDefault(direction: Direction.bridgeJSLiftParameter(direction))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testDirectionDefault(direction: BridgeJSRuntimeTests.Direction.bridgeJSLiftParameter(direction))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testRawStringEnumDefault")
-@_cdecl("bjs_DefaultArgumentExports_static_testRawStringEnumDefault")
-public func _bjs_DefaultArgumentExports_static_testRawStringEnumDefault(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testRawStringEnumDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testRawStringEnumDefault")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testRawStringEnumDefault(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testRawStringEnumDefault(theme: Theme.bridgeJSLiftParameter(themeBytes, themeLength))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testRawStringEnumDefault(theme: BridgeJSRuntimeTests.Theme.bridgeJSLiftParameter(themeBytes, themeLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testComplexInit")
-@_cdecl("bjs_DefaultArgumentExports_static_testComplexInit")
-public func _bjs_DefaultArgumentExports_static_testComplexInit(_ greeter: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testComplexInit")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testComplexInit")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testComplexInit(_ greeter: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testComplexInit(greeter: Greeter.bridgeJSLiftParameter(greeter))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testComplexInit(greeter: BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(greeter))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_testEmptyInit")
-@_cdecl("bjs_DefaultArgumentExports_static_testEmptyInit")
-public func _bjs_DefaultArgumentExports_static_testEmptyInit(_ object: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testEmptyInit")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testEmptyInit")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testEmptyInit(_ object: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.testEmptyInit(_: StaticPropertyHolder.bridgeJSLiftParameter(object))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.testEmptyInit(_: BridgeJSRuntimeTests.StaticPropertyHolder.bridgeJSLiftParameter(object))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_createConstructorDefaults")
-@_cdecl("bjs_DefaultArgumentExports_static_createConstructorDefaults")
-public func _bjs_DefaultArgumentExports_static_createConstructorDefaults(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ enabled: Int32, _ status: Int32, _ tagIsSome: Int32, _ tagBytes: Int32, _ tagLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_createConstructorDefaults")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_createConstructorDefaults")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_createConstructorDefaults(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ enabled: Int32, _ status: Int32, _ tagIsSome: Int32, _ tagBytes: Int32, _ tagLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.createConstructorDefaults(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), enabled: Bool.bridgeJSLiftParameter(enabled), status: Status.bridgeJSLiftParameter(status), tag: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.createConstructorDefaults(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), enabled: Bool.bridgeJSLiftParameter(enabled), status: BridgeJSRuntimeTests.Status.bridgeJSLiftParameter(status), tag: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_describeConstructorDefaults")
-@_cdecl("bjs_DefaultArgumentExports_static_describeConstructorDefaults")
-public func _bjs_DefaultArgumentExports_static_describeConstructorDefaults(_ value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_describeConstructorDefaults")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_describeConstructorDefaults")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_describeConstructorDefaults(_ value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.describeConstructorDefaults(_: DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(value))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.describeConstructorDefaults(_: BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_arrayWithDefault")
-@_cdecl("bjs_DefaultArgumentExports_static_arrayWithDefault")
-public func _bjs_DefaultArgumentExports_static_arrayWithDefault() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayWithDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayWithDefault")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayWithDefault() -> Int32 {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.arrayWithDefault(_: [Int].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.arrayWithDefault(_: [Int].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_arrayWithOptionalDefault")
-@_cdecl("bjs_DefaultArgumentExports_static_arrayWithOptionalDefault")
-public func _bjs_DefaultArgumentExports_static_arrayWithOptionalDefault() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayWithOptionalDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayWithOptionalDefault")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayWithOptionalDefault() -> Int32 {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.arrayWithOptionalDefault(_: Optional<[Int]>.bridgeJSLiftParameter())
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.arrayWithOptionalDefault(_: Optional<[Int]>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentExports_static_arrayMixedDefaults")
-@_cdecl("bjs_DefaultArgumentExports_static_arrayMixedDefaults")
-public func _bjs_DefaultArgumentExports_static_arrayMixedDefaults(_ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayMixedDefaults")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayMixedDefaults")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayMixedDefaults(_ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentExports.arrayMixedDefaults(prefix: String.bridgeJSLiftParameter(prefixBytes, prefixLength), values: [Int].bridgeJSStackPop(), suffix: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentExports.arrayMixedDefaults(prefix: String.bridgeJSLiftParameter(prefixBytes, prefixLength), values: [Int].bridgeJSStackPop(), suffix: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Direction: _BridgedSwiftCaseEnum {
+extension BridgeJSRuntimeTests.Direction: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Direction {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSRuntimeTests.Direction {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Direction {
-        return Direction(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSRuntimeTests.Direction {
+        return BridgeJSRuntimeTests.Direction(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -4962,15 +4962,15 @@ extension Direction: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Status: _BridgedSwiftCaseEnum {
+extension BridgeJSRuntimeTests.Status: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Status {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSRuntimeTests.Status {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Status {
-        return Status(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSRuntimeTests.Status {
+        return BridgeJSRuntimeTests.Status(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -5001,33 +5001,33 @@ extension Status: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.Theme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.HttpStatus: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension FileSize: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.FileSize: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension SessionId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.SessionId: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.Precision: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Ratio: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.Ratio: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension TSDirection: _BridgedSwiftCaseEnum {
+extension BridgeJSRuntimeTests.TSDirection: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> TSDirection {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSRuntimeTests.TSDirection {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> TSDirection {
-        return TSDirection(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSRuntimeTests.TSDirection {
+        return BridgeJSRuntimeTests.TSDirection(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -5062,11 +5062,11 @@ extension TSDirection: _BridgedSwiftCaseEnum {
     }
 }
 
-extension TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.TSTheme: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AsyncPayloadResult {
+extension BridgeJSRuntimeTests.AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.AsyncPayloadResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -5075,7 +5075,7 @@ extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
         case 2:
             return .idle
         default:
-            fatalError("Unknown AsyncPayloadResult case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.AsyncPayloadResult case ID: \(caseId)")
         }
     }
 
@@ -5093,37 +5093,37 @@ extension AsyncPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-@_expose(wasm, "bjs_Utils_StringUtils_static_uppercase")
-@_cdecl("bjs_Utils_StringUtils_static_uppercase")
-public func _bjs_Utils_StringUtils_static_uppercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Utils_StringUtils_static_uppercase")
+@_cdecl("bjs_BridgeJSRuntimeTests_Utils_StringUtils_static_uppercase")
+public func _bjs_BridgeJSRuntimeTests_Utils_StringUtils_static_uppercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Utils.StringUtils.uppercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
+    let ret = BridgeJSRuntimeTests.Utils.StringUtils.uppercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_StringUtils_static_lowercase")
-@_cdecl("bjs_Utils_StringUtils_static_lowercase")
-public func _bjs_Utils_StringUtils_static_lowercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Utils_StringUtils_static_lowercase")
+@_cdecl("bjs_BridgeJSRuntimeTests_Utils_StringUtils_static_lowercase")
+public func _bjs_BridgeJSRuntimeTests_Utils_StringUtils_static_lowercase(_ textBytes: Int32, _ textLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Utils.StringUtils.lowercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
+    let ret = BridgeJSRuntimeTests.Utils.StringUtils.lowercase(_: String.bridgeJSLiftParameter(textBytes, textLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Networking.API.Method: _BridgedSwiftCaseEnum {
+extension BridgeJSRuntimeTests.Networking.API.Method: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Networking.API.Method {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSRuntimeTests.Networking.API.Method {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Networking.API.Method {
-        return Networking.API.Method(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSRuntimeTests.Networking.API.Method {
+        return BridgeJSRuntimeTests.Networking.API.Method(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -5158,21 +5158,21 @@ extension Networking.API.Method: _BridgedSwiftCaseEnum {
     }
 }
 
-extension Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.Configuration.LogLevel: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.Configuration.Port: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
+extension BridgeJSRuntimeTests.Internal.SupportedMethod: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> Internal.SupportedMethod {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSRuntimeTests.Internal.SupportedMethod {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> Internal.SupportedMethod {
-        return Internal.SupportedMethod(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSRuntimeTests.Internal.SupportedMethod {
+        return BridgeJSRuntimeTests.Internal.SupportedMethod(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -5199,8 +5199,8 @@ extension Internal.SupportedMethod: _BridgedSwiftCaseEnum {
     }
 }
 
-extension APIResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIResult {
+extension BridgeJSRuntimeTests.APIResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.APIResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -5215,7 +5215,7 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
         case 5:
             return .info
         default:
-            fatalError("Unknown APIResult case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.APIResult case ID: \(caseId)")
         }
     }
 
@@ -5242,8 +5242,8 @@ extension APIResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ComplexResult {
+extension BridgeJSRuntimeTests.ComplexResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.ComplexResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -5260,7 +5260,7 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
         case 6:
             return .info
         default:
-            fatalError("Unknown ComplexResult case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.ComplexResult case ID: \(caseId)")
         }
     }
 
@@ -5305,8 +5305,8 @@ extension ComplexResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> Utilities.Result {
+extension BridgeJSRuntimeTests.Utilities.Result: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.Utilities.Result {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
@@ -5315,7 +5315,7 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
         case 2:
             return .status(Bool.bridgeJSStackPop(), Int.bridgeJSStackPop(), String.bridgeJSStackPop())
         default:
-            fatalError("Unknown Utilities.Result case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.Utilities.Result case ID: \(caseId)")
         }
     }
 
@@ -5337,15 +5337,15 @@ extension Utilities.Result: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> API.NetworkingResult {
+extension BridgeJSRuntimeTests.API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.API.NetworkingResult {
         switch caseId {
         case 0:
             return .success(String.bridgeJSStackPop())
         case 1:
             return .failure(String.bridgeJSStackPop(), Int.bridgeJSStackPop())
         default:
-            fatalError("Unknown API.NetworkingResult case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.API.NetworkingResult case ID: \(caseId)")
         }
     }
 
@@ -5362,17 +5362,17 @@ extension API.NetworkingResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> AllTypesResult {
+extension BridgeJSRuntimeTests.AllTypesResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.AllTypesResult {
         switch caseId {
         case 0:
-            return .structPayload(Address.bridgeJSStackPop())
+            return .structPayload(BridgeJSRuntimeTests.Address.bridgeJSStackPop())
         case 1:
-            return .classPayload(Greeter.bridgeJSStackPop())
+            return .classPayload(BridgeJSRuntimeTests.Greeter.bridgeJSStackPop())
         case 2:
             return .jsObjectPayload(JSObject.bridgeJSStackPop())
         case 3:
-            return .nestedEnum(APIResult.bridgeJSStackPop())
+            return .nestedEnum(BridgeJSRuntimeTests.APIResult.bridgeJSStackPop())
         case 4:
             return .arrayPayload([Int].bridgeJSStackPop())
         case 5:
@@ -5380,7 +5380,7 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
         case 6:
             return .empty
         default:
-            fatalError("Unknown AllTypesResult case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.AllTypesResult case ID: \(caseId)")
         }
     }
 
@@ -5410,21 +5410,21 @@ extension AllTypesResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> TypedPayloadResult {
+extension BridgeJSRuntimeTests.TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.TypedPayloadResult {
         switch caseId {
         case 0:
-            return .precision(Precision.bridgeJSStackPop())
+            return .precision(BridgeJSRuntimeTests.Precision.bridgeJSStackPop())
         case 1:
-            return .direction(Direction.bridgeJSStackPop())
+            return .direction(BridgeJSRuntimeTests.Direction.bridgeJSStackPop())
         case 2:
-            return .optPrecision(Optional<Precision>.bridgeJSStackPop())
+            return .optPrecision(Optional<BridgeJSRuntimeTests.Precision>.bridgeJSStackPop())
         case 3:
-            return .optDirection(Optional<Direction>.bridgeJSStackPop())
+            return .optDirection(Optional<BridgeJSRuntimeTests.Direction>.bridgeJSStackPop())
         case 4:
             return .empty
         default:
-            fatalError("Unknown TypedPayloadResult case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.TypedPayloadResult case ID: \(caseId)")
         }
     }
 
@@ -5448,15 +5448,15 @@ extension TypedPayloadResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension StaticCalculator: _BridgedSwiftCaseEnum {
+extension BridgeJSRuntimeTests.StaticCalculator: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> StaticCalculator {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSRuntimeTests.StaticCalculator {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> StaticCalculator {
-        return StaticCalculator(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSRuntimeTests.StaticCalculator {
+        return BridgeJSRuntimeTests.StaticCalculator(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -5483,81 +5483,81 @@ extension StaticCalculator: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_StaticCalculator_static_roundtrip")
-@_cdecl("bjs_StaticCalculator_static_roundtrip")
-public func _bjs_StaticCalculator_static_roundtrip(_ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticCalculator_static_roundtrip")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticCalculator_static_roundtrip")
+public func _bjs_BridgeJSRuntimeTests_StaticCalculator_static_roundtrip(_ value: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = StaticCalculator.roundtrip(_: Int.bridgeJSLiftParameter(value))
+    let ret = BridgeJSRuntimeTests.StaticCalculator.roundtrip(_: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticCalculator_static_doubleValue")
-@_cdecl("bjs_StaticCalculator_static_doubleValue")
-public func _bjs_StaticCalculator_static_doubleValue(_ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticCalculator_static_doubleValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticCalculator_static_doubleValue")
+public func _bjs_BridgeJSRuntimeTests_StaticCalculator_static_doubleValue(_ value: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = StaticCalculator.doubleValue(_: Int.bridgeJSLiftParameter(value))
+    let ret = BridgeJSRuntimeTests.StaticCalculator.doubleValue(_: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticCalculator_static_version_get")
-@_cdecl("bjs_StaticCalculator_static_version_get")
-public func _bjs_StaticCalculator_static_version_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticCalculator_static_version_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticCalculator_static_version_get")
+public func _bjs_BridgeJSRuntimeTests_StaticCalculator_static_version_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticCalculator.version
+    let ret = BridgeJSRuntimeTests.StaticCalculator.version
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticUtils_Nested_static_roundtrip")
-@_cdecl("bjs_StaticUtils_Nested_static_roundtrip")
-public func _bjs_StaticUtils_Nested_static_roundtrip(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticUtils_Nested_static_roundtrip")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticUtils_Nested_static_roundtrip")
+public func _bjs_BridgeJSRuntimeTests_StaticUtils_Nested_static_roundtrip(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = StaticUtils.Nested.roundtrip(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    let ret = BridgeJSRuntimeTests.StaticUtils.Nested.roundtrip(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_createGraph")
-@_cdecl("bjs_Services_Graph_GraphOperations_static_createGraph")
-public func _bjs_Services_Graph_GraphOperations_static_createGraph(_ rootId: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_GraphOperations_static_createGraph")
+@_cdecl("bjs_BridgeJSRuntimeTests_GraphOperations_static_createGraph")
+public func _bjs_BridgeJSRuntimeTests_GraphOperations_static_createGraph(_ rootId: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = GraphOperations.createGraph(rootId: Int.bridgeJSLiftParameter(rootId))
+    let ret = BridgeJSRuntimeTests.GraphOperations.createGraph(rootId: Int.bridgeJSLiftParameter(rootId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Services_Graph_GraphOperations_static_nodeCount")
-@_cdecl("bjs_Services_Graph_GraphOperations_static_nodeCount")
-public func _bjs_Services_Graph_GraphOperations_static_nodeCount(_ graphId: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_GraphOperations_static_nodeCount")
+@_cdecl("bjs_BridgeJSRuntimeTests_GraphOperations_static_nodeCount")
+public func _bjs_BridgeJSRuntimeTests_GraphOperations_static_nodeCount(_ graphId: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = GraphOperations.nodeCount(graphId: Int.bridgeJSLiftParameter(graphId))
+    let ret = BridgeJSRuntimeTests.GraphOperations.nodeCount(graphId: Int.bridgeJSLiftParameter(graphId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension StaticPropertyEnum: _BridgedSwiftCaseEnum {
+extension BridgeJSRuntimeTests.StaticPropertyEnum: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> StaticPropertyEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSRuntimeTests.StaticPropertyEnum {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> StaticPropertyEnum {
-        return StaticPropertyEnum(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSRuntimeTests.StaticPropertyEnum {
+        return BridgeJSRuntimeTests.StaticPropertyEnum(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -5584,231 +5584,231 @@ extension StaticPropertyEnum: _BridgedSwiftCaseEnum {
     }
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_enumProperty_get")
-@_cdecl("bjs_StaticPropertyEnum_static_enumProperty_get")
-public func _bjs_StaticPropertyEnum_static_enumProperty_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumProperty_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumProperty_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyEnum.enumProperty
+    let ret = BridgeJSRuntimeTests.StaticPropertyEnum.enumProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_enumProperty_set")
-@_cdecl("bjs_StaticPropertyEnum_static_enumProperty_set")
-public func _bjs_StaticPropertyEnum_static_enumProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumProperty_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumProperty_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyEnum.enumProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.StaticPropertyEnum.enumProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_enumConstant_get")
-@_cdecl("bjs_StaticPropertyEnum_static_enumConstant_get")
-public func _bjs_StaticPropertyEnum_static_enumConstant_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumConstant_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumConstant_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumConstant_get() -> Int32 {
     #if arch(wasm32)
-    let ret = StaticPropertyEnum.enumConstant
+    let ret = BridgeJSRuntimeTests.StaticPropertyEnum.enumConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_enumBool_get")
-@_cdecl("bjs_StaticPropertyEnum_static_enumBool_get")
-public func _bjs_StaticPropertyEnum_static_enumBool_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumBool_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumBool_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumBool_get() -> Int32 {
     #if arch(wasm32)
-    let ret = StaticPropertyEnum.enumBool
+    let ret = BridgeJSRuntimeTests.StaticPropertyEnum.enumBool
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_enumBool_set")
-@_cdecl("bjs_StaticPropertyEnum_static_enumBool_set")
-public func _bjs_StaticPropertyEnum_static_enumBool_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumBool_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumBool_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumBool_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyEnum.enumBool = Bool.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.StaticPropertyEnum.enumBool = Bool.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_enumVariable_get")
-@_cdecl("bjs_StaticPropertyEnum_static_enumVariable_get")
-public func _bjs_StaticPropertyEnum_static_enumVariable_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumVariable_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumVariable_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumVariable_get() -> Int32 {
     #if arch(wasm32)
-    let ret = StaticPropertyEnum.enumVariable
+    let ret = BridgeJSRuntimeTests.StaticPropertyEnum.enumVariable
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_enumVariable_set")
-@_cdecl("bjs_StaticPropertyEnum_static_enumVariable_set")
-public func _bjs_StaticPropertyEnum_static_enumVariable_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumVariable_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumVariable_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_enumVariable_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyEnum.enumVariable = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.StaticPropertyEnum.enumVariable = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_computedReadonly_get")
-@_cdecl("bjs_StaticPropertyEnum_static_computedReadonly_get")
-public func _bjs_StaticPropertyEnum_static_computedReadonly_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_computedReadonly_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_computedReadonly_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_computedReadonly_get() -> Int32 {
     #if arch(wasm32)
-    let ret = StaticPropertyEnum.computedReadonly
+    let ret = BridgeJSRuntimeTests.StaticPropertyEnum.computedReadonly
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_computedReadWrite_get")
-@_cdecl("bjs_StaticPropertyEnum_static_computedReadWrite_get")
-public func _bjs_StaticPropertyEnum_static_computedReadWrite_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_computedReadWrite_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_computedReadWrite_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_computedReadWrite_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyEnum.computedReadWrite
+    let ret = BridgeJSRuntimeTests.StaticPropertyEnum.computedReadWrite
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyEnum_static_computedReadWrite_set")
-@_cdecl("bjs_StaticPropertyEnum_static_computedReadWrite_set")
-public func _bjs_StaticPropertyEnum_static_computedReadWrite_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_computedReadWrite_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_computedReadWrite_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyEnum_static_computedReadWrite_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyEnum.computedReadWrite = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.StaticPropertyEnum.computedReadWrite = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyNamespace_static_namespaceProperty_get")
-@_cdecl("bjs_StaticPropertyNamespace_static_namespaceProperty_get")
-public func _bjs_StaticPropertyNamespace_static_namespaceProperty_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_static_namespaceProperty_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_static_namespaceProperty_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_static_namespaceProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyNamespace.namespaceProperty
+    let ret = BridgeJSRuntimeTests.StaticPropertyNamespace.namespaceProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyNamespace_static_namespaceProperty_set")
-@_cdecl("bjs_StaticPropertyNamespace_static_namespaceProperty_set")
-public func _bjs_StaticPropertyNamespace_static_namespaceProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_static_namespaceProperty_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_static_namespaceProperty_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_static_namespaceProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyNamespace.namespaceProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.StaticPropertyNamespace.namespaceProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyNamespace_static_namespaceConstant_get")
-@_cdecl("bjs_StaticPropertyNamespace_static_namespaceConstant_get")
-public func _bjs_StaticPropertyNamespace_static_namespaceConstant_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_static_namespaceConstant_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_static_namespaceConstant_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_static_namespaceConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyNamespace.namespaceConstant
+    let ret = BridgeJSRuntimeTests.StaticPropertyNamespace.namespaceConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyNamespace_NestedProperties_static_nestedProperty_get")
-@_cdecl("bjs_StaticPropertyNamespace_NestedProperties_static_nestedProperty_get")
-public func _bjs_StaticPropertyNamespace_NestedProperties_static_nestedProperty_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedProperty_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedProperty_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedProperty_get() -> Int32 {
     #if arch(wasm32)
-    let ret = StaticPropertyNamespace.NestedProperties.nestedProperty
+    let ret = BridgeJSRuntimeTests.StaticPropertyNamespace.NestedProperties.nestedProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyNamespace_NestedProperties_static_nestedProperty_set")
-@_cdecl("bjs_StaticPropertyNamespace_NestedProperties_static_nestedProperty_set")
-public func _bjs_StaticPropertyNamespace_NestedProperties_static_nestedProperty_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedProperty_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedProperty_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedProperty_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyNamespace.NestedProperties.nestedProperty = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.StaticPropertyNamespace.NestedProperties.nestedProperty = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyNamespace_NestedProperties_static_nestedConstant_get")
-@_cdecl("bjs_StaticPropertyNamespace_NestedProperties_static_nestedConstant_get")
-public func _bjs_StaticPropertyNamespace_NestedProperties_static_nestedConstant_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedConstant_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedConstant_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyNamespace.NestedProperties.nestedConstant
+    let ret = BridgeJSRuntimeTests.StaticPropertyNamespace.NestedProperties.nestedConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyNamespace_NestedProperties_static_nestedDouble_get")
-@_cdecl("bjs_StaticPropertyNamespace_NestedProperties_static_nestedDouble_get")
-public func _bjs_StaticPropertyNamespace_NestedProperties_static_nestedDouble_get() -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedDouble_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedDouble_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedDouble_get() -> Float64 {
     #if arch(wasm32)
-    let ret = StaticPropertyNamespace.NestedProperties.nestedDouble
+    let ret = BridgeJSRuntimeTests.StaticPropertyNamespace.NestedProperties.nestedDouble
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyNamespace_NestedProperties_static_nestedDouble_set")
-@_cdecl("bjs_StaticPropertyNamespace_NestedProperties_static_nestedDouble_set")
-public func _bjs_StaticPropertyNamespace_NestedProperties_static_nestedDouble_set(_ value: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedDouble_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedDouble_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyNamespace_NestedProperties_static_nestedDouble_set(_ value: Float64) -> Void {
     #if arch(wasm32)
-    StaticPropertyNamespace.NestedProperties.nestedDouble = Double.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.StaticPropertyNamespace.NestedProperties.nestedDouble = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_NestedStructGroupA_static_roundtripMetadata")
-@_cdecl("bjs_NestedStructGroupA_static_roundtripMetadata")
-public func _bjs_NestedStructGroupA_static_roundtripMetadata() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_NestedStructGroupA_static_roundtripMetadata")
+@_cdecl("bjs_BridgeJSRuntimeTests_NestedStructGroupA_static_roundtripMetadata")
+public func _bjs_BridgeJSRuntimeTests_NestedStructGroupA_static_roundtripMetadata() -> Void {
     #if arch(wasm32)
-    let ret = NestedStructGroupA.roundtripMetadata(_: NestedStructGroupA.Metadata.bridgeJSLiftParameter())
+    let ret = BridgeJSRuntimeTests.NestedStructGroupA.roundtripMetadata(_: BridgeJSRuntimeTests.NestedStructGroupA.Metadata.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_NestedStructGroupB_static_roundtripMetadata")
-@_cdecl("bjs_NestedStructGroupB_static_roundtripMetadata")
-public func _bjs_NestedStructGroupB_static_roundtripMetadata() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_NestedStructGroupB_static_roundtripMetadata")
+@_cdecl("bjs_BridgeJSRuntimeTests_NestedStructGroupB_static_roundtripMetadata")
+public func _bjs_BridgeJSRuntimeTests_NestedStructGroupB_static_roundtripMetadata() -> Void {
     #if arch(wasm32)
-    let ret = NestedStructGroupB.roundtripMetadata(_: NestedStructGroupB.Metadata.bridgeJSLiftParameter())
+    let ret = BridgeJSRuntimeTests.NestedStructGroupB.roundtripMetadata(_: BridgeJSRuntimeTests.NestedStructGroupB.Metadata.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension NestedTypeHost.Variant: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
+extension BridgeJSRuntimeTests.NestedTypeHost.Variant: _BridgedSwiftEnumNoPayload, _BridgedSwiftRawValueEnum {
 }
 
-extension LightColor: _BridgedSwiftCaseEnum {
+extension BridgeJSRuntimeTests.LightColor: _BridgedSwiftCaseEnum {
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerParameter() -> Int32 {
         return bridgeJSRawValue
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> LightColor {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftReturn(_ value: Int32) -> BridgeJSRuntimeTests.LightColor {
         return bridgeJSLiftParameter(value)
     }
-    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> LightColor {
-        return LightColor(bridgeJSRawValue: value)!
+    @_spi(BridgeJS) @_transparent public static func bridgeJSLiftParameter(_ value: Int32) -> BridgeJSRuntimeTests.LightColor {
+        return BridgeJSRuntimeTests.LightColor(bridgeJSRawValue: value)!
     }
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSLowerReturn() -> Int32 {
         return bridgeJSLowerParameter()
@@ -5839,8 +5839,8 @@ extension LightColor: _BridgedSwiftCaseEnum {
     }
 }
 
-extension ImportedPayloadSignal: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> ImportedPayloadSignal {
+extension BridgeJSRuntimeTests.ImportedPayloadSignal: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.ImportedPayloadSignal {
         switch caseId {
         case 0:
             return .start(String.bridgeJSStackPop())
@@ -5849,7 +5849,7 @@ extension ImportedPayloadSignal: _BridgedSwiftAssociatedValueEnum {
         case 2:
             return .idle
         default:
-            fatalError("Unknown ImportedPayloadSignal case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.ImportedPayloadSignal case ID: \(caseId)")
         }
     }
 
@@ -5867,491 +5867,491 @@ extension ImportedPayloadSignal: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripInt")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripInt")
-public func _bjs_IntegerTypesSupportExports_static_roundTripInt(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripInt(_: Int.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripInt(_: Int.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripUInt")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripUInt")
-public func _bjs_IntegerTypesSupportExports_static_roundTripUInt(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripUInt(_: UInt.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripUInt(_: UInt.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripInt8")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripInt8")
-public func _bjs_IntegerTypesSupportExports_static_roundTripInt8(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt8")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt8")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt8(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripInt8(_: Int8.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripInt8(_: Int8.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripUInt8")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripUInt8")
-public func _bjs_IntegerTypesSupportExports_static_roundTripUInt8(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt8")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt8")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt8(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripUInt8(_: UInt8.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripUInt8(_: UInt8.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripInt16")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripInt16")
-public func _bjs_IntegerTypesSupportExports_static_roundTripInt16(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt16")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt16")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt16(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripInt16(_: Int16.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripInt16(_: Int16.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripUInt16")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripUInt16")
-public func _bjs_IntegerTypesSupportExports_static_roundTripUInt16(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt16")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt16")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt16(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripUInt16(_: UInt16.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripUInt16(_: UInt16.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripInt32")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripInt32")
-public func _bjs_IntegerTypesSupportExports_static_roundTripInt32(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt32")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt32")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt32(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripInt32(_: Int32.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripInt32(_: Int32.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripUInt32")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripUInt32")
-public func _bjs_IntegerTypesSupportExports_static_roundTripUInt32(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt32")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt32")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt32(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripUInt32(_: UInt32.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripUInt32(_: UInt32.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripInt64")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripInt64")
-public func _bjs_IntegerTypesSupportExports_static_roundTripInt64(_ v: Int64) -> Int64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt64")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt64")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt64(_ v: Int64) -> Int64 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripInt64(_: Int64.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripInt64(_: Int64.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_IntegerTypesSupportExports_static_roundTripUInt64")
-@_cdecl("bjs_IntegerTypesSupportExports_static_roundTripUInt64")
-public func _bjs_IntegerTypesSupportExports_static_roundTripUInt64(_ v: Int64) -> Int64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt64")
+@_cdecl("bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt64")
+public func _bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt64(_ v: Int64) -> Int64 {
     #if arch(wasm32)
-    let ret = IntegerTypesSupportExports.roundTripUInt64(_: UInt64.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.IntegerTypesSupportExports.roundTripUInt64(_: UInt64.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSTypedArrayExports_static_roundTripUint8Array")
-@_cdecl("bjs_JSTypedArrayExports_static_roundTripUint8Array")
-public func _bjs_JSTypedArrayExports_static_roundTripUint8Array(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripUint8Array")
+@_cdecl("bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripUint8Array")
+public func _bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripUint8Array(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSTypedArrayExports.roundTripUint8Array(_: JSUint8Array.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.JSTypedArrayExports.roundTripUint8Array(_: JSUint8Array.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSTypedArrayExports_static_roundTripFloat32Array")
-@_cdecl("bjs_JSTypedArrayExports_static_roundTripFloat32Array")
-public func _bjs_JSTypedArrayExports_static_roundTripFloat32Array(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripFloat32Array")
+@_cdecl("bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripFloat32Array")
+public func _bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripFloat32Array(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSTypedArrayExports.roundTripFloat32Array(_: JSFloat32Array.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.JSTypedArrayExports.roundTripFloat32Array(_: JSFloat32Array.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSTypedArrayExports_static_roundTripFloat64Array")
-@_cdecl("bjs_JSTypedArrayExports_static_roundTripFloat64Array")
-public func _bjs_JSTypedArrayExports_static_roundTripFloat64Array(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripFloat64Array")
+@_cdecl("bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripFloat64Array")
+public func _bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripFloat64Array(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSTypedArrayExports.roundTripFloat64Array(_: JSFloat64Array.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.JSTypedArrayExports.roundTripFloat64Array(_: JSFloat64Array.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_JSTypedArrayExports_static_roundTripInt32Array")
-@_cdecl("bjs_JSTypedArrayExports_static_roundTripInt32Array")
-public func _bjs_JSTypedArrayExports_static_roundTripInt32Array(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripInt32Array")
+@_cdecl("bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripInt32Array")
+public func _bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripInt32Array(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = JSTypedArrayExports.roundTripInt32Array(_: JSInt32Array.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.JSTypedArrayExports.roundTripInt32Array(_: JSInt32Array.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalString")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalString")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalString(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalString")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalString")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalString(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalString(_: Optional<String>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalString(_: Optional<String>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalInt")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalInt")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalInt(_ vIsSome: Int32, _ vValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalInt")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalInt")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalInt(_ vIsSome: Int32, _ vValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalInt(_: Optional<Int>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalInt(_: Optional<Int>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalBool")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalBool")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalBool(_ vIsSome: Int32, _ vValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalBool")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalBool")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalBool(_ vIsSome: Int32, _ vValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalBool(_: Optional<Bool>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalBool(_: Optional<Bool>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalFloat")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalFloat")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalFloat(_ vIsSome: Int32, _ vValue: Float32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalFloat")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalFloat")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalFloat(_ vIsSome: Int32, _ vValue: Float32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalFloat(_: Optional<Float>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalFloat(_: Optional<Float>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalDouble")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalDouble")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalDouble(_ vIsSome: Int32, _ vValue: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalDouble")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalDouble")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalDouble(_ vIsSome: Int32, _ vValue: Float64) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalDouble(_: Optional<Double>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalDouble(_: Optional<Double>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalSyntax")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalSyntax")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalSyntax(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSyntax")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSyntax")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSyntax(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalSyntax(_: Optional<String>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalSyntax(_: Optional<String>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalCaseEnum")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalCaseEnum")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalCaseEnum(_ vIsSome: Int32, _ vValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalCaseEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalCaseEnum")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalCaseEnum(_ vIsSome: Int32, _ vValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalCaseEnum(_: Optional<Status>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalCaseEnum(_: Optional<BridgeJSRuntimeTests.Status>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalStringRawValueEnum")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalStringRawValueEnum")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalStringRawValueEnum(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalStringRawValueEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalStringRawValueEnum")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalStringRawValueEnum(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalStringRawValueEnum(_: Optional<Theme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalStringRawValueEnum(_: Optional<BridgeJSRuntimeTests.Theme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalIntRawValueEnum")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalIntRawValueEnum")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalIntRawValueEnum(_ vIsSome: Int32, _ vValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalIntRawValueEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalIntRawValueEnum")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalIntRawValueEnum(_ vIsSome: Int32, _ vValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalIntRawValueEnum(_: Optional<HttpStatus>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalIntRawValueEnum(_: Optional<BridgeJSRuntimeTests.HttpStatus>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalInt64RawValueEnum")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalInt64RawValueEnum")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalInt64RawValueEnum(_ vIsSome: Int32, _ vValue: Int64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalInt64RawValueEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalInt64RawValueEnum")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalInt64RawValueEnum(_ vIsSome: Int32, _ vValue: Int64) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalInt64RawValueEnum(_: Optional<FileSize>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalInt64RawValueEnum(_: Optional<BridgeJSRuntimeTests.FileSize>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalUInt64RawValueEnum")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalUInt64RawValueEnum")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalUInt64RawValueEnum(_ vIsSome: Int32, _ vValue: Int64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalUInt64RawValueEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalUInt64RawValueEnum")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalUInt64RawValueEnum(_ vIsSome: Int32, _ vValue: Int64) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalUInt64RawValueEnum(_: Optional<SessionId>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalUInt64RawValueEnum(_: Optional<BridgeJSRuntimeTests.SessionId>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalTSEnum")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalTSEnum")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalTSEnum(_ vIsSome: Int32, _ vValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTSEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTSEnum")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTSEnum(_ vIsSome: Int32, _ vValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalTSEnum(_: Optional<TSDirection>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalTSEnum(_: Optional<BridgeJSRuntimeTests.TSDirection>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalTSStringEnum")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalTSStringEnum")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalTSStringEnum(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTSStringEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTSStringEnum")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTSStringEnum(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalTSStringEnum(_: Optional<TSTheme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalTSStringEnum(_: Optional<BridgeJSRuntimeTests.TSTheme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalNamespacedEnum")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalNamespacedEnum")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalNamespacedEnum(_ vIsSome: Int32, _ vValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalNamespacedEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalNamespacedEnum")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalNamespacedEnum(_ vIsSome: Int32, _ vValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalNamespacedEnum(_: Optional<Networking.API.Method>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalNamespacedEnum(_: Optional<BridgeJSRuntimeTests.Networking.API.Method>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalSwiftClass")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalSwiftClass")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalSwiftClass(_ vIsSome: Int32, _ vValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSwiftClass")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSwiftClass")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSwiftClass(_ vIsSome: Int32, _ vValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalSwiftClass(_: Optional<Greeter>.bridgeJSLiftParameter(vIsSome, vValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalSwiftClass(_: Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalIntArray")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalIntArray")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalIntArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalIntArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalIntArray")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalIntArray() -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalIntArray(_: Optional<[Int]>.bridgeJSLiftParameter())
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalIntArray(_: Optional<[Int]>.bridgeJSLiftParameter())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalStringArray")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalStringArray")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalStringArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalStringArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalStringArray")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalStringArray() -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalStringArray(_: Optional<[String]>.bridgeJSLiftParameter())
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalStringArray(_: Optional<[String]>.bridgeJSLiftParameter())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalSwiftClassArray")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalSwiftClassArray")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalSwiftClassArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSwiftClassArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSwiftClassArray")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSwiftClassArray() -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalSwiftClassArray(_: Optional<[Greeter]>.bridgeJSLiftParameter())
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalSwiftClassArray(_: Optional<[BridgeJSRuntimeTests.Greeter]>.bridgeJSLiftParameter())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalAPIResult")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalAPIResult")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalAPIResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAPIResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAPIResult")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAPIResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalAPIResult(_: Optional<APIResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalAPIResult(_: Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalTypedPayloadResult")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalTypedPayloadResult")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalTypedPayloadResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTypedPayloadResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTypedPayloadResult")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTypedPayloadResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalTypedPayloadResult(_: Optional<TypedPayloadResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalTypedPayloadResult(_: Optional<BridgeJSRuntimeTests.TypedPayloadResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalComplexResult")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalComplexResult")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalComplexResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalComplexResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalComplexResult")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalComplexResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalComplexResult(_: Optional<ComplexResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalComplexResult(_: Optional<BridgeJSRuntimeTests.ComplexResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalAllTypesResult")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalAllTypesResult")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalAllTypesResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAllTypesResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAllTypesResult")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAllTypesResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalAllTypesResult(_: Optional<AllTypesResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalAllTypesResult(_: Optional<BridgeJSRuntimeTests.AllTypesResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalPayloadResult")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalPayloadResult")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalPayloadResult(_ v: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalPayloadResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalPayloadResult")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalPayloadResult(_ v: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalPayloadResult(_: OptionalAllTypesResult.bridgeJSLiftParameter(v))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalPayloadResult(_: BridgeJSRuntimeTests.OptionalAllTypesResult.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalPayloadResultOpt")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalPayloadResultOpt")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalPayloadResultOpt(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalPayloadResultOpt")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalPayloadResultOpt")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalPayloadResultOpt(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalPayloadResultOpt(_: Optional<OptionalAllTypesResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalPayloadResultOpt(_: Optional<BridgeJSRuntimeTests.OptionalAllTypesResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_roundTripOptionalAPIOptionalResult")
-@_cdecl("bjs_OptionalSupportExports_static_roundTripOptionalAPIOptionalResult")
-public func _bjs_OptionalSupportExports_static_roundTripOptionalAPIOptionalResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAPIOptionalResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAPIOptionalResult")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAPIOptionalResult(_ vIsSome: Int32, _ vCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.roundTripOptionalAPIOptionalResult(_: Optional<APIOptionalResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.roundTripOptionalAPIOptionalResult(_: Optional<BridgeJSRuntimeTests.APIOptionalResult>.bridgeJSLiftParameter(vIsSome, vCaseId))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_takeOptionalJSObject")
-@_cdecl("bjs_OptionalSupportExports_static_takeOptionalJSObject")
-public func _bjs_OptionalSupportExports_static_takeOptionalJSObject(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_takeOptionalJSObject")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_takeOptionalJSObject")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_takeOptionalJSObject(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
-    OptionalSupportExports.takeOptionalJSObject(_: Optional<JSObject>.bridgeJSLiftParameter(valueIsSome, valueValue))
+    BridgeJSRuntimeTests.OptionalSupportExports.takeOptionalJSObject(_: Optional<JSObject>.bridgeJSLiftParameter(valueIsSome, valueValue))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_applyOptionalGreeter")
-@_cdecl("bjs_OptionalSupportExports_static_applyOptionalGreeter")
-public func _bjs_OptionalSupportExports_static_applyOptionalGreeter(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer, _ transform: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_applyOptionalGreeter")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_applyOptionalGreeter")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_applyOptionalGreeter(_ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer, _ transform: Int32) -> Void {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.applyOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue), _: _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC.bridgeJSLift(transform))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.applyOptionalGreeter(_: Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue), _: _BJS_Closure_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC.bridgeJSLift(transform))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_makeOptionalHolder")
-@_cdecl("bjs_OptionalSupportExports_static_makeOptionalHolder")
-public func _bjs_OptionalSupportExports_static_makeOptionalHolder(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_makeOptionalHolder")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_makeOptionalHolder")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_makeOptionalHolder(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = OptionalSupportExports.makeOptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.makeOptionalHolder(nullableGreeter: Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalSupportExports_static_compareAPIResults")
-@_cdecl("bjs_OptionalSupportExports_static_compareAPIResults")
-public func _bjs_OptionalSupportExports_static_compareAPIResults(_ r1IsSome: Int32, _ r1CaseId: Int32, _ r2IsSome: Int32, _ r2CaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_compareAPIResults")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_compareAPIResults")
+public func _bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_compareAPIResults(_ r1IsSome: Int32, _ r1CaseId: Int32, _ r2IsSome: Int32, _ r2CaseId: Int32) -> Void {
     #if arch(wasm32)
-    let _tmp_r2 = Optional<APIResult>.bridgeJSLiftParameter(r2IsSome, r2CaseId)
-    let _tmp_r1 = Optional<APIResult>.bridgeJSLiftParameter(r1IsSome, r1CaseId)
-    let ret = OptionalSupportExports.compareAPIResults(_: _tmp_r1, _: _tmp_r2)
+    let _tmp_r2 = Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftParameter(r2IsSome, r2CaseId)
+    let _tmp_r1 = Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftParameter(r1IsSome, r1CaseId)
+    let ret = BridgeJSRuntimeTests.OptionalSupportExports.compareAPIResults(_: _tmp_r1, _: _tmp_r2)
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> OptionalAllTypesResult {
+extension BridgeJSRuntimeTests.OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.OptionalAllTypesResult {
         switch caseId {
         case 0:
-            return .optStruct(Optional<Address>.bridgeJSStackPop())
+            return .optStruct(Optional<BridgeJSRuntimeTests.Address>.bridgeJSStackPop())
         case 1:
-            return .optClass(Optional<Greeter>.bridgeJSStackPop())
+            return .optClass(Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSStackPop())
         case 2:
             return .optJSObject(Optional<JSObject>.bridgeJSStackPop())
         case 3:
-            return .optNestedEnum(Optional<APIResult>.bridgeJSStackPop())
+            return .optNestedEnum(Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSStackPop())
         case 4:
             return .optArray(Optional<[Int]>.bridgeJSStackPop())
         case 5:
@@ -6359,7 +6359,7 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
         case 6:
             return .empty
         default:
-            fatalError("Unknown OptionalAllTypesResult case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.OptionalAllTypesResult case ID: \(caseId)")
         }
     }
 
@@ -6389,8 +6389,8 @@ extension OptionalAllTypesResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> APIOptionalResult {
+extension BridgeJSRuntimeTests.APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPopPayload(_ caseId: Int32) -> BridgeJSRuntimeTests.APIOptionalResult {
         switch caseId {
         case 0:
             return .success(Optional<String>.bridgeJSStackPop())
@@ -6399,7 +6399,7 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
         case 2:
             return .status(Optional<Bool>.bridgeJSStackPop(), Optional<Int>.bridgeJSStackPop(), Optional<String>.bridgeJSStackPop())
         default:
-            fatalError("Unknown APIOptionalResult case ID: \(caseId)")
+            fatalError("Unknown BridgeJSRuntimeTests.APIOptionalResult case ID: \(caseId)")
         }
     }
 
@@ -6421,11 +6421,11 @@ extension APIOptionalResult: _BridgedSwiftAssociatedValueEnum {
     }
 }
 
-extension JSCoordinate: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> JSCoordinate {
+extension BridgeJSRuntimeTests.JSCoordinate: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.JSCoordinate {
         let longitude = Double.bridgeJSStackPop()
         let latitude = Double.bridgeJSStackPop()
-        return JSCoordinate(latitude: latitude, longitude: longitude)
+        return BridgeJSRuntimeTests.JSCoordinate(latitude: latitude, longitude: longitude)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6434,57 +6434,57 @@ extension JSCoordinate: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_JSCoordinate(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_JSCoordinate(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_JSCoordinate()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_JSCoordinate()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_JSCoordinate")
-fileprivate func _bjs_struct_lower_JSCoordinate_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_JSCoordinate")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_JSCoordinate_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_JSCoordinate_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_JSCoordinate_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_JSCoordinate(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_JSCoordinate_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_JSCoordinate(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_JSCoordinate_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_JSCoordinate")
-fileprivate func _bjs_struct_lift_JSCoordinate_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_JSCoordinate")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_JSCoordinate_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_JSCoordinate_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_JSCoordinate_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_JSCoordinate() -> Int32 {
-    return _bjs_struct_lift_JSCoordinate_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_JSCoordinate() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_JSCoordinate_extern()
 }
 
-@_expose(wasm, "bjs_JSCoordinate_init")
-@_cdecl("bjs_JSCoordinate_init")
-public func _bjs_JSCoordinate_init(_ latitude: Float64, _ longitude: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_JSCoordinate_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_JSCoordinate_init")
+public func _bjs_BridgeJSRuntimeTests_JSCoordinate_init(_ latitude: Float64, _ longitude: Float64) -> Void {
     #if arch(wasm32)
-    let ret = JSCoordinate(latitude: Double.bridgeJSLiftParameter(latitude), longitude: Double.bridgeJSLiftParameter(longitude))
+    let ret = BridgeJSRuntimeTests.JSCoordinate(latitude: Double.bridgeJSLiftParameter(latitude), longitude: Double.bridgeJSLiftParameter(longitude))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension NestedStructGroupA.Metadata: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> NestedStructGroupA.Metadata {
+extension BridgeJSRuntimeTests.NestedStructGroupA.Metadata: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.NestedStructGroupA.Metadata {
         let count = Int.bridgeJSStackPop()
         let label = String.bridgeJSStackPop()
-        return NestedStructGroupA.Metadata(label: label, count: count)
+        return BridgeJSRuntimeTests.NestedStructGroupA.Metadata(label: label, count: count)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6493,46 +6493,46 @@ extension NestedStructGroupA.Metadata: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_NestedStructGroupA_Metadata(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupA_Metadata(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_NestedStructGroupA_Metadata()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupA_Metadata()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_NestedStructGroupA_Metadata")
-fileprivate func _bjs_struct_lower_NestedStructGroupA_Metadata_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_NestedStructGroupA_Metadata")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupA_Metadata_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_NestedStructGroupA_Metadata_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupA_Metadata_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_NestedStructGroupA_Metadata(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_NestedStructGroupA_Metadata_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupA_Metadata(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupA_Metadata_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_NestedStructGroupA_Metadata")
-fileprivate func _bjs_struct_lift_NestedStructGroupA_Metadata_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_NestedStructGroupA_Metadata")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupA_Metadata_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_NestedStructGroupA_Metadata_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupA_Metadata_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_NestedStructGroupA_Metadata() -> Int32 {
-    return _bjs_struct_lift_NestedStructGroupA_Metadata_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupA_Metadata() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupA_Metadata_extern()
 }
 
-extension NestedStructGroupB.Metadata: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> NestedStructGroupB.Metadata {
+extension BridgeJSRuntimeTests.NestedStructGroupB.Metadata: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.NestedStructGroupB.Metadata {
         let value = Double.bridgeJSStackPop()
         let tag = String.bridgeJSStackPop()
-        return NestedStructGroupB.Metadata(tag: tag, value: value)
+        return BridgeJSRuntimeTests.NestedStructGroupB.Metadata(tag: tag, value: value)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6541,45 +6541,45 @@ extension NestedStructGroupB.Metadata: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_NestedStructGroupB_Metadata(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupB_Metadata(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_NestedStructGroupB_Metadata()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupB_Metadata()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_NestedStructGroupB_Metadata")
-fileprivate func _bjs_struct_lower_NestedStructGroupB_Metadata_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_NestedStructGroupB_Metadata")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupB_Metadata_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_NestedStructGroupB_Metadata_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupB_Metadata_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_NestedStructGroupB_Metadata(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_NestedStructGroupB_Metadata_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupB_Metadata(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_NestedStructGroupB_Metadata_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_NestedStructGroupB_Metadata")
-fileprivate func _bjs_struct_lift_NestedStructGroupB_Metadata_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_NestedStructGroupB_Metadata")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupB_Metadata_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_NestedStructGroupB_Metadata_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupB_Metadata_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_NestedStructGroupB_Metadata() -> Int32 {
-    return _bjs_struct_lift_NestedStructGroupB_Metadata_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupB_Metadata() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_NestedStructGroupB_Metadata_extern()
 }
 
-extension NestedTypeHost.Label: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> NestedTypeHost.Label {
+extension BridgeJSRuntimeTests.NestedTypeHost.Label: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.NestedTypeHost.Label {
         let text = String.bridgeJSStackPop()
-        return NestedTypeHost.Label(text: text)
+        return BridgeJSRuntimeTests.NestedTypeHost.Label(text: text)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6587,79 +6587,79 @@ extension NestedTypeHost.Label: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_NestedTypeHost_Label(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_NestedTypeHost_Label(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_NestedTypeHost_Label()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_NestedTypeHost_Label()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_NestedTypeHost_Label")
-fileprivate func _bjs_struct_lower_NestedTypeHost_Label_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_NestedTypeHost_Label")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_NestedTypeHost_Label_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_NestedTypeHost_Label_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_NestedTypeHost_Label_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_NestedTypeHost_Label(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_NestedTypeHost_Label_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_NestedTypeHost_Label(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_NestedTypeHost_Label_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_NestedTypeHost_Label")
-fileprivate func _bjs_struct_lift_NestedTypeHost_Label_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_NestedTypeHost_Label")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_NestedTypeHost_Label_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_NestedTypeHost_Label_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_NestedTypeHost_Label_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_NestedTypeHost_Label() -> Int32 {
-    return _bjs_struct_lift_NestedTypeHost_Label_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_NestedTypeHost_Label() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_NestedTypeHost_Label_extern()
 }
 
-@_expose(wasm, "bjs_NestedTypeHost_Label_init")
-@_cdecl("bjs_NestedTypeHost_Label_init")
-public func _bjs_NestedTypeHost_Label_init(_ textBytes: Int32, _ textLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_init")
+public func _bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_init(_ textBytes: Int32, _ textLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = NestedTypeHost.Label(text: String.bridgeJSLiftParameter(textBytes, textLength))
+    let ret = BridgeJSRuntimeTests.NestedTypeHost.Label(text: String.bridgeJSLiftParameter(textBytes, textLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_NestedTypeHost_Label_static_maxLength_get")
-@_cdecl("bjs_NestedTypeHost_Label_static_maxLength_get")
-public func _bjs_NestedTypeHost_Label_static_maxLength_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_static_maxLength_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_static_maxLength_get")
+public func _bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_static_maxLength_get() -> Int32 {
     #if arch(wasm32)
-    let ret = NestedTypeHost.Label.maxLength
+    let ret = BridgeJSRuntimeTests.NestedTypeHost.Label.maxLength
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_NestedTypeHost_Label_static_untitled")
-@_cdecl("bjs_NestedTypeHost_Label_static_untitled")
-public func _bjs_NestedTypeHost_Label_static_untitled() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_static_untitled")
+@_cdecl("bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_static_untitled")
+public func _bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_static_untitled() -> Void {
     #if arch(wasm32)
-    let ret = NestedTypeHost.Label.untitled()
+    let ret = BridgeJSRuntimeTests.NestedTypeHost.Label.untitled()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Point: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Point {
+extension BridgeJSRuntimeTests.Point: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.Point {
         let y = Int.bridgeJSStackPop()
         let x = Int.bridgeJSStackPop()
-        return Point(x: x, y: y)
+        return BridgeJSRuntimeTests.Point(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6668,49 +6668,49 @@ extension Point: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Point(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_Point(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Point()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_Point()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Point")
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_Point")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Point_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Point_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Point_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Point(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Point_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Point(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_Point_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Point")
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_Point")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Point_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Point_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Point_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Point() -> Int32 {
-    return _bjs_struct_lift_Point_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Point() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_Point_extern()
 }
 
-extension PointerFields: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PointerFields {
+extension BridgeJSRuntimeTests.PointerFields: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.PointerFields {
         let mutPtr = UnsafeMutablePointer<UInt8>.bridgeJSStackPop()
         let ptr = UnsafePointer<UInt8>.bridgeJSStackPop()
         let opaque = OpaquePointer.bridgeJSStackPop()
         let mutRaw = UnsafeMutableRawPointer.bridgeJSStackPop()
         let raw = UnsafeRawPointer.bridgeJSStackPop()
-        return PointerFields(raw: raw, mutRaw: mutRaw, opaque: opaque, ptr: ptr, mutPtr: mutPtr)
+        return BridgeJSRuntimeTests.PointerFields(raw: raw, mutRaw: mutRaw, opaque: opaque, ptr: ptr, mutPtr: mutPtr)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6722,60 +6722,60 @@ extension PointerFields: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_PointerFields(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_PointerFields(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PointerFields()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_PointerFields()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PointerFields")
-fileprivate func _bjs_struct_lower_PointerFields_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_PointerFields")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_PointerFields_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PointerFields_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_PointerFields_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_PointerFields(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_PointerFields_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_PointerFields(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_PointerFields_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PointerFields")
-fileprivate func _bjs_struct_lift_PointerFields_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_PointerFields")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_PointerFields_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_PointerFields_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_PointerFields_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_PointerFields() -> Int32 {
-    return _bjs_struct_lift_PointerFields_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_PointerFields() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_PointerFields_extern()
 }
 
-@_expose(wasm, "bjs_PointerFields_init")
-@_cdecl("bjs_PointerFields_init")
-public func _bjs_PointerFields_init(_ raw: UnsafeMutableRawPointer, _ mutRaw: UnsafeMutableRawPointer, _ opaque: UnsafeMutableRawPointer, _ ptr: UnsafeMutableRawPointer, _ mutPtr: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PointerFields_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_PointerFields_init")
+public func _bjs_BridgeJSRuntimeTests_PointerFields_init(_ raw: UnsafeMutableRawPointer, _ mutRaw: UnsafeMutableRawPointer, _ opaque: UnsafeMutableRawPointer, _ ptr: UnsafeMutableRawPointer, _ mutPtr: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PointerFields(raw: UnsafeRawPointer.bridgeJSLiftParameter(raw), mutRaw: UnsafeMutableRawPointer.bridgeJSLiftParameter(mutRaw), opaque: OpaquePointer.bridgeJSLiftParameter(opaque), ptr: UnsafePointer<UInt8>.bridgeJSLiftParameter(ptr), mutPtr: UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter(mutPtr))
+    let ret = BridgeJSRuntimeTests.PointerFields(raw: UnsafeRawPointer.bridgeJSLiftParameter(raw), mutRaw: UnsafeMutableRawPointer.bridgeJSLiftParameter(mutRaw), opaque: OpaquePointer.bridgeJSLiftParameter(opaque), ptr: UnsafePointer<UInt8>.bridgeJSLiftParameter(ptr), mutPtr: UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter(mutPtr))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension DataPoint: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> DataPoint {
+extension BridgeJSRuntimeTests.DataPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.DataPoint {
         let optFlag = Optional<Bool>.bridgeJSStackPop()
         let optCount = Optional<Int>.bridgeJSStackPop()
         let label = String.bridgeJSStackPop()
         let y = Double.bridgeJSStackPop()
         let x = Double.bridgeJSStackPop()
-        return DataPoint(x: x, y: y, label: label, optCount: optCount, optFlag: optFlag)
+        return BridgeJSRuntimeTests.DataPoint(x: x, y: y, label: label, optCount: optCount, optFlag: optFlag)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6787,79 +6787,79 @@ extension DataPoint: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_DataPoint(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_DataPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_DataPoint()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_DataPoint()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_DataPoint")
-fileprivate func _bjs_struct_lower_DataPoint_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_DataPoint")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_DataPoint_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_DataPoint_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_DataPoint_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_DataPoint(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_DataPoint_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_DataPoint(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_DataPoint_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_DataPoint")
-fileprivate func _bjs_struct_lift_DataPoint_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_DataPoint")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_DataPoint_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_DataPoint_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_DataPoint_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_DataPoint() -> Int32 {
-    return _bjs_struct_lift_DataPoint_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_DataPoint() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_DataPoint_extern()
 }
 
-@_expose(wasm, "bjs_DataPoint_init")
-@_cdecl("bjs_DataPoint_init")
-public func _bjs_DataPoint_init(_ x: Float64, _ y: Float64, _ labelBytes: Int32, _ labelLength: Int32, _ optCountIsSome: Int32, _ optCountValue: Int32, _ optFlagIsSome: Int32, _ optFlagValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataPoint_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataPoint_init")
+public func _bjs_BridgeJSRuntimeTests_DataPoint_init(_ x: Float64, _ y: Float64, _ labelBytes: Int32, _ labelLength: Int32, _ optCountIsSome: Int32, _ optCountValue: Int32, _ optFlagIsSome: Int32, _ optFlagValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = DataPoint(x: Double.bridgeJSLiftParameter(x), y: Double.bridgeJSLiftParameter(y), label: String.bridgeJSLiftParameter(labelBytes, labelLength), optCount: Optional<Int>.bridgeJSLiftParameter(optCountIsSome, optCountValue), optFlag: Optional<Bool>.bridgeJSLiftParameter(optFlagIsSome, optFlagValue))
+    let ret = BridgeJSRuntimeTests.DataPoint(x: Double.bridgeJSLiftParameter(x), y: Double.bridgeJSLiftParameter(y), label: String.bridgeJSLiftParameter(labelBytes, labelLength), optCount: Optional<Int>.bridgeJSLiftParameter(optCountIsSome, optCountValue), optFlag: Optional<Bool>.bridgeJSLiftParameter(optFlagIsSome, optFlagValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataPoint_static_dimensions_get")
-@_cdecl("bjs_DataPoint_static_dimensions_get")
-public func _bjs_DataPoint_static_dimensions_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataPoint_static_dimensions_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataPoint_static_dimensions_get")
+public func _bjs_BridgeJSRuntimeTests_DataPoint_static_dimensions_get() -> Int32 {
     #if arch(wasm32)
-    let ret = DataPoint.dimensions
+    let ret = BridgeJSRuntimeTests.DataPoint.dimensions
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataPoint_static_origin")
-@_cdecl("bjs_DataPoint_static_origin")
-public func _bjs_DataPoint_static_origin() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataPoint_static_origin")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataPoint_static_origin")
+public func _bjs_BridgeJSRuntimeTests_DataPoint_static_origin() -> Void {
     #if arch(wasm32)
-    let ret = DataPoint.origin()
+    let ret = BridgeJSRuntimeTests.DataPoint.origin()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PublicPoint: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> PublicPoint {
+extension BridgeJSRuntimeTests.PublicPoint: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.PublicPoint {
         let y = Int.bridgeJSStackPop()
         let x = Int.bridgeJSStackPop()
-        return PublicPoint(x: x, y: y)
+        return BridgeJSRuntimeTests.PublicPoint(x: x, y: y)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6868,58 +6868,58 @@ extension PublicPoint: _BridgedSwiftStruct {
     }
 
     public init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_PublicPoint(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_PublicPoint(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     public func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_PublicPoint()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_PublicPoint()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_PublicPoint")
-fileprivate func _bjs_struct_lower_PublicPoint_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_PublicPoint")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_PublicPoint_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_PublicPoint_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_PublicPoint_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_PublicPoint(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_PublicPoint_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_PublicPoint(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_PublicPoint_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_PublicPoint")
-fileprivate func _bjs_struct_lift_PublicPoint_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_PublicPoint")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_PublicPoint_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_PublicPoint_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_PublicPoint_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_PublicPoint() -> Int32 {
-    return _bjs_struct_lift_PublicPoint_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_PublicPoint() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_PublicPoint_extern()
 }
 
-@_expose(wasm, "bjs_PublicPoint_init")
-@_cdecl("bjs_PublicPoint_init")
-public func _bjs_PublicPoint_init(_ x: Int32, _ y: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PublicPoint_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_PublicPoint_init")
+public func _bjs_BridgeJSRuntimeTests_PublicPoint_init(_ x: Int32, _ y: Int32) -> Void {
     #if arch(wasm32)
-    let ret = PublicPoint(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
+    let ret = BridgeJSRuntimeTests.PublicPoint(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Address: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Address {
+extension BridgeJSRuntimeTests.Address: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.Address {
         let zipCode = Optional<Int>.bridgeJSStackPop()
         let city = String.bridgeJSStackPop()
         let street = String.bridgeJSStackPop()
-        return Address(street: street, city: city, zipCode: zipCode)
+        return BridgeJSRuntimeTests.Address(street: street, city: city, zipCode: zipCode)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6929,49 +6929,49 @@ extension Address: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Address(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_Address(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Address()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_Address()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Address")
-fileprivate func _bjs_struct_lower_Address_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_Address")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Address_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Address_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Address_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Address(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Address_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Address(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_Address_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Address")
-fileprivate func _bjs_struct_lift_Address_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_Address")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Address_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Address_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Address_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Address() -> Int32 {
-    return _bjs_struct_lift_Address_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Address() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_Address_extern()
 }
 
-extension Contact: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Contact {
-        let secondaryAddress = Optional<Address>.bridgeJSStackPop()
+extension BridgeJSRuntimeTests.Contact: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.Contact {
+        let secondaryAddress = Optional<BridgeJSRuntimeTests.Address>.bridgeJSStackPop()
         let email = Optional<String>.bridgeJSStackPop()
-        let address = Address.bridgeJSStackPop()
+        let address = BridgeJSRuntimeTests.Address.bridgeJSStackPop()
         let age = Int.bridgeJSStackPop()
         let name = String.bridgeJSStackPop()
-        return Contact(name: name, age: age, address: address, email: email, secondaryAddress: secondaryAddress)
+        return BridgeJSRuntimeTests.Contact(name: name, age: age, address: address, email: email, secondaryAddress: secondaryAddress)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -6983,48 +6983,48 @@ extension Contact: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Contact(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_Contact(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Contact()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_Contact()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Contact")
-fileprivate func _bjs_struct_lower_Contact_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_Contact")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Contact_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Contact_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Contact_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Contact(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Contact_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Contact(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_Contact_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Contact")
-fileprivate func _bjs_struct_lift_Contact_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_Contact")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Contact_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Contact_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Contact_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Contact() -> Int32 {
-    return _bjs_struct_lift_Contact_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Contact() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_Contact_extern()
 }
 
-extension Config: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Config {
-        let status = Status.bridgeJSStackPop()
-        let direction = Optional<Direction>.bridgeJSStackPop()
-        let theme = Optional<Theme>.bridgeJSStackPop()
+extension BridgeJSRuntimeTests.Config: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.Config {
+        let status = BridgeJSRuntimeTests.Status.bridgeJSStackPop()
+        let direction = Optional<BridgeJSRuntimeTests.Direction>.bridgeJSStackPop()
+        let theme = Optional<BridgeJSRuntimeTests.Theme>.bridgeJSStackPop()
         let name = String.bridgeJSStackPop()
-        return Config(name: name, theme: theme, direction: direction, status: status)
+        return BridgeJSRuntimeTests.Config(name: name, theme: theme, direction: direction, status: status)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7035,46 +7035,46 @@ extension Config: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Config(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_Config(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Config()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_Config()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Config")
-fileprivate func _bjs_struct_lower_Config_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_Config")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Config_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Config_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Config_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Config(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Config_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Config(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_Config_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Config")
-fileprivate func _bjs_struct_lift_Config_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_Config")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Config_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Config_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Config_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Config() -> Int32 {
-    return _bjs_struct_lift_Config_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Config() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_Config_extern()
 }
 
-extension SessionData: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> SessionData {
-        let owner = Optional<Greeter>.bridgeJSStackPop()
+extension BridgeJSRuntimeTests.SessionData: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.SessionData {
+        let owner = Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSStackPop()
         let id = Int.bridgeJSStackPop()
-        return SessionData(id: id, owner: owner)
+        return BridgeJSRuntimeTests.SessionData(id: id, owner: owner)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7083,48 +7083,48 @@ extension SessionData: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_SessionData(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_SessionData(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_SessionData()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_SessionData()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_SessionData")
-fileprivate func _bjs_struct_lower_SessionData_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_SessionData")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_SessionData_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_SessionData_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_SessionData_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_SessionData(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_SessionData_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_SessionData(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_SessionData_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_SessionData")
-fileprivate func _bjs_struct_lift_SessionData_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_SessionData")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_SessionData_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_SessionData_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_SessionData_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_SessionData() -> Int32 {
-    return _bjs_struct_lift_SessionData_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_SessionData() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_SessionData_extern()
 }
 
-extension ValidationReport: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ValidationReport {
-        let outcome = Optional<APIResult>.bridgeJSStackPop()
-        let status = Optional<Status>.bridgeJSStackPop()
-        let result = APIResult.bridgeJSStackPop()
+extension BridgeJSRuntimeTests.ValidationReport: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.ValidationReport {
+        let outcome = Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSStackPop()
+        let status = Optional<BridgeJSRuntimeTests.Status>.bridgeJSStackPop()
+        let result = BridgeJSRuntimeTests.APIResult.bridgeJSStackPop()
         let id = Int.bridgeJSStackPop()
-        return ValidationReport(id: id, result: result, status: status, outcome: outcome)
+        return BridgeJSRuntimeTests.ValidationReport(id: id, result: result, status: status, outcome: outcome)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7135,54 +7135,54 @@ extension ValidationReport: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_ValidationReport(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_ValidationReport(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ValidationReport()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_ValidationReport()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ValidationReport")
-fileprivate func _bjs_struct_lower_ValidationReport_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_ValidationReport")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_ValidationReport_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ValidationReport_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_ValidationReport_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_ValidationReport(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_ValidationReport_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_ValidationReport(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_ValidationReport_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ValidationReport")
-fileprivate func _bjs_struct_lift_ValidationReport_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_ValidationReport")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_ValidationReport_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_ValidationReport_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_ValidationReport_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_ValidationReport() -> Int32 {
-    return _bjs_struct_lift_ValidationReport_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_ValidationReport() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_ValidationReport_extern()
 }
 
-extension AdvancedConfig: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> AdvancedConfig {
-        let overrideDefaults = Optional<ConfigStruct>.bridgeJSStackPop()
-        let defaults = ConfigStruct.bridgeJSStackPop()
-        let location = Optional<DataPoint>.bridgeJSStackPop()
+extension BridgeJSRuntimeTests.AdvancedConfig: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.AdvancedConfig {
+        let overrideDefaults = Optional<BridgeJSRuntimeTests.ConfigStruct>.bridgeJSStackPop()
+        let defaults = BridgeJSRuntimeTests.ConfigStruct.bridgeJSStackPop()
+        let location = Optional<BridgeJSRuntimeTests.DataPoint>.bridgeJSStackPop()
         let metadata = Optional<JSObject>.bridgeJSStackPop()
-        let result = Optional<APIResult>.bridgeJSStackPop()
-        let status = Status.bridgeJSStackPop()
-        let theme = Theme.bridgeJSStackPop()
+        let result = Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSStackPop()
+        let status = BridgeJSRuntimeTests.Status.bridgeJSStackPop()
+        let theme = BridgeJSRuntimeTests.Theme.bridgeJSStackPop()
         let enabled = Bool.bridgeJSStackPop()
         let title = String.bridgeJSStackPop()
         let id = Int.bridgeJSStackPop()
-        return AdvancedConfig(id: id, title: title, enabled: enabled, theme: theme, status: status, result: result, metadata: metadata, location: location, defaults: defaults, overrideDefaults: overrideDefaults)
+        return BridgeJSRuntimeTests.AdvancedConfig(id: id, title: title, enabled: enabled, theme: theme, status: status, result: result, metadata: metadata, location: location, defaults: defaults, overrideDefaults: overrideDefaults)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7199,48 +7199,48 @@ extension AdvancedConfig: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_AdvancedConfig(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_AdvancedConfig(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_AdvancedConfig()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_AdvancedConfig()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_AdvancedConfig")
-fileprivate func _bjs_struct_lower_AdvancedConfig_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_AdvancedConfig")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_AdvancedConfig_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_AdvancedConfig_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_AdvancedConfig_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_AdvancedConfig(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_AdvancedConfig_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_AdvancedConfig(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_AdvancedConfig_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_AdvancedConfig")
-fileprivate func _bjs_struct_lift_AdvancedConfig_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_AdvancedConfig")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_AdvancedConfig_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_AdvancedConfig_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_AdvancedConfig_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_AdvancedConfig() -> Int32 {
-    return _bjs_struct_lift_AdvancedConfig_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_AdvancedConfig() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_AdvancedConfig_extern()
 }
 
-extension MeasurementConfig: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> MeasurementConfig {
-        let optionalRatio = Optional<Ratio>.bridgeJSStackPop()
-        let optionalPrecision = Optional<Precision>.bridgeJSStackPop()
-        let ratio = Ratio.bridgeJSStackPop()
-        let precision = Precision.bridgeJSStackPop()
-        return MeasurementConfig(precision: precision, ratio: ratio, optionalPrecision: optionalPrecision, optionalRatio: optionalRatio)
+extension BridgeJSRuntimeTests.MeasurementConfig: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.MeasurementConfig {
+        let optionalRatio = Optional<BridgeJSRuntimeTests.Ratio>.bridgeJSStackPop()
+        let optionalPrecision = Optional<BridgeJSRuntimeTests.Precision>.bridgeJSStackPop()
+        let ratio = BridgeJSRuntimeTests.Ratio.bridgeJSStackPop()
+        let precision = BridgeJSRuntimeTests.Precision.bridgeJSStackPop()
+        return BridgeJSRuntimeTests.MeasurementConfig(precision: precision, ratio: ratio, optionalPrecision: optionalPrecision, optionalRatio: optionalRatio)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7251,45 +7251,45 @@ extension MeasurementConfig: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_MeasurementConfig(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_MeasurementConfig(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_MeasurementConfig()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_MeasurementConfig()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MeasurementConfig")
-fileprivate func _bjs_struct_lower_MeasurementConfig_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_MeasurementConfig")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_MeasurementConfig_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_MeasurementConfig_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_MeasurementConfig_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_MeasurementConfig(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_MeasurementConfig_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_MeasurementConfig(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_MeasurementConfig_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_MeasurementConfig")
-fileprivate func _bjs_struct_lift_MeasurementConfig_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_MeasurementConfig")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_MeasurementConfig_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_MeasurementConfig_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_MeasurementConfig_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_MeasurementConfig() -> Int32 {
-    return _bjs_struct_lift_MeasurementConfig_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_MeasurementConfig() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_MeasurementConfig_extern()
 }
 
-extension MathOperations: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> MathOperations {
+extension BridgeJSRuntimeTests.MathOperations: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.MathOperations {
         let baseValue = Double.bridgeJSStackPop()
-        return MathOperations(baseValue: baseValue)
+        return BridgeJSRuntimeTests.MathOperations(baseValue: baseValue)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7297,90 +7297,90 @@ extension MathOperations: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_MathOperations(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_MathOperations(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_MathOperations()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_MathOperations()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_MathOperations")
-fileprivate func _bjs_struct_lower_MathOperations_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_MathOperations")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_MathOperations_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_MathOperations_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_MathOperations_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_MathOperations(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_MathOperations_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_MathOperations(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_MathOperations_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_MathOperations")
-fileprivate func _bjs_struct_lift_MathOperations_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_MathOperations")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_MathOperations_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_MathOperations_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_MathOperations_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_MathOperations() -> Int32 {
-    return _bjs_struct_lift_MathOperations_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_MathOperations() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_MathOperations_extern()
 }
 
-@_expose(wasm, "bjs_MathOperations_init")
-@_cdecl("bjs_MathOperations_init")
-public func _bjs_MathOperations_init(_ baseValue: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_MathOperations_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_MathOperations_init")
+public func _bjs_BridgeJSRuntimeTests_MathOperations_init(_ baseValue: Float64) -> Void {
     #if arch(wasm32)
-    let ret = MathOperations(baseValue: Double.bridgeJSLiftParameter(baseValue))
+    let ret = BridgeJSRuntimeTests.MathOperations(baseValue: Double.bridgeJSLiftParameter(baseValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathOperations_add")
-@_cdecl("bjs_MathOperations_add")
-public func _bjs_MathOperations_add(_ a: Float64, _ b: Float64) -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_MathOperations_add")
+@_cdecl("bjs_BridgeJSRuntimeTests_MathOperations_add")
+public func _bjs_BridgeJSRuntimeTests_MathOperations_add(_ a: Float64, _ b: Float64) -> Float64 {
     #if arch(wasm32)
-    let ret = MathOperations.bridgeJSLiftParameter().add(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
+    let ret = BridgeJSRuntimeTests.MathOperations.bridgeJSLiftParameter().add(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathOperations_multiply")
-@_cdecl("bjs_MathOperations_multiply")
-public func _bjs_MathOperations_multiply(_ a: Float64, _ b: Float64) -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_MathOperations_multiply")
+@_cdecl("bjs_BridgeJSRuntimeTests_MathOperations_multiply")
+public func _bjs_BridgeJSRuntimeTests_MathOperations_multiply(_ a: Float64, _ b: Float64) -> Float64 {
     #if arch(wasm32)
-    let ret = MathOperations.bridgeJSLiftParameter().multiply(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
+    let ret = BridgeJSRuntimeTests.MathOperations.bridgeJSLiftParameter().multiply(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathOperations_static_subtract")
-@_cdecl("bjs_MathOperations_static_subtract")
-public func _bjs_MathOperations_static_subtract(_ a: Float64, _ b: Float64) -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_MathOperations_static_subtract")
+@_cdecl("bjs_BridgeJSRuntimeTests_MathOperations_static_subtract")
+public func _bjs_BridgeJSRuntimeTests_MathOperations_static_subtract(_ a: Float64, _ b: Float64) -> Float64 {
     #if arch(wasm32)
-    let ret = MathOperations.subtract(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
+    let ret = BridgeJSRuntimeTests.MathOperations.subtract(a: Double.bridgeJSLiftParameter(a), b: Double.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension CopyableCart: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> CopyableCart {
+extension BridgeJSRuntimeTests.CopyableCart: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.CopyableCart {
         let note = Optional<String>.bridgeJSStackPop()
         let x = Int.bridgeJSStackPop()
-        return CopyableCart(x: x, note: note)
+        return BridgeJSRuntimeTests.CopyableCart(x: x, note: note)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7389,57 +7389,57 @@ extension CopyableCart: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_CopyableCart(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCart(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_CopyableCart()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCart()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableCart")
-fileprivate func _bjs_struct_lower_CopyableCart_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_CopyableCart")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCart_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_CopyableCart_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCart_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_CopyableCart(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_CopyableCart_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCart(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCart_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_CopyableCart")
-fileprivate func _bjs_struct_lift_CopyableCart_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_CopyableCart")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCart_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_CopyableCart_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCart_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_CopyableCart() -> Int32 {
-    return _bjs_struct_lift_CopyableCart_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCart() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCart_extern()
 }
 
-@_expose(wasm, "bjs_CopyableCart_static_fromJSObject")
-@_cdecl("bjs_CopyableCart_static_fromJSObject")
-public func _bjs_CopyableCart_static_fromJSObject(_ object: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_CopyableCart_static_fromJSObject")
+@_cdecl("bjs_BridgeJSRuntimeTests_CopyableCart_static_fromJSObject")
+public func _bjs_BridgeJSRuntimeTests_CopyableCart_static_fromJSObject(_ object: Int32) -> Void {
     #if arch(wasm32)
-    let ret = CopyableCart.fromJSObject(_: JSObject.bridgeJSLiftParameter(object))
+    let ret = BridgeJSRuntimeTests.CopyableCart.fromJSObject(_: JSObject.bridgeJSLiftParameter(object))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension CopyableCartItem: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> CopyableCartItem {
+extension BridgeJSRuntimeTests.CopyableCartItem: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.CopyableCartItem {
         let quantity = Int.bridgeJSStackPop()
         let sku = String.bridgeJSStackPop()
-        return CopyableCartItem(sku: sku, quantity: quantity)
+        return BridgeJSRuntimeTests.CopyableCartItem(sku: sku, quantity: quantity)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7448,47 +7448,47 @@ extension CopyableCartItem: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_CopyableCartItem(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCartItem(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_CopyableCartItem()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCartItem()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableCartItem")
-fileprivate func _bjs_struct_lower_CopyableCartItem_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_CopyableCartItem")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCartItem_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_CopyableCartItem_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCartItem_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_CopyableCartItem(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_CopyableCartItem_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCartItem(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_CopyableCartItem_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_CopyableCartItem")
-fileprivate func _bjs_struct_lift_CopyableCartItem_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_CopyableCartItem")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCartItem_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_CopyableCartItem_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCartItem_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_CopyableCartItem() -> Int32 {
-    return _bjs_struct_lift_CopyableCartItem_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCartItem() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_CopyableCartItem_extern()
 }
 
-extension CopyableNestedCart: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> CopyableNestedCart {
-        let shippingAddress = Optional<Address>.bridgeJSStackPop()
-        let item = CopyableCartItem.bridgeJSStackPop()
+extension BridgeJSRuntimeTests.CopyableNestedCart: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.CopyableNestedCart {
+        let shippingAddress = Optional<BridgeJSRuntimeTests.Address>.bridgeJSStackPop()
+        let item = BridgeJSRuntimeTests.CopyableCartItem.bridgeJSStackPop()
         let id = Int.bridgeJSStackPop()
-        return CopyableNestedCart(id: id, item: item, shippingAddress: shippingAddress)
+        return BridgeJSRuntimeTests.CopyableNestedCart(id: id, item: item, shippingAddress: shippingAddress)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7498,57 +7498,57 @@ extension CopyableNestedCart: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_CopyableNestedCart(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_CopyableNestedCart(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_CopyableNestedCart()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_CopyableNestedCart()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_CopyableNestedCart")
-fileprivate func _bjs_struct_lower_CopyableNestedCart_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_CopyableNestedCart")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_CopyableNestedCart_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_CopyableNestedCart_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_CopyableNestedCart_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_CopyableNestedCart(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_CopyableNestedCart_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_CopyableNestedCart(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_CopyableNestedCart_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_CopyableNestedCart")
-fileprivate func _bjs_struct_lift_CopyableNestedCart_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_CopyableNestedCart")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_CopyableNestedCart_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_CopyableNestedCart_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_CopyableNestedCart_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_CopyableNestedCart() -> Int32 {
-    return _bjs_struct_lift_CopyableNestedCart_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_CopyableNestedCart() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_CopyableNestedCart_extern()
 }
 
-@_expose(wasm, "bjs_CopyableNestedCart_static_fromJSObject")
-@_cdecl("bjs_CopyableNestedCart_static_fromJSObject")
-public func _bjs_CopyableNestedCart_static_fromJSObject(_ object: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_CopyableNestedCart_static_fromJSObject")
+@_cdecl("bjs_BridgeJSRuntimeTests_CopyableNestedCart_static_fromJSObject")
+public func _bjs_BridgeJSRuntimeTests_CopyableNestedCart_static_fromJSObject(_ object: Int32) -> Void {
     #if arch(wasm32)
-    let ret = CopyableNestedCart.fromJSObject(_: JSObject.bridgeJSLiftParameter(object))
+    let ret = BridgeJSRuntimeTests.CopyableNestedCart.fromJSObject(_: JSObject.bridgeJSLiftParameter(object))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ConfigStruct: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ConfigStruct {
+extension BridgeJSRuntimeTests.ConfigStruct: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.ConfigStruct {
         let value = Int.bridgeJSStackPop()
         let name = String.bridgeJSStackPop()
-        return ConfigStruct(name: name, value: value)
+        return BridgeJSRuntimeTests.ConfigStruct(name: name, value: value)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7557,110 +7557,110 @@ extension ConfigStruct: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_ConfigStruct(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_ConfigStruct(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ConfigStruct()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_ConfigStruct()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ConfigStruct")
-fileprivate func _bjs_struct_lower_ConfigStruct_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_ConfigStruct")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_ConfigStruct_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ConfigStruct_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_ConfigStruct_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_ConfigStruct(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_ConfigStruct_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_ConfigStruct(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_ConfigStruct_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ConfigStruct")
-fileprivate func _bjs_struct_lift_ConfigStruct_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_ConfigStruct")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_ConfigStruct_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_ConfigStruct_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_ConfigStruct_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_ConfigStruct() -> Int32 {
-    return _bjs_struct_lift_ConfigStruct_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_ConfigStruct() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_ConfigStruct_extern()
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_defaultConfig_get")
-@_cdecl("bjs_ConfigStruct_static_defaultConfig_get")
-public func _bjs_ConfigStruct_static_defaultConfig_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ConfigStruct_static_defaultConfig_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_ConfigStruct_static_defaultConfig_get")
+public func _bjs_BridgeJSRuntimeTests_ConfigStruct_static_defaultConfig_get() -> Void {
     #if arch(wasm32)
-    let ret = ConfigStruct.defaultConfig
+    let ret = BridgeJSRuntimeTests.ConfigStruct.defaultConfig
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_defaultConfig_set")
-@_cdecl("bjs_ConfigStruct_static_defaultConfig_set")
-public func _bjs_ConfigStruct_static_defaultConfig_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ConfigStruct_static_defaultConfig_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_ConfigStruct_static_defaultConfig_set")
+public func _bjs_BridgeJSRuntimeTests_ConfigStruct_static_defaultConfig_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    ConfigStruct.defaultConfig = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.ConfigStruct.defaultConfig = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_maxRetries_get")
-@_cdecl("bjs_ConfigStruct_static_maxRetries_get")
-public func _bjs_ConfigStruct_static_maxRetries_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ConfigStruct_static_maxRetries_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_ConfigStruct_static_maxRetries_get")
+public func _bjs_BridgeJSRuntimeTests_ConfigStruct_static_maxRetries_get() -> Int32 {
     #if arch(wasm32)
-    let ret = ConfigStruct.maxRetries
+    let ret = BridgeJSRuntimeTests.ConfigStruct.maxRetries
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_timeout_get")
-@_cdecl("bjs_ConfigStruct_static_timeout_get")
-public func _bjs_ConfigStruct_static_timeout_get() -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ConfigStruct_static_timeout_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_ConfigStruct_static_timeout_get")
+public func _bjs_BridgeJSRuntimeTests_ConfigStruct_static_timeout_get() -> Float64 {
     #if arch(wasm32)
-    let ret = ConfigStruct.timeout
+    let ret = BridgeJSRuntimeTests.ConfigStruct.timeout
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_timeout_set")
-@_cdecl("bjs_ConfigStruct_static_timeout_set")
-public func _bjs_ConfigStruct_static_timeout_set(_ value: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ConfigStruct_static_timeout_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_ConfigStruct_static_timeout_set")
+public func _bjs_BridgeJSRuntimeTests_ConfigStruct_static_timeout_set(_ value: Float64) -> Void {
     #if arch(wasm32)
-    ConfigStruct.timeout = Double.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.ConfigStruct.timeout = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ConfigStruct_static_computedSetting_get")
-@_cdecl("bjs_ConfigStruct_static_computedSetting_get")
-public func _bjs_ConfigStruct_static_computedSetting_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ConfigStruct_static_computedSetting_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_ConfigStruct_static_computedSetting_get")
+public func _bjs_BridgeJSRuntimeTests_ConfigStruct_static_computedSetting_get() -> Void {
     #if arch(wasm32)
-    let ret = ConfigStruct.computedSetting
+    let ret = BridgeJSRuntimeTests.ConfigStruct.computedSetting
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Vector2D: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> Vector2D {
+extension BridgeJSRuntimeTests.Vector2D: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.Vector2D {
         let dy = Double.bridgeJSStackPop()
         let dx = Double.bridgeJSStackPop()
-        return Vector2D(dx: dx, dy: dy)
+        return BridgeJSRuntimeTests.Vector2D(dx: dx, dy: dy)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7669,79 +7669,79 @@ extension Vector2D: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_Vector2D(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_Vector2D(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_Vector2D()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_Vector2D()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_Vector2D")
-fileprivate func _bjs_struct_lower_Vector2D_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_Vector2D")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Vector2D_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_Vector2D_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Vector2D_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_Vector2D(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_Vector2D_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_Vector2D(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_Vector2D_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_Vector2D")
-fileprivate func _bjs_struct_lift_Vector2D_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_Vector2D")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Vector2D_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_Vector2D_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Vector2D_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_Vector2D() -> Int32 {
-    return _bjs_struct_lift_Vector2D_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_Vector2D() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_Vector2D_extern()
 }
 
-@_expose(wasm, "bjs_Vector2D_init")
-@_cdecl("bjs_Vector2D_init")
-public func _bjs_Vector2D_init(_ dx: Float64, _ dy: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Vector2D_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_Vector2D_init")
+public func _bjs_BridgeJSRuntimeTests_Vector2D_init(_ dx: Float64, _ dy: Float64) -> Void {
     #if arch(wasm32)
-    let ret = Vector2D(dx: Double.bridgeJSLiftParameter(dx), dy: Double.bridgeJSLiftParameter(dy))
+    let ret = BridgeJSRuntimeTests.Vector2D(dx: Double.bridgeJSLiftParameter(dx), dy: Double.bridgeJSLiftParameter(dy))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Vector2D_magnitude")
-@_cdecl("bjs_Vector2D_magnitude")
-public func _bjs_Vector2D_magnitude() -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Vector2D_magnitude")
+@_cdecl("bjs_BridgeJSRuntimeTests_Vector2D_magnitude")
+public func _bjs_BridgeJSRuntimeTests_Vector2D_magnitude() -> Float64 {
     #if arch(wasm32)
-    let ret = Vector2D.bridgeJSLiftParameter().magnitude()
+    let ret = BridgeJSRuntimeTests.Vector2D.bridgeJSLiftParameter().magnitude()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Vector2D_scaled")
-@_cdecl("bjs_Vector2D_scaled")
-public func _bjs_Vector2D_scaled(_ factor: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Vector2D_scaled")
+@_cdecl("bjs_BridgeJSRuntimeTests_Vector2D_scaled")
+public func _bjs_BridgeJSRuntimeTests_Vector2D_scaled(_ factor: Float64) -> Void {
     #if arch(wasm32)
-    let ret = Vector2D.bridgeJSLiftParameter().scaled(by: Double.bridgeJSLiftParameter(factor))
+    let ret = BridgeJSRuntimeTests.Vector2D.bridgeJSLiftParameter().scaled(by: Double.bridgeJSLiftParameter(factor))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension JSObjectContainer: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> JSObjectContainer {
+extension BridgeJSRuntimeTests.JSObjectContainer: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.JSObjectContainer {
         let optionalObject = Optional<JSObject>.bridgeJSStackPop()
         let object = JSObject.bridgeJSStackPop()
-        return JSObjectContainer(object: object, optionalObject: optionalObject)
+        return BridgeJSRuntimeTests.JSObjectContainer(object: object, optionalObject: optionalObject)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7750,46 +7750,46 @@ extension JSObjectContainer: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_JSObjectContainer(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_JSObjectContainer(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_JSObjectContainer()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_JSObjectContainer()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_JSObjectContainer")
-fileprivate func _bjs_struct_lower_JSObjectContainer_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_JSObjectContainer")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_JSObjectContainer_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_JSObjectContainer_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_JSObjectContainer_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_JSObjectContainer(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_JSObjectContainer_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_JSObjectContainer(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_JSObjectContainer_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_JSObjectContainer")
-fileprivate func _bjs_struct_lift_JSObjectContainer_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_JSObjectContainer")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_JSObjectContainer_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_JSObjectContainer_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_JSObjectContainer_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_JSObjectContainer() -> Int32 {
-    return _bjs_struct_lift_JSObjectContainer_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_JSObjectContainer() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_JSObjectContainer_extern()
 }
 
-extension FooContainer: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> FooContainer {
+extension BridgeJSRuntimeTests.FooContainer: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.FooContainer {
         let optionalFoo = Optional<JSObject>.bridgeJSStackPop().map { Foo(unsafelyWrapping: $0) }
         let foo = Foo(unsafelyWrapping: JSObject.bridgeJSStackPop())
-        return FooContainer(foo: foo, optionalFoo: optionalFoo)
+        return BridgeJSRuntimeTests.FooContainer(foo: foo, optionalFoo: optionalFoo)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7798,46 +7798,46 @@ extension FooContainer: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_FooContainer(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_FooContainer(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_FooContainer()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_FooContainer()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_FooContainer")
-fileprivate func _bjs_struct_lower_FooContainer_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_FooContainer")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_FooContainer_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_FooContainer_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_FooContainer_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_FooContainer(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_FooContainer_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_FooContainer(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_FooContainer_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_FooContainer")
-fileprivate func _bjs_struct_lift_FooContainer_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_FooContainer")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_FooContainer_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_FooContainer_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_FooContainer_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_FooContainer() -> Int32 {
-    return _bjs_struct_lift_FooContainer_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_FooContainer() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_FooContainer_extern()
 }
 
-extension ArrayMembers: _BridgedSwiftStruct {
-    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> ArrayMembers {
+extension BridgeJSRuntimeTests.ArrayMembers: _BridgedSwiftStruct {
+    @_spi(BridgeJS) @_transparent public static func bridgeJSStackPop() -> BridgeJSRuntimeTests.ArrayMembers {
         let optStrings = Optional<[String]>.bridgeJSStackPop()
         let ints = [Int].bridgeJSStackPop()
-        return ArrayMembers(ints: ints, optStrings: optStrings)
+        return BridgeJSRuntimeTests.ArrayMembers(ints: ints, optStrings: optStrings)
     }
 
     @_spi(BridgeJS) @_transparent public consuming func bridgeJSStackPush() {
@@ -7846,66 +7846,66 @@ extension ArrayMembers: _BridgedSwiftStruct {
     }
 
     init(unsafelyCopying jsObject: JSObject) {
-        _bjs_struct_lower_ArrayMembers(jsObject.bridgeJSLowerParameter())
+        _bjs_struct_lower_BridgeJSRuntimeTests_ArrayMembers(jsObject.bridgeJSLowerParameter())
         self = Self.bridgeJSStackPop()
     }
 
     func toJSObject() -> JSObject {
         let __bjs_self = self
         __bjs_self.bridgeJSStackPush()
-        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_ArrayMembers()))
+        return JSObject(id: UInt32(bitPattern: _bjs_struct_lift_BridgeJSRuntimeTests_ArrayMembers()))
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_ArrayMembers")
-fileprivate func _bjs_struct_lower_ArrayMembers_extern(_ objectId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lower_BridgeJSRuntimeTests_ArrayMembers")
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_ArrayMembers_extern(_ objectId: Int32) -> Void
 #else
-fileprivate func _bjs_struct_lower_ArrayMembers_extern(_ objectId: Int32) -> Void {
+fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_ArrayMembers_extern(_ objectId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lower_ArrayMembers(_ objectId: Int32) -> Void {
-    return _bjs_struct_lower_ArrayMembers_extern(objectId)
+@inline(never) fileprivate func _bjs_struct_lower_BridgeJSRuntimeTests_ArrayMembers(_ objectId: Int32) -> Void {
+    return _bjs_struct_lower_BridgeJSRuntimeTests_ArrayMembers_extern(objectId)
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_ArrayMembers")
-fileprivate func _bjs_struct_lift_ArrayMembers_extern() -> Int32
+@_extern(wasm, module: "bjs", name: "swift_js_struct_lift_BridgeJSRuntimeTests_ArrayMembers")
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_ArrayMembers_extern() -> Int32
 #else
-fileprivate func _bjs_struct_lift_ArrayMembers_extern() -> Int32 {
+fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_ArrayMembers_extern() -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_struct_lift_ArrayMembers() -> Int32 {
-    return _bjs_struct_lift_ArrayMembers_extern()
+@inline(never) fileprivate func _bjs_struct_lift_BridgeJSRuntimeTests_ArrayMembers() -> Int32 {
+    return _bjs_struct_lift_BridgeJSRuntimeTests_ArrayMembers_extern()
 }
 
-@_expose(wasm, "bjs_ArrayMembers_sumValues")
-@_cdecl("bjs_ArrayMembers_sumValues")
-public func _bjs_ArrayMembers_sumValues() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArrayMembers_sumValues")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArrayMembers_sumValues")
+public func _bjs_BridgeJSRuntimeTests_ArrayMembers_sumValues() -> Int32 {
     #if arch(wasm32)
-    let ret = ArrayMembers.bridgeJSLiftParameter().sumValues(_: [Int].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArrayMembers.bridgeJSLiftParameter().sumValues(_: [Int].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ArrayMembers_firstString")
-@_cdecl("bjs_ArrayMembers_firstString")
-public func _bjs_ArrayMembers_firstString() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ArrayMembers_firstString")
+@_cdecl("bjs_BridgeJSRuntimeTests_ArrayMembers_firstString")
+public func _bjs_BridgeJSRuntimeTests_ArrayMembers_firstString() -> Void {
     #if arch(wasm32)
-    let ret = ArrayMembers.bridgeJSLiftParameter().firstString(_: [String].bridgeJSStackPop())
+    let ret = BridgeJSRuntimeTests.ArrayMembers.bridgeJSLiftParameter().firstString(_: [String].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeTag")
-@_cdecl("bjs_makeTag")
-public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeTag")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeTag")
+public func _bjs_BridgeJSRuntimeTests_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = makeTag(_: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -7914,78 +7914,78 @@ public func _bjs_makeTag(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutab
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripPolygon")
-@_cdecl("bjs_roundTripPolygon")
-public func _bjs_roundTripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripPolygon")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripPolygon")
+public func _bjs_BridgeJSRuntimeTests_roundTripPolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundTripPolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+    let ret = roundTripPolygon(_: BridgeJSRuntimeTests.Polygon.bridgeJSLiftParameter(polygon))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_appendVertex")
-@_cdecl("bjs_appendVertex")
-public func _bjs_appendVertex(_ polygon: UnsafeMutableRawPointer, _ value: Float64) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_appendVertex")
+@_cdecl("bjs_BridgeJSRuntimeTests_appendVertex")
+public func _bjs_BridgeJSRuntimeTests_appendVertex(_ polygon: UnsafeMutableRawPointer, _ value: Float64) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = appendVertex(_: Polygon.bridgeJSLiftParameter(polygon), _: Double.bridgeJSLiftParameter(value))
+    let ret = appendVertex(_: BridgeJSRuntimeTests.Polygon.bridgeJSLiftParameter(polygon), _: Double.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_optionalRoundTripPolygon")
-@_cdecl("bjs_optionalRoundTripPolygon")
-public func _bjs_optionalRoundTripPolygon(_ polygonIsSome: Int32, _ polygonValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_optionalRoundTripPolygon")
+@_cdecl("bjs_BridgeJSRuntimeTests_optionalRoundTripPolygon")
+public func _bjs_BridgeJSRuntimeTests_optionalRoundTripPolygon(_ polygonIsSome: Int32, _ polygonValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = optionalRoundTripPolygon(_: Optional<Polygon>.bridgeJSLiftParameter(polygonIsSome, polygonValue))
+    let ret = optionalRoundTripPolygon(_: Optional<BridgeJSRuntimeTests.Polygon>.bridgeJSLiftParameter(polygonIsSome, polygonValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_polygonVertexCount")
-@_cdecl("bjs_polygonVertexCount")
-public func _bjs_polygonVertexCount(_ polygon: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_polygonVertexCount")
+@_cdecl("bjs_BridgeJSRuntimeTests_polygonVertexCount")
+public func _bjs_BridgeJSRuntimeTests_polygonVertexCount(_ polygon: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = polygonVertexCount(_: Polygon.bridgeJSLiftParameter(polygon))
+    let ret = polygonVertexCount(_: BridgeJSRuntimeTests.Polygon.bridgeJSLiftParameter(polygon))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripPolygonArray")
-@_cdecl("bjs_roundTripPolygonArray")
-public func _bjs_roundTripPolygonArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripPolygonArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripPolygonArray")
+public func _bjs_BridgeJSRuntimeTests_roundTripPolygonArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripPolygonArray(_: [Polygon].bridgeJSStackPop())
+    let ret = roundTripPolygonArray(_: [BridgeJSRuntimeTests.Polygon].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_concatPolygons")
-@_cdecl("bjs_concatPolygons")
-public func _bjs_concatPolygons() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_concatPolygons")
+@_cdecl("bjs_BridgeJSRuntimeTests_concatPolygons")
+public func _bjs_BridgeJSRuntimeTests_concatPolygons() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = concatPolygons(_: [Polygon].bridgeJSStackPop())
+    let ret = concatPolygons(_: [BridgeJSRuntimeTests.Polygon].bridgeJSStackPop())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_validatePolygon")
-@_cdecl("bjs_validatePolygon")
-public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_validatePolygon")
+@_cdecl("bjs_BridgeJSRuntimeTests_validatePolygon")
+public func _bjs_BridgeJSRuntimeTests_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     do {
-        let ret = try validatePolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+        let ret = try validatePolygon(_: BridgeJSRuntimeTests.Polygon.bridgeJSLiftParameter(polygon))
         return ret.bridgeJSLowerReturn()
     } catch let error {
         if let error = error.thrownValue.object {
@@ -8005,20 +8005,20 @@ public func _bjs_validatePolygon(_ polygon: UnsafeMutableRawPointer) -> UnsafeMu
     #endif
 }
 
-@_expose(wasm, "bjs_splitPolygon")
-@_cdecl("bjs_splitPolygon")
-public func _bjs_splitPolygon(_ polygon: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_splitPolygon")
+@_cdecl("bjs_BridgeJSRuntimeTests_splitPolygon")
+public func _bjs_BridgeJSRuntimeTests_splitPolygon(_ polygon: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = splitPolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+    let ret = splitPolygon(_: BridgeJSRuntimeTests.Polygon.bridgeJSLiftParameter(polygon))
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makePolygonInspector")
-@_cdecl("bjs_makePolygonInspector")
-public func _bjs_makePolygonInspector() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makePolygonInspector")
+@_cdecl("bjs_BridgeJSRuntimeTests_makePolygonInspector")
+public func _bjs_BridgeJSRuntimeTests_makePolygonInspector() -> Int32 {
     #if arch(wasm32)
     let ret = makePolygonInspector()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -8027,20 +8027,20 @@ public func _bjs_makePolygonInspector() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalPolygonArray")
-@_cdecl("bjs_roundTripOptionalPolygonArray")
-public func _bjs_roundTripOptionalPolygonArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripOptionalPolygonArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripOptionalPolygonArray")
+public func _bjs_BridgeJSRuntimeTests_roundTripOptionalPolygonArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalPolygonArray(_: [Optional<Polygon>].bridgeJSStackPop())
+    let ret = roundTripOptionalPolygonArray(_: [Optional<BridgeJSRuntimeTests.Polygon>].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeTagHolder")
-@_cdecl("bjs_makeTagHolder")
-public func _bjs_makeTagHolder(_ nameBytes: Int32, _ nameLength: Int32, _ version: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeTagHolder")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeTagHolder")
+public func _bjs_BridgeJSRuntimeTests_makeTagHolder(_ nameBytes: Int32, _ nameLength: Int32, _ version: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = makeTagHolder(_: String.bridgeJSLiftParameter(nameBytes, nameLength), _: Int.bridgeJSLiftParameter(version))
     return ret.bridgeJSLowerReturn()
@@ -8049,75 +8049,75 @@ public func _bjs_makeTagHolder(_ nameBytes: Int32, _ nameLength: Int32, _ versio
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripCoordinate")
-@_cdecl("bjs_roundTripCoordinate")
-public func _bjs_roundTripCoordinate() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripCoordinate")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripCoordinate")
+public func _bjs_BridgeJSRuntimeTests_roundTripCoordinate() -> Void {
     #if arch(wasm32)
-    let ret = roundTripCoordinate(_: Coordinate.bridgeJSLiftParameter())
+    let ret = roundTripCoordinate(_: BridgeJSRuntimeTests.Coordinate.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripPriority")
-@_cdecl("bjs_roundTripPriority")
-public func _bjs_roundTripPriority(_ priority: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripPriority")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripPriority")
+public func _bjs_BridgeJSRuntimeTests_roundTripPriority(_ priority: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundTripPriority(_: Priority.bridgeJSLiftParameter(priority))
+    let ret = roundTripPriority(_: BridgeJSRuntimeTests.Priority.bridgeJSLiftParameter(priority))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripAlert")
-@_cdecl("bjs_roundTripAlert")
-public func _bjs_roundTripAlert(_ alert: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripAlert")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripAlert")
+public func _bjs_BridgeJSRuntimeTests_roundTripAlert(_ alert: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundTripAlert(_: Alert.bridgeJSLiftParameter(alert))
+    let ret = roundTripAlert(_: BridgeJSRuntimeTests.Alert.bridgeJSLiftParameter(alert))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeAlert")
-@_cdecl("bjs_makeAlert")
-public func _bjs_makeAlert(_ level: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAlert")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAlert")
+public func _bjs_BridgeJSRuntimeTests_makeAlert(_ level: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = makeAlert(_: Severity.bridgeJSLiftParameter(level))
+    let ret = makeAlert(_: BridgeJSRuntimeTests.Severity.bridgeJSLiftParameter(level))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripShape")
-@_cdecl("bjs_roundTripShape")
-public func _bjs_roundTripShape(_ s: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripShape")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripShape")
+public func _bjs_BridgeJSRuntimeTests_roundTripShape(_ s: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripShape(_: Shape.bridgeJSLiftParameter(s))
+    let ret = roundTripShape(_: BridgeJSRuntimeTests.Shape.bridgeJSLiftParameter(s))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeShapePolygon")
-@_cdecl("bjs_makeShapePolygon")
-public func _bjs_makeShapePolygon(_ polygon: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeShapePolygon")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeShapePolygon")
+public func _bjs_BridgeJSRuntimeTests_makeShapePolygon(_ polygon: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = makeShapePolygon(_: Polygon.bridgeJSLiftParameter(polygon))
+    let ret = makeShapePolygon(_: BridgeJSRuntimeTests.Polygon.bridgeJSLiftParameter(polygon))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeShapeEmpty")
-@_cdecl("bjs_makeShapeEmpty")
-public func _bjs_makeShapeEmpty() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeShapeEmpty")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeShapeEmpty")
+public func _bjs_BridgeJSRuntimeTests_makeShapeEmpty() -> Void {
     #if arch(wasm32)
     let ret = makeShapeEmpty()
     return ret.bridgeJSLowerReturn()
@@ -8126,64 +8126,64 @@ public func _bjs_makeShapeEmpty() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUserId")
-@_cdecl("bjs_roundTripUserId")
-public func _bjs_roundTripUserId(_ id: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripUserId")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripUserId")
+public func _bjs_BridgeJSRuntimeTests_roundTripUserId(_ id: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundTripUserId(_: UserId.bridgeJSLiftParameter(id))
+    let ret = roundTripUserId(_: BridgeJSRuntimeTests.UserId.bridgeJSLiftParameter(id))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalUserId")
-@_cdecl("bjs_roundTripOptionalUserId")
-public func _bjs_roundTripOptionalUserId(_ idIsSome: Int32, _ idValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripOptionalUserId")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripOptionalUserId")
+public func _bjs_BridgeJSRuntimeTests_roundTripOptionalUserId(_ idIsSome: Int32, _ idValue: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalUserId(_: Optional<UserId>.bridgeJSLiftParameter(idIsSome, idValue))
+    let ret = roundTripOptionalUserId(_: Optional<BridgeJSRuntimeTests.UserId>.bridgeJSLiftParameter(idIsSome, idValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUserIdArray")
-@_cdecl("bjs_roundTripUserIdArray")
-public func _bjs_roundTripUserIdArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripUserIdArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripUserIdArray")
+public func _bjs_BridgeJSRuntimeTests_roundTripUserIdArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripUserIdArray(_: [UserId].bridgeJSStackPop())
+    let ret = roundTripUserIdArray(_: [BridgeJSRuntimeTests.UserId].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripBoxed")
-@_cdecl("bjs_roundTripBoxed")
-public func _bjs_roundTripBoxed(_ boxedKind: Int32, _ boxedPayload1: Int32, _ boxedPayload2: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripBoxed")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripBoxed")
+public func _bjs_BridgeJSRuntimeTests_roundTripBoxed(_ boxedKind: Int32, _ boxedPayload1: Int32, _ boxedPayload2: Float64) -> Void {
     #if arch(wasm32)
-    let ret = roundTripBoxed(_: Boxed.bridgeJSLiftParameter(boxedKind, boxedPayload1, boxedPayload2))
+    let ret = roundTripBoxed(_: BridgeJSRuntimeTests.Boxed.bridgeJSLiftParameter(boxedKind, boxedPayload1, boxedPayload2))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalBoxed")
-@_cdecl("bjs_roundTripOptionalBoxed")
-public func _bjs_roundTripOptionalBoxed(_ boxedIsSome: Int32, _ boxedKind: Int32, _ boxedPayload1: Int32, _ boxedPayload2: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripOptionalBoxed")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripOptionalBoxed")
+public func _bjs_BridgeJSRuntimeTests_roundTripOptionalBoxed(_ boxedIsSome: Int32, _ boxedKind: Int32, _ boxedPayload1: Int32, _ boxedPayload2: Float64) -> Void {
     #if arch(wasm32)
-    let ret = roundTripOptionalBoxed(_: Optional<Boxed>.bridgeJSLiftParameter(boxedIsSome, boxedKind, boxedPayload1, boxedPayload2))
+    let ret = roundTripOptionalBoxed(_: Optional<BridgeJSRuntimeTests.Boxed>.bridgeJSLiftParameter(boxedIsSome, boxedKind, boxedPayload1, boxedPayload2))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_awaitAsyncCallback")
-@_cdecl("bjs_awaitAsyncCallback")
-public func _bjs_awaitAsyncCallback(_ fetch: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_awaitAsyncCallback")
+@_cdecl("bjs_BridgeJSRuntimeTests_awaitAsyncCallback")
+public func _bjs_BridgeJSRuntimeTests_awaitAsyncCallback(_ fetch: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
         return try await awaitAsyncCallback(_: _BJS_Closure_20BridgeJSRuntimeTestsYaKSS_SS.bridgeJSLift(fetch))
@@ -8193,9 +8193,9 @@ public func _bjs_awaitAsyncCallback(_ fetch: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAsyncParser")
-@_cdecl("bjs_makeAsyncParser")
-public func _bjs_makeAsyncParser() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAsyncParser")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAsyncParser")
+public func _bjs_BridgeJSRuntimeTests_makeAsyncParser() -> Int32 {
     #if arch(wasm32)
     let ret = makeAsyncParser()
     return ret.bridgeJSLowerReturn()
@@ -8204,9 +8204,9 @@ public func _bjs_makeAsyncParser() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAsyncEcho")
-@_cdecl("bjs_makeAsyncEcho")
-public func _bjs_makeAsyncEcho() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAsyncEcho")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAsyncEcho")
+public func _bjs_BridgeJSRuntimeTests_makeAsyncEcho() -> Int32 {
     #if arch(wasm32)
     let ret = makeAsyncEcho()
     return ret.bridgeJSLowerReturn()
@@ -8215,9 +8215,9 @@ public func _bjs_makeAsyncEcho() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAsyncRecorder")
-@_cdecl("bjs_makeAsyncRecorder")
-public func _bjs_makeAsyncRecorder() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAsyncRecorder")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAsyncRecorder")
+public func _bjs_BridgeJSRuntimeTests_makeAsyncRecorder() -> Int32 {
     #if arch(wasm32)
     let ret = makeAsyncRecorder()
     return ret.bridgeJSLowerReturn()
@@ -8226,9 +8226,9 @@ public func _bjs_makeAsyncRecorder() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_lastRecordedValue")
-@_cdecl("bjs_lastRecordedValue")
-public func _bjs_lastRecordedValue() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_lastRecordedValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_lastRecordedValue")
+public func _bjs_BridgeJSRuntimeTests_lastRecordedValue() -> Void {
     #if arch(wasm32)
     let ret = lastRecordedValue()
     return ret.bridgeJSLowerReturn()
@@ -8237,9 +8237,9 @@ public func _bjs_lastRecordedValue() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAsyncPayloadLoader")
-@_cdecl("bjs_makeAsyncPayloadLoader")
-public func _bjs_makeAsyncPayloadLoader() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAsyncPayloadLoader")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAsyncPayloadLoader")
+public func _bjs_BridgeJSRuntimeTests_makeAsyncPayloadLoader() -> Int32 {
     #if arch(wasm32)
     let ret = makeAsyncPayloadLoader()
     return ret.bridgeJSLowerReturn()
@@ -8248,21 +8248,21 @@ public func _bjs_makeAsyncPayloadLoader() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_awaitPayloadCallback")
-@_cdecl("bjs_awaitPayloadCallback")
-public func _bjs_awaitPayloadCallback(_ load: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_awaitPayloadCallback")
+@_cdecl("bjs_BridgeJSRuntimeTests_awaitPayloadCallback")
+public func _bjs_BridgeJSRuntimeTests_awaitPayloadCallback(_ load: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { () async throws(JSException) -> String in
-        return try await awaitPayloadCallback(_: _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO.bridgeJSLift(load))
+        return try await awaitPayloadCallback(_: _BJS_Closure_20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO.bridgeJSLift(load))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeAsyncPointMaker")
-@_cdecl("bjs_makeAsyncPointMaker")
-public func _bjs_makeAsyncPointMaker() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAsyncPointMaker")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAsyncPointMaker")
+public func _bjs_BridgeJSRuntimeTests_makeAsyncPointMaker() -> Int32 {
     #if arch(wasm32)
     let ret = makeAsyncPointMaker()
     return ret.bridgeJSLowerReturn()
@@ -8271,9 +8271,9 @@ public func _bjs_makeAsyncPointMaker() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_makeThrowingParser")
-@_cdecl("bjs_makeThrowingParser")
-public func _bjs_makeThrowingParser() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeThrowingParser")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeThrowingParser")
+public func _bjs_BridgeJSRuntimeTests_makeThrowingParser() -> Int32 {
     #if arch(wasm32)
     let ret = makeThrowingParser()
     return ret.bridgeJSLowerReturn()
@@ -8282,9 +8282,9 @@ public func _bjs_makeThrowingParser() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_runValidator")
-@_cdecl("bjs_runValidator")
-public func _bjs_runValidator(_ validate: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_runValidator")
+@_cdecl("bjs_BridgeJSRuntimeTests_runValidator")
+public func _bjs_BridgeJSRuntimeTests_runValidator(_ validate: Int32) -> Int32 {
     #if arch(wasm32)
     do {
         let ret = try runValidator(_: _BJS_Closure_20BridgeJSRuntimeTestsKSS_Sb.bridgeJSLift(validate))
@@ -8307,9 +8307,9 @@ public func _bjs_runValidator(_ validate: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripVoid")
-@_cdecl("bjs_roundTripVoid")
-public func _bjs_roundTripVoid() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripVoid")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripVoid")
+public func _bjs_BridgeJSRuntimeTests_roundTripVoid() -> Void {
     #if arch(wasm32)
     roundTripVoid()
     #else
@@ -8317,9 +8317,9 @@ public func _bjs_roundTripVoid() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripFloat")
-@_cdecl("bjs_roundTripFloat")
-public func _bjs_roundTripFloat(_ v: Float32) -> Float32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripFloat")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripFloat")
+public func _bjs_BridgeJSRuntimeTests_roundTripFloat(_ v: Float32) -> Float32 {
     #if arch(wasm32)
     let ret = roundTripFloat(v: Float.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -8328,9 +8328,9 @@ public func _bjs_roundTripFloat(_ v: Float32) -> Float32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripDouble")
-@_cdecl("bjs_roundTripDouble")
-public func _bjs_roundTripDouble(_ v: Float64) -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripDouble")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripDouble")
+public func _bjs_BridgeJSRuntimeTests_roundTripDouble(_ v: Float64) -> Float64 {
     #if arch(wasm32)
     let ret = roundTripDouble(v: Double.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -8339,9 +8339,9 @@ public func _bjs_roundTripDouble(_ v: Float64) -> Float64 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripBool")
-@_cdecl("bjs_roundTripBool")
-public func _bjs_roundTripBool(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripBool")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripBool")
+public func _bjs_BridgeJSRuntimeTests_roundTripBool(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundTripBool(v: Bool.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -8350,9 +8350,9 @@ public func _bjs_roundTripBool(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripString")
-@_cdecl("bjs_roundTripString")
-public func _bjs_roundTripString(_ vBytes: Int32, _ vLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripString")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripString")
+public func _bjs_BridgeJSRuntimeTests_roundTripString(_ vBytes: Int32, _ vLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripString(v: String.bridgeJSLiftParameter(vBytes, vLength))
     return ret.bridgeJSLowerReturn()
@@ -8361,20 +8361,20 @@ public func _bjs_roundTripString(_ vBytes: Int32, _ vLength: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripSwiftHeapObject")
-@_cdecl("bjs_roundTripSwiftHeapObject")
-public func _bjs_roundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripSwiftHeapObject")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripSwiftHeapObject")
+public func _bjs_BridgeJSRuntimeTests_roundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundTripSwiftHeapObject(v: Greeter.bridgeJSLiftParameter(v))
+    let ret = roundTripSwiftHeapObject(v: BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUnsafeRawPointer")
-@_cdecl("bjs_roundTripUnsafeRawPointer")
-public func _bjs_roundTripUnsafeRawPointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripUnsafeRawPointer")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripUnsafeRawPointer")
+public func _bjs_BridgeJSRuntimeTests_roundTripUnsafeRawPointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = roundTripUnsafeRawPointer(v: UnsafeRawPointer.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -8383,9 +8383,9 @@ public func _bjs_roundTripUnsafeRawPointer(_ v: UnsafeMutableRawPointer) -> Unsa
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUnsafeMutableRawPointer")
-@_cdecl("bjs_roundTripUnsafeMutableRawPointer")
-public func _bjs_roundTripUnsafeMutableRawPointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripUnsafeMutableRawPointer")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripUnsafeMutableRawPointer")
+public func _bjs_BridgeJSRuntimeTests_roundTripUnsafeMutableRawPointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = roundTripUnsafeMutableRawPointer(v: UnsafeMutableRawPointer.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -8394,9 +8394,9 @@ public func _bjs_roundTripUnsafeMutableRawPointer(_ v: UnsafeMutableRawPointer) 
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOpaquePointer")
-@_cdecl("bjs_roundTripOpaquePointer")
-public func _bjs_roundTripOpaquePointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripOpaquePointer")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripOpaquePointer")
+public func _bjs_BridgeJSRuntimeTests_roundTripOpaquePointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = roundTripOpaquePointer(v: OpaquePointer.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -8405,9 +8405,9 @@ public func _bjs_roundTripOpaquePointer(_ v: UnsafeMutableRawPointer) -> UnsafeM
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUnsafePointer")
-@_cdecl("bjs_roundTripUnsafePointer")
-public func _bjs_roundTripUnsafePointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripUnsafePointer")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripUnsafePointer")
+public func _bjs_BridgeJSRuntimeTests_roundTripUnsafePointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = roundTripUnsafePointer(v: UnsafePointer<UInt8>.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -8416,9 +8416,9 @@ public func _bjs_roundTripUnsafePointer(_ v: UnsafeMutableRawPointer) -> UnsafeM
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUnsafeMutablePointer")
-@_cdecl("bjs_roundTripUnsafeMutablePointer")
-public func _bjs_roundTripUnsafeMutablePointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripUnsafeMutablePointer")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripUnsafeMutablePointer")
+public func _bjs_BridgeJSRuntimeTests_roundTripUnsafeMutablePointer(_ v: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = roundTripUnsafeMutablePointer(v: UnsafeMutablePointer<UInt8>.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -8427,9 +8427,9 @@ public func _bjs_roundTripUnsafeMutablePointer(_ v: UnsafeMutableRawPointer) -> 
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripJSObject")
-@_cdecl("bjs_roundTripJSObject")
-public func _bjs_roundTripJSObject(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripJSObject")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripJSObject")
+public func _bjs_BridgeJSRuntimeTests_roundTripJSObject(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = roundTripJSObject(v: JSObject.bridgeJSLiftParameter(v))
     return ret.bridgeJSLowerReturn()
@@ -8438,9 +8438,9 @@ public func _bjs_roundTripJSObject(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripDictionaryExport")
-@_cdecl("bjs_roundTripDictionaryExport")
-public func _bjs_roundTripDictionaryExport() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripDictionaryExport")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripDictionaryExport")
+public func _bjs_BridgeJSRuntimeTests_roundTripDictionaryExport() -> Void {
     #if arch(wasm32)
     let ret = roundTripDictionaryExport(v: [String: Int].bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
@@ -8449,9 +8449,9 @@ public func _bjs_roundTripDictionaryExport() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalDictionaryExport")
-@_cdecl("bjs_roundTripOptionalDictionaryExport")
-public func _bjs_roundTripOptionalDictionaryExport() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripOptionalDictionaryExport")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripOptionalDictionaryExport")
+public func _bjs_BridgeJSRuntimeTests_roundTripOptionalDictionaryExport() -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalDictionaryExport(v: Optional<[String: String]>.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
@@ -8460,9 +8460,9 @@ public func _bjs_roundTripOptionalDictionaryExport() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripJSValue")
-@_cdecl("bjs_roundTripJSValue")
-public func _bjs_roundTripJSValue(_ vKind: Int32, _ vPayload1: Int32, _ vPayload2: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripJSValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripJSValue")
+public func _bjs_BridgeJSRuntimeTests_roundTripJSValue(_ vKind: Int32, _ vPayload1: Int32, _ vPayload2: Float64) -> Void {
     #if arch(wasm32)
     let ret = roundTripJSValue(v: JSValue.bridgeJSLiftParameter(vKind, vPayload1, vPayload2))
     return ret.bridgeJSLowerReturn()
@@ -8471,9 +8471,9 @@ public func _bjs_roundTripJSValue(_ vKind: Int32, _ vPayload1: Int32, _ vPayload
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalJSValue")
-@_cdecl("bjs_roundTripOptionalJSValue")
-public func _bjs_roundTripOptionalJSValue(_ vIsSome: Int32, _ vKind: Int32, _ vPayload1: Int32, _ vPayload2: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripOptionalJSValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripOptionalJSValue")
+public func _bjs_BridgeJSRuntimeTests_roundTripOptionalJSValue(_ vIsSome: Int32, _ vKind: Int32, _ vPayload1: Int32, _ vPayload2: Float64) -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalJSValue(v: Optional<JSValue>.bridgeJSLiftParameter(vIsSome, vKind, vPayload1, vPayload2))
     return ret.bridgeJSLowerReturn()
@@ -8482,9 +8482,9 @@ public func _bjs_roundTripOptionalJSValue(_ vIsSome: Int32, _ vKind: Int32, _ vP
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalJSValueArray")
-@_cdecl("bjs_roundTripOptionalJSValueArray")
-public func _bjs_roundTripOptionalJSValueArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripOptionalJSValueArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripOptionalJSValueArray")
+public func _bjs_BridgeJSRuntimeTests_roundTripOptionalJSValueArray() -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalJSValueArray(v: Optional<[JSValue]>.bridgeJSLiftParameter())
     ret.bridgeJSStackPush()
@@ -8493,9 +8493,9 @@ public func _bjs_roundTripOptionalJSValueArray() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_makeImportedFoo")
-@_cdecl("bjs_makeImportedFoo")
-public func _bjs_makeImportedFoo(_ valueBytes: Int32, _ valueLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeImportedFoo")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeImportedFoo")
+public func _bjs_BridgeJSRuntimeTests_makeImportedFoo(_ valueBytes: Int32, _ valueLength: Int32) -> Int32 {
     #if arch(wasm32)
     do {
         let ret = try makeImportedFoo(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
@@ -8518,9 +8518,9 @@ public func _bjs_makeImportedFoo(_ valueBytes: Int32, _ valueLength: Int32) -> I
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripOptionalImportedClass")
-@_cdecl("bjs_roundTripOptionalImportedClass")
-public func _bjs_roundTripOptionalImportedClass(_ vIsSome: Int32, _ vValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripOptionalImportedClass")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripOptionalImportedClass")
+public func _bjs_BridgeJSRuntimeTests_roundTripOptionalImportedClass(_ vIsSome: Int32, _ vValue: Int32) -> Void {
     #if arch(wasm32)
     let ret = roundTripOptionalImportedClass(v: Optional<Foo>.bridgeJSLiftParameter(vIsSome, vValue))
     return ret.bridgeJSLowerReturn()
@@ -8529,9 +8529,9 @@ public func _bjs_roundTripOptionalImportedClass(_ vIsSome: Int32, _ vValue: Int3
     #endif
 }
 
-@_expose(wasm, "bjs_throwsSwiftError")
-@_cdecl("bjs_throwsSwiftError")
-public func _bjs_throwsSwiftError(_ shouldThrow: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_throwsSwiftError")
+@_cdecl("bjs_BridgeJSRuntimeTests_throwsSwiftError")
+public func _bjs_BridgeJSRuntimeTests_throwsSwiftError(_ shouldThrow: Int32) -> Void {
     #if arch(wasm32)
     do {
         try throwsSwiftError(shouldThrow: Bool.bridgeJSLiftParameter(shouldThrow))
@@ -8553,9 +8553,9 @@ public func _bjs_throwsSwiftError(_ shouldThrow: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_throwsWithIntResult")
-@_cdecl("bjs_throwsWithIntResult")
-public func _bjs_throwsWithIntResult() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_throwsWithIntResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_throwsWithIntResult")
+public func _bjs_BridgeJSRuntimeTests_throwsWithIntResult() -> Int32 {
     #if arch(wasm32)
     do {
         let ret = try throwsWithIntResult()
@@ -8578,9 +8578,9 @@ public func _bjs_throwsWithIntResult() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_throwsWithStringResult")
-@_cdecl("bjs_throwsWithStringResult")
-public func _bjs_throwsWithStringResult() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_throwsWithStringResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_throwsWithStringResult")
+public func _bjs_BridgeJSRuntimeTests_throwsWithStringResult() -> Void {
     #if arch(wasm32)
     do {
         let ret = try throwsWithStringResult()
@@ -8603,9 +8603,9 @@ public func _bjs_throwsWithStringResult() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_throwsWithBoolResult")
-@_cdecl("bjs_throwsWithBoolResult")
-public func _bjs_throwsWithBoolResult() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_throwsWithBoolResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_throwsWithBoolResult")
+public func _bjs_BridgeJSRuntimeTests_throwsWithBoolResult() -> Int32 {
     #if arch(wasm32)
     do {
         let ret = try throwsWithBoolResult()
@@ -8628,9 +8628,9 @@ public func _bjs_throwsWithBoolResult() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_throwsWithFloatResult")
-@_cdecl("bjs_throwsWithFloatResult")
-public func _bjs_throwsWithFloatResult() -> Float32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_throwsWithFloatResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_throwsWithFloatResult")
+public func _bjs_BridgeJSRuntimeTests_throwsWithFloatResult() -> Float32 {
     #if arch(wasm32)
     do {
         let ret = try throwsWithFloatResult()
@@ -8653,9 +8653,9 @@ public func _bjs_throwsWithFloatResult() -> Float32 {
     #endif
 }
 
-@_expose(wasm, "bjs_throwsWithDoubleResult")
-@_cdecl("bjs_throwsWithDoubleResult")
-public func _bjs_throwsWithDoubleResult() -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_throwsWithDoubleResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_throwsWithDoubleResult")
+public func _bjs_BridgeJSRuntimeTests_throwsWithDoubleResult() -> Float64 {
     #if arch(wasm32)
     do {
         let ret = try throwsWithDoubleResult()
@@ -8678,9 +8678,9 @@ public func _bjs_throwsWithDoubleResult() -> Float64 {
     #endif
 }
 
-@_expose(wasm, "bjs_throwsWithSwiftHeapObjectResult")
-@_cdecl("bjs_throwsWithSwiftHeapObjectResult")
-public func _bjs_throwsWithSwiftHeapObjectResult() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_throwsWithSwiftHeapObjectResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_throwsWithSwiftHeapObjectResult")
+public func _bjs_BridgeJSRuntimeTests_throwsWithSwiftHeapObjectResult() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     do {
         let ret = try throwsWithSwiftHeapObjectResult()
@@ -8703,9 +8703,9 @@ public func _bjs_throwsWithSwiftHeapObjectResult() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_throwsWithJSObjectResult")
-@_cdecl("bjs_throwsWithJSObjectResult")
-public func _bjs_throwsWithJSObjectResult() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_throwsWithJSObjectResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_throwsWithJSObjectResult")
+public func _bjs_BridgeJSRuntimeTests_throwsWithJSObjectResult() -> Int32 {
     #if arch(wasm32)
     do {
         let ret = try throwsWithJSObjectResult()
@@ -8728,9 +8728,9 @@ public func _bjs_throwsWithJSObjectResult() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_zeroArgAsyncThrows")
-@_cdecl("bjs_zeroArgAsyncThrows")
-public func _bjs_zeroArgAsyncThrows() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_zeroArgAsyncThrows")
+@_cdecl("bjs_BridgeJSRuntimeTests_zeroArgAsyncThrows")
+public func _bjs_BridgeJSRuntimeTests_zeroArgAsyncThrows() -> Int32 {
     #if arch(wasm32)
     let __bjs_capture = 0
     return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) { [__bjs_capture] () async throws(JSException) -> String in
@@ -8742,9 +8742,9 @@ public func _bjs_zeroArgAsyncThrows() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripVoid")
-@_cdecl("bjs_asyncRoundTripVoid")
-public func _bjs_asyncRoundTripVoid() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripVoid")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripVoid")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripVoid() -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_y, reject: Promise_reject) {
         await asyncRoundTripVoid()
@@ -8754,9 +8754,9 @@ public func _bjs_asyncRoundTripVoid() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripInt")
-@_cdecl("bjs_asyncRoundTripInt")
-public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripInt")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripInt")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripInt(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_Si, reject: Promise_reject) {
         return await asyncRoundTripInt(v: Int.bridgeJSLiftParameter(v))
@@ -8766,9 +8766,9 @@ public func _bjs_asyncRoundTripInt(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripFloat")
-@_cdecl("bjs_asyncRoundTripFloat")
-public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripFloat")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripFloat")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripFloat(_ v: Float32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_Sf, reject: Promise_reject) {
         return await asyncRoundTripFloat(v: Float.bridgeJSLiftParameter(v))
@@ -8778,9 +8778,9 @@ public func _bjs_asyncRoundTripFloat(_ v: Float32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripDouble")
-@_cdecl("bjs_asyncRoundTripDouble")
-public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripDouble")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripDouble")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripDouble(_ v: Float64) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_Sd, reject: Promise_reject) {
         return await asyncRoundTripDouble(v: Double.bridgeJSLiftParameter(v))
@@ -8790,9 +8790,9 @@ public func _bjs_asyncRoundTripDouble(_ v: Float64) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripBool")
-@_cdecl("bjs_asyncRoundTripBool")
-public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripBool")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripBool")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripBool(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_Sb, reject: Promise_reject) {
         return await asyncRoundTripBool(v: Bool.bridgeJSLiftParameter(v))
@@ -8802,9 +8802,9 @@ public func _bjs_asyncRoundTripBool(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripString")
-@_cdecl("bjs_asyncRoundTripString")
-public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripString")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripString")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_SS, reject: Promise_reject) {
         return await asyncRoundTripString(v: String.bridgeJSLiftParameter(vBytes, vLength))
@@ -8814,21 +8814,21 @@ public func _bjs_asyncRoundTripString(_ vBytes: Int32, _ vLength: Int32) -> Int3
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripSwiftHeapObject")
-@_cdecl("bjs_asyncRoundTripSwiftHeapObject")
-public func _bjs_asyncRoundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripSwiftHeapObject")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripSwiftHeapObject")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripSwiftHeapObject(_ v: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_7GreeterC, reject: Promise_reject) {
-        return await asyncRoundTripSwiftHeapObject(v: Greeter.bridgeJSLiftParameter(v))
+    return _bjs_makePromise(resolve: Promise_resolve_28BridgeJSRuntimeTests_GreeterC, reject: Promise_reject) {
+        return await asyncRoundTripSwiftHeapObject(v: BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(v))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripJSObject")
-@_cdecl("bjs_asyncRoundTripJSObject")
-public func _bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripJSObject")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripJSObject")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
     #if arch(wasm32)
     return _bjs_makePromise(resolve: Promise_resolve_8JSObjectC, reject: Promise_reject) {
         return await asyncRoundTripJSObject(v: JSObject.bridgeJSLiftParameter(v))
@@ -8838,19 +8838,19 @@ public func _bjs_asyncRoundTripJSObject(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_takeGreeter")
-@_cdecl("bjs_takeGreeter")
-public func _bjs_takeGreeter(_ g: UnsafeMutableRawPointer, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_takeGreeter")
+@_cdecl("bjs_BridgeJSRuntimeTests_takeGreeter")
+public func _bjs_BridgeJSRuntimeTests_takeGreeter(_ g: UnsafeMutableRawPointer, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
-    takeGreeter(g: Greeter.bridgeJSLiftParameter(g), name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    takeGreeter(g: BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(g), name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_createCalculator")
-@_cdecl("bjs_createCalculator")
-public func _bjs_createCalculator() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_createCalculator")
+@_cdecl("bjs_BridgeJSRuntimeTests_createCalculator")
+public func _bjs_BridgeJSRuntimeTests_createCalculator() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = createCalculator()
     return ret.bridgeJSLowerReturn()
@@ -8859,20 +8859,20 @@ public func _bjs_createCalculator() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_useCalculator")
-@_cdecl("bjs_useCalculator")
-public func _bjs_useCalculator(_ calc: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_useCalculator")
+@_cdecl("bjs_BridgeJSRuntimeTests_useCalculator")
+public func _bjs_BridgeJSRuntimeTests_useCalculator(_ calc: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = useCalculator(calc: Calculator.bridgeJSLiftParameter(calc), x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
+    let ret = useCalculator(calc: BridgeJSRuntimeTests.Calculator.bridgeJSLiftParameter(calc), x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_testGreeterToJSValue")
-@_cdecl("bjs_testGreeterToJSValue")
-public func _bjs_testGreeterToJSValue() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_testGreeterToJSValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_testGreeterToJSValue")
+public func _bjs_BridgeJSRuntimeTests_testGreeterToJSValue() -> Int32 {
     #if arch(wasm32)
     let ret = testGreeterToJSValue()
     return ret.bridgeJSLowerReturn()
@@ -8881,9 +8881,9 @@ public func _bjs_testGreeterToJSValue() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_testCalculatorToJSValue")
-@_cdecl("bjs_testCalculatorToJSValue")
-public func _bjs_testCalculatorToJSValue() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_testCalculatorToJSValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_testCalculatorToJSValue")
+public func _bjs_BridgeJSRuntimeTests_testCalculatorToJSValue() -> Int32 {
     #if arch(wasm32)
     let ret = testCalculatorToJSValue()
     return ret.bridgeJSLowerReturn()
@@ -8892,31 +8892,31 @@ public func _bjs_testCalculatorToJSValue() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_testSwiftClassAsJSValue")
-@_cdecl("bjs_testSwiftClassAsJSValue")
-public func _bjs_testSwiftClassAsJSValue(_ greeter: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_testSwiftClassAsJSValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_testSwiftClassAsJSValue")
+public func _bjs_BridgeJSRuntimeTests_testSwiftClassAsJSValue(_ greeter: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = testSwiftClassAsJSValue(greeter: Greeter.bridgeJSLiftParameter(greeter))
+    let ret = testSwiftClassAsJSValue(greeter: BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(greeter))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setDirection")
-@_cdecl("bjs_setDirection")
-public func _bjs_setDirection(_ direction: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_setDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_setDirection")
+public func _bjs_BridgeJSRuntimeTests_setDirection(_ direction: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = setDirection(_: Direction.bridgeJSLiftParameter(direction))
+    let ret = setDirection(_: BridgeJSRuntimeTests.Direction.bridgeJSLiftParameter(direction))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getDirection")
-@_cdecl("bjs_getDirection")
-public func _bjs_getDirection() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_getDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_getDirection")
+public func _bjs_BridgeJSRuntimeTests_getDirection() -> Int32 {
     #if arch(wasm32)
     let ret = getDirection()
     return ret.bridgeJSLowerReturn()
@@ -8925,31 +8925,31 @@ public func _bjs_getDirection() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_processDirection")
-@_cdecl("bjs_processDirection")
-public func _bjs_processDirection(_ input: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_processDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_processDirection")
+public func _bjs_BridgeJSRuntimeTests_processDirection(_ input: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = processDirection(_: Direction.bridgeJSLiftParameter(input))
+    let ret = processDirection(_: BridgeJSRuntimeTests.Direction.bridgeJSLiftParameter(input))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setTheme")
-@_cdecl("bjs_setTheme")
-public func _bjs_setTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_setTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_setTheme")
+public func _bjs_BridgeJSRuntimeTests_setTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = setTheme(_: Theme.bridgeJSLiftParameter(themeBytes, themeLength))
+    let ret = setTheme(_: BridgeJSRuntimeTests.Theme.bridgeJSLiftParameter(themeBytes, themeLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getTheme")
-@_cdecl("bjs_getTheme")
-public func _bjs_getTheme() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_getTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_getTheme")
+public func _bjs_BridgeJSRuntimeTests_getTheme() -> Void {
     #if arch(wasm32)
     let ret = getTheme()
     return ret.bridgeJSLowerReturn()
@@ -8958,60 +8958,60 @@ public func _bjs_getTheme() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripTheme")
-@_cdecl("bjs_asyncRoundTripTheme")
-public func _bjs_asyncRoundTripTheme(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripTheme")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripTheme(_ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_5ThemeO, reject: Promise_reject) {
-        return await asyncRoundTripTheme(_: Theme.bridgeJSLiftParameter(vBytes, vLength))
+    return _bjs_makePromise(resolve: Promise_resolve_26BridgeJSRuntimeTests_ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripTheme(_: BridgeJSRuntimeTests.Theme.bridgeJSLiftParameter(vBytes, vLength))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripDirection")
-@_cdecl("bjs_asyncRoundTripDirection")
-public func _bjs_asyncRoundTripDirection(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripDirection")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripDirection(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_9DirectionO, reject: Promise_reject) {
-        return await asyncRoundTripDirection(_: Direction.bridgeJSLiftParameter(v))
+    return _bjs_makePromise(resolve: Promise_resolve_30BridgeJSRuntimeTests_DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripDirection(_: BridgeJSRuntimeTests.Direction.bridgeJSLiftParameter(v))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripOptionalTheme")
-@_cdecl("bjs_asyncRoundTripOptionalTheme")
-public func _bjs_asyncRoundTripOptionalTheme(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalTheme")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalTheme(_ vIsSome: Int32, _ vBytes: Int32, _ vLength: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq5ThemeO, reject: Promise_reject) {
-        return await asyncRoundTripOptionalTheme(_: Optional<Theme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
+    return _bjs_makePromise(resolve: Promise_resolve_Sq26BridgeJSRuntimeTests_ThemeO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalTheme(_: Optional<BridgeJSRuntimeTests.Theme>.bridgeJSLiftParameter(vIsSome, vBytes, vLength))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripOptionalDirection")
-@_cdecl("bjs_asyncRoundTripOptionalDirection")
-public func _bjs_asyncRoundTripOptionalDirection(_ vIsSome: Int32, _ vValue: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalDirection")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalDirection(_ vIsSome: Int32, _ vValue: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq9DirectionO, reject: Promise_reject) {
-        return await asyncRoundTripOptionalDirection(_: Optional<Direction>.bridgeJSLiftParameter(vIsSome, vValue))
+    return _bjs_makePromise(resolve: Promise_resolve_Sq30BridgeJSRuntimeTests_DirectionO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalDirection(_: Optional<BridgeJSRuntimeTests.Direction>.bridgeJSLiftParameter(vIsSome, vValue))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripDirectionArray")
-@_cdecl("bjs_asyncRoundTripDirectionArray")
-public func _bjs_asyncRoundTripDirectionArray() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripDirectionArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripDirectionArray")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripDirectionArray() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = [Direction].bridgeJSStackPop()
-    return _bjs_makePromise(resolve: Promise_resolve_Sa9DirectionO, reject: Promise_reject) {
+    let _tmp_v = [BridgeJSRuntimeTests.Direction].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa30BridgeJSRuntimeTests_DirectionO, reject: Promise_reject) {
         return await asyncRoundTripDirectionArray(_: _tmp_v)
     }
     #else
@@ -9019,12 +9019,12 @@ public func _bjs_asyncRoundTripDirectionArray() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripDirectionDict")
-@_cdecl("bjs_asyncRoundTripDirectionDict")
-public func _bjs_asyncRoundTripDirectionDict() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripDirectionDict")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripDirectionDict")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripDirectionDict() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = [String: Direction].bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_SD9DirectionO, reject: Promise_reject) {
+    let _tmp_v = [String: BridgeJSRuntimeTests.Direction].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD30BridgeJSRuntimeTests_DirectionO, reject: Promise_reject) {
         return await asyncRoundTripDirectionDict(_: _tmp_v)
     }
     #else
@@ -9032,12 +9032,12 @@ public func _bjs_asyncRoundTripDirectionDict() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripThemeArray")
-@_cdecl("bjs_asyncRoundTripThemeArray")
-public func _bjs_asyncRoundTripThemeArray() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripThemeArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripThemeArray")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripThemeArray() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = [Theme].bridgeJSStackPop()
-    return _bjs_makePromise(resolve: Promise_resolve_Sa5ThemeO, reject: Promise_reject) {
+    let _tmp_v = [BridgeJSRuntimeTests.Theme].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa26BridgeJSRuntimeTests_ThemeO, reject: Promise_reject) {
         return await asyncRoundTripThemeArray(_: _tmp_v)
     }
     #else
@@ -9045,12 +9045,12 @@ public func _bjs_asyncRoundTripThemeArray() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripThemeDict")
-@_cdecl("bjs_asyncRoundTripThemeDict")
-public func _bjs_asyncRoundTripThemeDict() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripThemeDict")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripThemeDict")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripThemeDict() -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = [String: Theme].bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_SD5ThemeO, reject: Promise_reject) {
+    let _tmp_v = [String: BridgeJSRuntimeTests.Theme].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD26BridgeJSRuntimeTests_ThemeO, reject: Promise_reject) {
         return await asyncRoundTripThemeDict(_: _tmp_v)
     }
     #else
@@ -9058,36 +9058,36 @@ public func _bjs_asyncRoundTripThemeDict() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripFileSize")
-@_cdecl("bjs_asyncRoundTripFileSize")
-public func _bjs_asyncRoundTripFileSize(_ v: Int64) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripFileSize")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripFileSize")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripFileSize(_ v: Int64) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_8FileSizeO, reject: Promise_reject) {
-        return await asyncRoundTripFileSize(_: FileSize.bridgeJSLiftParameter(v))
+    return _bjs_makePromise(resolve: Promise_resolve_29BridgeJSRuntimeTests_FileSizeO, reject: Promise_reject) {
+        return await asyncRoundTripFileSize(_: BridgeJSRuntimeTests.FileSize.bridgeJSLiftParameter(v))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripOptionalFileSize")
-@_cdecl("bjs_asyncRoundTripOptionalFileSize")
-public func _bjs_asyncRoundTripOptionalFileSize(_ vIsSome: Int32, _ vValue: Int64) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalFileSize")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalFileSize")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalFileSize(_ vIsSome: Int32, _ vValue: Int64) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq8FileSizeO, reject: Promise_reject) {
-        return await asyncRoundTripOptionalFileSize(_: Optional<FileSize>.bridgeJSLiftParameter(vIsSome, vValue))
+    return _bjs_makePromise(resolve: Promise_resolve_Sq29BridgeJSRuntimeTests_FileSizeO, reject: Promise_reject) {
+        return await asyncRoundTripOptionalFileSize(_: Optional<BridgeJSRuntimeTests.FileSize>.bridgeJSLiftParameter(vIsSome, vValue))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripAssociatedValueEnum")
-@_cdecl("bjs_asyncRoundTripAssociatedValueEnum")
-public func _bjs_asyncRoundTripAssociatedValueEnum(_ v: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripAssociatedValueEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripAssociatedValueEnum")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripAssociatedValueEnum(_ v: Int32) -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = AsyncPayloadResult.bridgeJSLiftParameter(v)
-    return _bjs_makePromise(resolve: Promise_resolve_18AsyncPayloadResultO, reject: Promise_reject) {
+    let _tmp_v = BridgeJSRuntimeTests.AsyncPayloadResult.bridgeJSLiftParameter(v)
+    return _bjs_makePromise(resolve: Promise_resolve_39BridgeJSRuntimeTests_AsyncPayloadResultO, reject: Promise_reject) {
         return await asyncRoundTripAssociatedValueEnum(_: _tmp_v)
     }
     #else
@@ -9095,12 +9095,12 @@ public func _bjs_asyncRoundTripAssociatedValueEnum(_ v: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripOptionalAssociatedValueEnum")
-@_cdecl("bjs_asyncRoundTripOptionalAssociatedValueEnum")
-public func _bjs_asyncRoundTripOptionalAssociatedValueEnum(_ vIsSome: Int32, _ vCaseId: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalAssociatedValueEnum")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalAssociatedValueEnum")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalAssociatedValueEnum(_ vIsSome: Int32, _ vCaseId: Int32) -> Int32 {
     #if arch(wasm32)
-    let _tmp_v = Optional<AsyncPayloadResult>.bridgeJSLiftParameter(vIsSome, vCaseId)
-    return _bjs_makePromise(resolve: Promise_resolve_Sq18AsyncPayloadResultO, reject: Promise_reject) {
+    let _tmp_v = Optional<BridgeJSRuntimeTests.AsyncPayloadResult>.bridgeJSLiftParameter(vIsSome, vCaseId)
+    return _bjs_makePromise(resolve: Promise_resolve_Sq39BridgeJSRuntimeTests_AsyncPayloadResultO, reject: Promise_reject) {
         return await asyncRoundTripOptionalAssociatedValueEnum(_: _tmp_v)
     }
     #else
@@ -9108,20 +9108,20 @@ public func _bjs_asyncRoundTripOptionalAssociatedValueEnum(_ vIsSome: Int32, _ v
     #endif
 }
 
-@_expose(wasm, "bjs_setHttpStatus")
-@_cdecl("bjs_setHttpStatus")
-public func _bjs_setHttpStatus(_ status: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_setHttpStatus")
+@_cdecl("bjs_BridgeJSRuntimeTests_setHttpStatus")
+public func _bjs_BridgeJSRuntimeTests_setHttpStatus(_ status: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = setHttpStatus(_: HttpStatus.bridgeJSLiftParameter(status))
+    let ret = setHttpStatus(_: BridgeJSRuntimeTests.HttpStatus.bridgeJSLiftParameter(status))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getHttpStatus")
-@_cdecl("bjs_getHttpStatus")
-public func _bjs_getHttpStatus() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_getHttpStatus")
+@_cdecl("bjs_BridgeJSRuntimeTests_getHttpStatus")
+public func _bjs_BridgeJSRuntimeTests_getHttpStatus() -> Int32 {
     #if arch(wasm32)
     let ret = getHttpStatus()
     return ret.bridgeJSLowerReturn()
@@ -9130,20 +9130,20 @@ public func _bjs_getHttpStatus() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_setFileSize")
-@_cdecl("bjs_setFileSize")
-public func _bjs_setFileSize(_ size: Int64) -> Int64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_setFileSize")
+@_cdecl("bjs_BridgeJSRuntimeTests_setFileSize")
+public func _bjs_BridgeJSRuntimeTests_setFileSize(_ size: Int64) -> Int64 {
     #if arch(wasm32)
-    let ret = setFileSize(_: FileSize.bridgeJSLiftParameter(size))
+    let ret = setFileSize(_: BridgeJSRuntimeTests.FileSize.bridgeJSLiftParameter(size))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getFileSize")
-@_cdecl("bjs_getFileSize")
-public func _bjs_getFileSize() -> Int64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_getFileSize")
+@_cdecl("bjs_BridgeJSRuntimeTests_getFileSize")
+public func _bjs_BridgeJSRuntimeTests_getFileSize() -> Int64 {
     #if arch(wasm32)
     let ret = getFileSize()
     return ret.bridgeJSLowerReturn()
@@ -9152,20 +9152,20 @@ public func _bjs_getFileSize() -> Int64 {
     #endif
 }
 
-@_expose(wasm, "bjs_setSessionId")
-@_cdecl("bjs_setSessionId")
-public func _bjs_setSessionId(_ session: Int64) -> Int64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_setSessionId")
+@_cdecl("bjs_BridgeJSRuntimeTests_setSessionId")
+public func _bjs_BridgeJSRuntimeTests_setSessionId(_ session: Int64) -> Int64 {
     #if arch(wasm32)
-    let ret = setSessionId(_: SessionId.bridgeJSLiftParameter(session))
+    let ret = setSessionId(_: BridgeJSRuntimeTests.SessionId.bridgeJSLiftParameter(session))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getSessionId")
-@_cdecl("bjs_getSessionId")
-public func _bjs_getSessionId() -> Int64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_getSessionId")
+@_cdecl("bjs_BridgeJSRuntimeTests_getSessionId")
+public func _bjs_BridgeJSRuntimeTests_getSessionId() -> Int64 {
     #if arch(wasm32)
     let ret = getSessionId()
     return ret.bridgeJSLowerReturn()
@@ -9174,31 +9174,31 @@ public func _bjs_getSessionId() -> Int64 {
     #endif
 }
 
-@_expose(wasm, "bjs_processTheme")
-@_cdecl("bjs_processTheme")
-public func _bjs_processTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_processTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_processTheme")
+public func _bjs_BridgeJSRuntimeTests_processTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = processTheme(_: Theme.bridgeJSLiftParameter(themeBytes, themeLength))
+    let ret = processTheme(_: BridgeJSRuntimeTests.Theme.bridgeJSLiftParameter(themeBytes, themeLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_setTSDirection")
-@_cdecl("bjs_setTSDirection")
-public func _bjs_setTSDirection(_ direction: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_setTSDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_setTSDirection")
+public func _bjs_BridgeJSRuntimeTests_setTSDirection(_ direction: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = setTSDirection(_: TSDirection.bridgeJSLiftParameter(direction))
+    let ret = setTSDirection(_: BridgeJSRuntimeTests.TSDirection.bridgeJSLiftParameter(direction))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getTSDirection")
-@_cdecl("bjs_getTSDirection")
-public func _bjs_getTSDirection() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_getTSDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_getTSDirection")
+public func _bjs_BridgeJSRuntimeTests_getTSDirection() -> Int32 {
     #if arch(wasm32)
     let ret = getTSDirection()
     return ret.bridgeJSLowerReturn()
@@ -9207,20 +9207,20 @@ public func _bjs_getTSDirection() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_setTSTheme")
-@_cdecl("bjs_setTSTheme")
-public func _bjs_setTSTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_setTSTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_setTSTheme")
+public func _bjs_BridgeJSRuntimeTests_setTSTheme(_ themeBytes: Int32, _ themeLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = setTSTheme(_: TSTheme.bridgeJSLiftParameter(themeBytes, themeLength))
+    let ret = setTSTheme(_: BridgeJSRuntimeTests.TSTheme.bridgeJSLiftParameter(themeBytes, themeLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_getTSTheme")
-@_cdecl("bjs_getTSTheme")
-public func _bjs_getTSTheme() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_getTSTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_getTSTheme")
+public func _bjs_BridgeJSRuntimeTests_getTSTheme() -> Void {
     #if arch(wasm32)
     let ret = getTSTheme()
     return ret.bridgeJSLowerReturn()
@@ -9229,9 +9229,9 @@ public func _bjs_getTSTheme() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_createConverter")
-@_cdecl("bjs_createConverter")
-public func _bjs_createConverter() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_createConverter")
+@_cdecl("bjs_BridgeJSRuntimeTests_createConverter")
+public func _bjs_BridgeJSRuntimeTests_createConverter() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = createConverter()
     return ret.bridgeJSLowerReturn()
@@ -9240,31 +9240,31 @@ public func _bjs_createConverter() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_useConverter")
-@_cdecl("bjs_useConverter")
-public func _bjs_useConverter(_ converter: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_useConverter")
+@_cdecl("bjs_BridgeJSRuntimeTests_useConverter")
+public func _bjs_BridgeJSRuntimeTests_useConverter(_ converter: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = useConverter(converter: Utils.Converter.bridgeJSLiftParameter(converter), value: Int.bridgeJSLiftParameter(value))
+    let ret = useConverter(converter: BridgeJSRuntimeTests.Utils.Converter.bridgeJSLiftParameter(converter), value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripConverterArray")
-@_cdecl("bjs_roundTripConverterArray")
-public func _bjs_roundTripConverterArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripConverterArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripConverterArray")
+public func _bjs_BridgeJSRuntimeTests_roundTripConverterArray() -> Void {
     #if arch(wasm32)
-    let ret = roundTripConverterArray(_: [Utils.Converter].bridgeJSStackPop())
+    let ret = roundTripConverterArray(_: [BridgeJSRuntimeTests.Utils.Converter].bridgeJSStackPop())
     ret.bridgeJSStackPush()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_createHTTPServer")
-@_cdecl("bjs_createHTTPServer")
-public func _bjs_createHTTPServer() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_createHTTPServer")
+@_cdecl("bjs_BridgeJSRuntimeTests_createHTTPServer")
+public func _bjs_BridgeJSRuntimeTests_createHTTPServer() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = createHTTPServer()
     return ret.bridgeJSLowerReturn()
@@ -9273,9 +9273,9 @@ public func _bjs_createHTTPServer() -> UnsafeMutableRawPointer {
     #endif
 }
 
-@_expose(wasm, "bjs_createUUID")
-@_cdecl("bjs_createUUID")
-public func _bjs_createUUID(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_createUUID")
+@_cdecl("bjs_BridgeJSRuntimeTests_createUUID")
+public func _bjs_BridgeJSRuntimeTests_createUUID(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = createUUID(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
@@ -9284,86 +9284,86 @@ public func _bjs_createUUID(_ valueBytes: Int32, _ valueLength: Int32) -> Unsafe
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripUUID")
-@_cdecl("bjs_roundTripUUID")
-public func _bjs_roundTripUUID(_ uuid: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripUUID")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripUUID")
+public func _bjs_BridgeJSRuntimeTests_roundTripUUID(_ uuid: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = roundTripUUID(_: UUID.bridgeJSLiftParameter(uuid))
+    let ret = roundTripUUID(_: BridgeJSRuntimeTests.UUID.bridgeJSLiftParameter(uuid))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripNetworkingAPIMethod")
-@_cdecl("bjs_roundtripNetworkingAPIMethod")
-public func _bjs_roundtripNetworkingAPIMethod(_ method: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundtripNetworkingAPIMethod")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundtripNetworkingAPIMethod")
+public func _bjs_BridgeJSRuntimeTests_roundtripNetworkingAPIMethod(_ method: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripNetworkingAPIMethod(_: Networking.API.Method.bridgeJSLiftParameter(method))
+    let ret = roundtripNetworkingAPIMethod(_: BridgeJSRuntimeTests.Networking.API.Method.bridgeJSLiftParameter(method))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripConfigurationLogLevel")
-@_cdecl("bjs_roundtripConfigurationLogLevel")
-public func _bjs_roundtripConfigurationLogLevel(_ levelBytes: Int32, _ levelLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundtripConfigurationLogLevel")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundtripConfigurationLogLevel")
+public func _bjs_BridgeJSRuntimeTests_roundtripConfigurationLogLevel(_ levelBytes: Int32, _ levelLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundtripConfigurationLogLevel(_: Configuration.LogLevel.bridgeJSLiftParameter(levelBytes, levelLength))
+    let ret = roundtripConfigurationLogLevel(_: BridgeJSRuntimeTests.Configuration.LogLevel.bridgeJSLiftParameter(levelBytes, levelLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripConfigurationPort")
-@_cdecl("bjs_roundtripConfigurationPort")
-public func _bjs_roundtripConfigurationPort(_ port: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundtripConfigurationPort")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundtripConfigurationPort")
+public func _bjs_BridgeJSRuntimeTests_roundtripConfigurationPort(_ port: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripConfigurationPort(_: Configuration.Port.bridgeJSLiftParameter(port))
+    let ret = roundtripConfigurationPort(_: BridgeJSRuntimeTests.Configuration.Port.bridgeJSLiftParameter(port))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_processConfigurationLogLevel")
-@_cdecl("bjs_processConfigurationLogLevel")
-public func _bjs_processConfigurationLogLevel(_ levelBytes: Int32, _ levelLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_processConfigurationLogLevel")
+@_cdecl("bjs_BridgeJSRuntimeTests_processConfigurationLogLevel")
+public func _bjs_BridgeJSRuntimeTests_processConfigurationLogLevel(_ levelBytes: Int32, _ levelLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = processConfigurationLogLevel(_: Configuration.LogLevel.bridgeJSLiftParameter(levelBytes, levelLength))
+    let ret = processConfigurationLogLevel(_: BridgeJSRuntimeTests.Configuration.LogLevel.bridgeJSLiftParameter(levelBytes, levelLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripInternalSupportedMethod")
-@_cdecl("bjs_roundtripInternalSupportedMethod")
-public func _bjs_roundtripInternalSupportedMethod(_ method: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundtripInternalSupportedMethod")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundtripInternalSupportedMethod")
+public func _bjs_BridgeJSRuntimeTests_roundtripInternalSupportedMethod(_ method: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = roundtripInternalSupportedMethod(_: Internal.SupportedMethod.bridgeJSLiftParameter(method))
+    let ret = roundtripInternalSupportedMethod(_: BridgeJSRuntimeTests.Internal.SupportedMethod.bridgeJSLiftParameter(method))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripAPIResult")
-@_cdecl("bjs_roundtripAPIResult")
-public func _bjs_roundtripAPIResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundtripAPIResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundtripAPIResult")
+public func _bjs_BridgeJSRuntimeTests_roundtripAPIResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundtripAPIResult(result: APIResult.bridgeJSLiftParameter(result))
+    let ret = roundtripAPIResult(result: BridgeJSRuntimeTests.APIResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeAPIResultSuccess")
-@_cdecl("bjs_makeAPIResultSuccess")
-public func _bjs_makeAPIResultSuccess(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAPIResultSuccess")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAPIResultSuccess")
+public func _bjs_BridgeJSRuntimeTests_makeAPIResultSuccess(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeAPIResultSuccess(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
@@ -9372,9 +9372,9 @@ public func _bjs_makeAPIResultSuccess(_ valueBytes: Int32, _ valueLength: Int32)
     #endif
 }
 
-@_expose(wasm, "bjs_makeAPIResultFailure")
-@_cdecl("bjs_makeAPIResultFailure")
-public func _bjs_makeAPIResultFailure(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAPIResultFailure")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAPIResultFailure")
+public func _bjs_BridgeJSRuntimeTests_makeAPIResultFailure(_ value: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeAPIResultFailure(_: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
@@ -9383,9 +9383,9 @@ public func _bjs_makeAPIResultFailure(_ value: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAPIResultInfo")
-@_cdecl("bjs_makeAPIResultInfo")
-public func _bjs_makeAPIResultInfo() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAPIResultInfo")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAPIResultInfo")
+public func _bjs_BridgeJSRuntimeTests_makeAPIResultInfo() -> Void {
     #if arch(wasm32)
     let ret = makeAPIResultInfo()
     return ret.bridgeJSLowerReturn()
@@ -9394,9 +9394,9 @@ public func _bjs_makeAPIResultInfo() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAPIResultFlag")
-@_cdecl("bjs_makeAPIResultFlag")
-public func _bjs_makeAPIResultFlag(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAPIResultFlag")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAPIResultFlag")
+public func _bjs_BridgeJSRuntimeTests_makeAPIResultFlag(_ value: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeAPIResultFlag(_: Bool.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
@@ -9405,9 +9405,9 @@ public func _bjs_makeAPIResultFlag(_ value: Int32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAPIResultRate")
-@_cdecl("bjs_makeAPIResultRate")
-public func _bjs_makeAPIResultRate(_ value: Float32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAPIResultRate")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAPIResultRate")
+public func _bjs_BridgeJSRuntimeTests_makeAPIResultRate(_ value: Float32) -> Void {
     #if arch(wasm32)
     let ret = makeAPIResultRate(_: Float.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
@@ -9416,9 +9416,9 @@ public func _bjs_makeAPIResultRate(_ value: Float32) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_makeAPIResultPrecise")
-@_cdecl("bjs_makeAPIResultPrecise")
-public func _bjs_makeAPIResultPrecise(_ value: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAPIResultPrecise")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAPIResultPrecise")
+public func _bjs_BridgeJSRuntimeTests_makeAPIResultPrecise(_ value: Float64) -> Void {
     #if arch(wasm32)
     let ret = makeAPIResultPrecise(_: Double.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
@@ -9427,20 +9427,20 @@ public func _bjs_makeAPIResultPrecise(_ value: Float64) -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripComplexResult")
-@_cdecl("bjs_roundtripComplexResult")
-public func _bjs_roundtripComplexResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundtripComplexResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundtripComplexResult")
+public func _bjs_BridgeJSRuntimeTests_roundtripComplexResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundtripComplexResult(_: ComplexResult.bridgeJSLiftParameter(result))
+    let ret = roundtripComplexResult(_: BridgeJSRuntimeTests.ComplexResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_makeComplexResultSuccess")
-@_cdecl("bjs_makeComplexResultSuccess")
-public func _bjs_makeComplexResultSuccess(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeComplexResultSuccess")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeComplexResultSuccess")
+public func _bjs_BridgeJSRuntimeTests_makeComplexResultSuccess(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeComplexResultSuccess(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
@@ -9449,9 +9449,9 @@ public func _bjs_makeComplexResultSuccess(_ valueBytes: Int32, _ valueLength: In
     #endif
 }
 
-@_expose(wasm, "bjs_makeComplexResultError")
-@_cdecl("bjs_makeComplexResultError")
-public func _bjs_makeComplexResultError(_ messageBytes: Int32, _ messageLength: Int32, _ code: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeComplexResultError")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeComplexResultError")
+public func _bjs_BridgeJSRuntimeTests_makeComplexResultError(_ messageBytes: Int32, _ messageLength: Int32, _ code: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeComplexResultError(_: String.bridgeJSLiftParameter(messageBytes, messageLength), _: Int.bridgeJSLiftParameter(code))
     return ret.bridgeJSLowerReturn()
@@ -9460,9 +9460,9 @@ public func _bjs_makeComplexResultError(_ messageBytes: Int32, _ messageLength: 
     #endif
 }
 
-@_expose(wasm, "bjs_makeComplexResultLocation")
-@_cdecl("bjs_makeComplexResultLocation")
-public func _bjs_makeComplexResultLocation(_ lat: Float64, _ lng: Float64, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeComplexResultLocation")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeComplexResultLocation")
+public func _bjs_BridgeJSRuntimeTests_makeComplexResultLocation(_ lat: Float64, _ lng: Float64, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeComplexResultLocation(_: Double.bridgeJSLiftParameter(lat), _: Double.bridgeJSLiftParameter(lng), _: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
@@ -9471,9 +9471,9 @@ public func _bjs_makeComplexResultLocation(_ lat: Float64, _ lng: Float64, _ nam
     #endif
 }
 
-@_expose(wasm, "bjs_makeComplexResultStatus")
-@_cdecl("bjs_makeComplexResultStatus")
-public func _bjs_makeComplexResultStatus(_ active: Int32, _ code: Int32, _ messageBytes: Int32, _ messageLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeComplexResultStatus")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeComplexResultStatus")
+public func _bjs_BridgeJSRuntimeTests_makeComplexResultStatus(_ active: Int32, _ code: Int32, _ messageBytes: Int32, _ messageLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeComplexResultStatus(_: Bool.bridgeJSLiftParameter(active), _: Int.bridgeJSLiftParameter(code), _: String.bridgeJSLiftParameter(messageBytes, messageLength))
     return ret.bridgeJSLowerReturn()
@@ -9482,9 +9482,9 @@ public func _bjs_makeComplexResultStatus(_ active: Int32, _ code: Int32, _ messa
     #endif
 }
 
-@_expose(wasm, "bjs_makeComplexResultCoordinates")
-@_cdecl("bjs_makeComplexResultCoordinates")
-public func _bjs_makeComplexResultCoordinates(_ x: Float64, _ y: Float64, _ z: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeComplexResultCoordinates")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeComplexResultCoordinates")
+public func _bjs_BridgeJSRuntimeTests_makeComplexResultCoordinates(_ x: Float64, _ y: Float64, _ z: Float64) -> Void {
     #if arch(wasm32)
     let ret = makeComplexResultCoordinates(_: Double.bridgeJSLiftParameter(x), _: Double.bridgeJSLiftParameter(y), _: Double.bridgeJSLiftParameter(z))
     return ret.bridgeJSLowerReturn()
@@ -9493,9 +9493,9 @@ public func _bjs_makeComplexResultCoordinates(_ x: Float64, _ y: Float64, _ z: F
     #endif
 }
 
-@_expose(wasm, "bjs_makeComplexResultComprehensive")
-@_cdecl("bjs_makeComplexResultComprehensive")
-public func _bjs_makeComplexResultComprehensive(_ flag1: Int32, _ flag2: Int32, _ count1: Int32, _ count2: Int32, _ value1: Float64, _ value2: Float64, _ text1Bytes: Int32, _ text1Length: Int32, _ text2Bytes: Int32, _ text2Length: Int32, _ text3Bytes: Int32, _ text3Length: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeComplexResultComprehensive")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeComplexResultComprehensive")
+public func _bjs_BridgeJSRuntimeTests_makeComplexResultComprehensive(_ flag1: Int32, _ flag2: Int32, _ count1: Int32, _ count2: Int32, _ value1: Float64, _ value2: Float64, _ text1Bytes: Int32, _ text1Length: Int32, _ text2Bytes: Int32, _ text2Length: Int32, _ text3Bytes: Int32, _ text3Length: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeComplexResultComprehensive(_: Bool.bridgeJSLiftParameter(flag1), _: Bool.bridgeJSLiftParameter(flag2), _: Int.bridgeJSLiftParameter(count1), _: Int.bridgeJSLiftParameter(count2), _: Double.bridgeJSLiftParameter(value1), _: Double.bridgeJSLiftParameter(value2), _: String.bridgeJSLiftParameter(text1Bytes, text1Length), _: String.bridgeJSLiftParameter(text2Bytes, text2Length), _: String.bridgeJSLiftParameter(text3Bytes, text3Length))
     return ret.bridgeJSLowerReturn()
@@ -9504,9 +9504,9 @@ public func _bjs_makeComplexResultComprehensive(_ flag1: Int32, _ flag2: Int32, 
     #endif
 }
 
-@_expose(wasm, "bjs_makeComplexResultInfo")
-@_cdecl("bjs_makeComplexResultInfo")
-public func _bjs_makeComplexResultInfo() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeComplexResultInfo")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeComplexResultInfo")
+public func _bjs_BridgeJSRuntimeTests_makeComplexResultInfo() -> Void {
     #if arch(wasm32)
     let ret = makeComplexResultInfo()
     return ret.bridgeJSLowerReturn()
@@ -9515,9 +9515,9 @@ public func _bjs_makeComplexResultInfo() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_makeUtilitiesResultSuccess")
-@_cdecl("bjs_makeUtilitiesResultSuccess")
-public func _bjs_makeUtilitiesResultSuccess(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeUtilitiesResultSuccess")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeUtilitiesResultSuccess")
+public func _bjs_BridgeJSRuntimeTests_makeUtilitiesResultSuccess(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeUtilitiesResultSuccess(_: String.bridgeJSLiftParameter(messageBytes, messageLength))
     return ret.bridgeJSLowerReturn()
@@ -9526,9 +9526,9 @@ public func _bjs_makeUtilitiesResultSuccess(_ messageBytes: Int32, _ messageLeng
     #endif
 }
 
-@_expose(wasm, "bjs_makeUtilitiesResultFailure")
-@_cdecl("bjs_makeUtilitiesResultFailure")
-public func _bjs_makeUtilitiesResultFailure(_ errorBytes: Int32, _ errorLength: Int32, _ code: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeUtilitiesResultFailure")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeUtilitiesResultFailure")
+public func _bjs_BridgeJSRuntimeTests_makeUtilitiesResultFailure(_ errorBytes: Int32, _ errorLength: Int32, _ code: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeUtilitiesResultFailure(_: String.bridgeJSLiftParameter(errorBytes, errorLength), _: Int.bridgeJSLiftParameter(code))
     return ret.bridgeJSLowerReturn()
@@ -9537,9 +9537,9 @@ public func _bjs_makeUtilitiesResultFailure(_ errorBytes: Int32, _ errorLength: 
     #endif
 }
 
-@_expose(wasm, "bjs_makeUtilitiesResultStatus")
-@_cdecl("bjs_makeUtilitiesResultStatus")
-public func _bjs_makeUtilitiesResultStatus(_ active: Int32, _ code: Int32, _ messageBytes: Int32, _ messageLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeUtilitiesResultStatus")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeUtilitiesResultStatus")
+public func _bjs_BridgeJSRuntimeTests_makeUtilitiesResultStatus(_ active: Int32, _ code: Int32, _ messageBytes: Int32, _ messageLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeUtilitiesResultStatus(_: Bool.bridgeJSLiftParameter(active), _: Int.bridgeJSLiftParameter(code), _: String.bridgeJSLiftParameter(messageBytes, messageLength))
     return ret.bridgeJSLowerReturn()
@@ -9548,9 +9548,9 @@ public func _bjs_makeUtilitiesResultStatus(_ active: Int32, _ code: Int32, _ mes
     #endif
 }
 
-@_expose(wasm, "bjs_makeAPINetworkingResultSuccess")
-@_cdecl("bjs_makeAPINetworkingResultSuccess")
-public func _bjs_makeAPINetworkingResultSuccess(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAPINetworkingResultSuccess")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAPINetworkingResultSuccess")
+public func _bjs_BridgeJSRuntimeTests_makeAPINetworkingResultSuccess(_ messageBytes: Int32, _ messageLength: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeAPINetworkingResultSuccess(_: String.bridgeJSLiftParameter(messageBytes, messageLength))
     return ret.bridgeJSLowerReturn()
@@ -9559,9 +9559,9 @@ public func _bjs_makeAPINetworkingResultSuccess(_ messageBytes: Int32, _ message
     #endif
 }
 
-@_expose(wasm, "bjs_makeAPINetworkingResultFailure")
-@_cdecl("bjs_makeAPINetworkingResultFailure")
-public func _bjs_makeAPINetworkingResultFailure(_ errorBytes: Int32, _ errorLength: Int32, _ code: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAPINetworkingResultFailure")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAPINetworkingResultFailure")
+public func _bjs_BridgeJSRuntimeTests_makeAPINetworkingResultFailure(_ errorBytes: Int32, _ errorLength: Int32, _ code: Int32) -> Void {
     #if arch(wasm32)
     let ret = makeAPINetworkingResultFailure(_: String.bridgeJSLiftParameter(errorBytes, errorLength), _: Int.bridgeJSLiftParameter(code))
     return ret.bridgeJSLowerReturn()
@@ -9570,53 +9570,53 @@ public func _bjs_makeAPINetworkingResultFailure(_ errorBytes: Int32, _ errorLeng
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripUtilitiesResult")
-@_cdecl("bjs_roundtripUtilitiesResult")
-public func _bjs_roundtripUtilitiesResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundtripUtilitiesResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundtripUtilitiesResult")
+public func _bjs_BridgeJSRuntimeTests_roundtripUtilitiesResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundtripUtilitiesResult(_: Utilities.Result.bridgeJSLiftParameter(result))
+    let ret = roundtripUtilitiesResult(_: BridgeJSRuntimeTests.Utilities.Result.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundtripAPINetworkingResult")
-@_cdecl("bjs_roundtripAPINetworkingResult")
-public func _bjs_roundtripAPINetworkingResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundtripAPINetworkingResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundtripAPINetworkingResult")
+public func _bjs_BridgeJSRuntimeTests_roundtripAPINetworkingResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundtripAPINetworkingResult(_: API.NetworkingResult.bridgeJSLiftParameter(result))
+    let ret = roundtripAPINetworkingResult(_: BridgeJSRuntimeTests.API.NetworkingResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripAllTypesResult")
-@_cdecl("bjs_roundTripAllTypesResult")
-public func _bjs_roundTripAllTypesResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripAllTypesResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripAllTypesResult")
+public func _bjs_BridgeJSRuntimeTests_roundTripAllTypesResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripAllTypesResult(_: AllTypesResult.bridgeJSLiftParameter(result))
+    let ret = roundTripAllTypesResult(_: BridgeJSRuntimeTests.AllTypesResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripTypedPayloadResult")
-@_cdecl("bjs_roundTripTypedPayloadResult")
-public func _bjs_roundTripTypedPayloadResult(_ result: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripTypedPayloadResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripTypedPayloadResult")
+public func _bjs_BridgeJSRuntimeTests_roundTripTypedPayloadResult(_ result: Int32) -> Void {
     #if arch(wasm32)
-    let ret = roundTripTypedPayloadResult(_: TypedPayloadResult.bridgeJSLiftParameter(result))
+    let ret = roundTripTypedPayloadResult(_: BridgeJSRuntimeTests.TypedPayloadResult.bridgeJSLiftParameter(result))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_createPropertyHolder")
-@_cdecl("bjs_createPropertyHolder")
-public func _bjs_createPropertyHolder(_ intValue: Int32, _ floatValue: Float32, _ doubleValue: Float64, _ boolValue: Int32, _ stringValueBytes: Int32, _ stringValueLength: Int32, _ jsObject: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_createPropertyHolder")
+@_cdecl("bjs_BridgeJSRuntimeTests_createPropertyHolder")
+public func _bjs_BridgeJSRuntimeTests_createPropertyHolder(_ intValue: Int32, _ floatValue: Float32, _ doubleValue: Float64, _ boolValue: Int32, _ stringValueBytes: Int32, _ stringValueLength: Int32, _ jsObject: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
     let ret = createPropertyHolder(intValue: Int.bridgeJSLiftParameter(intValue), floatValue: Float.bridgeJSLiftParameter(floatValue), doubleValue: Double.bridgeJSLiftParameter(doubleValue), boolValue: Bool.bridgeJSLiftParameter(boolValue), stringValue: String.bridgeJSLiftParameter(stringValueBytes, stringValueLength), jsObject: JSObject.bridgeJSLiftParameter(jsObject))
     return ret.bridgeJSLowerReturn()
@@ -9625,20 +9625,20 @@ public func _bjs_createPropertyHolder(_ intValue: Int32, _ floatValue: Float32, 
     #endif
 }
 
-@_expose(wasm, "bjs_testPropertyHolder")
-@_cdecl("bjs_testPropertyHolder")
-public func _bjs_testPropertyHolder(_ holder: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_testPropertyHolder")
+@_cdecl("bjs_BridgeJSRuntimeTests_testPropertyHolder")
+public func _bjs_BridgeJSRuntimeTests_testPropertyHolder(_ holder: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = testPropertyHolder(holder: PropertyHolder.bridgeJSLiftParameter(holder))
+    let ret = testPropertyHolder(holder: BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(holder))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_resetObserverCounts")
-@_cdecl("bjs_resetObserverCounts")
-public func _bjs_resetObserverCounts() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_resetObserverCounts")
+@_cdecl("bjs_BridgeJSRuntimeTests_resetObserverCounts")
+public func _bjs_BridgeJSRuntimeTests_resetObserverCounts() -> Void {
     #if arch(wasm32)
     resetObserverCounts()
     #else
@@ -9646,9 +9646,9 @@ public func _bjs_resetObserverCounts() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_getObserverStats")
-@_cdecl("bjs_getObserverStats")
-public func _bjs_getObserverStats() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_getObserverStats")
+@_cdecl("bjs_BridgeJSRuntimeTests_getObserverStats")
+public func _bjs_BridgeJSRuntimeTests_getObserverStats() -> Void {
     #if arch(wasm32)
     let ret = getObserverStats()
     return ret.bridgeJSLowerReturn()
@@ -9657,9 +9657,9 @@ public func _bjs_getObserverStats() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_formatName")
-@_cdecl("bjs_formatName")
-public func _bjs_formatName(_ nameBytes: Int32, _ nameLength: Int32, _ transform: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_formatName")
+@_cdecl("bjs_BridgeJSRuntimeTests_formatName")
+public func _bjs_BridgeJSRuntimeTests_formatName(_ nameBytes: Int32, _ nameLength: Int32, _ transform: Int32) -> Void {
     #if arch(wasm32)
     let ret = formatName(_: String.bridgeJSLiftParameter(nameBytes, nameLength), transform: _BJS_Closure_20BridgeJSRuntimeTestsSS_SS.bridgeJSLift(transform))
     return ret.bridgeJSLowerReturn()
@@ -9668,9 +9668,9 @@ public func _bjs_formatName(_ nameBytes: Int32, _ nameLength: Int32, _ transform
     #endif
 }
 
-@_expose(wasm, "bjs_makeFormatter")
-@_cdecl("bjs_makeFormatter")
-public func _bjs_makeFormatter(_ prefixBytes: Int32, _ prefixLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeFormatter")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeFormatter")
+public func _bjs_BridgeJSRuntimeTests_makeFormatter(_ prefixBytes: Int32, _ prefixLength: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = makeFormatter(prefix: String.bridgeJSLiftParameter(prefixBytes, prefixLength))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -9679,9 +9679,9 @@ public func _bjs_makeFormatter(_ prefixBytes: Int32, _ prefixLength: Int32) -> I
     #endif
 }
 
-@_expose(wasm, "bjs_makeAdder")
-@_cdecl("bjs_makeAdder")
-public func _bjs_makeAdder(_ base: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_makeAdder")
+@_cdecl("bjs_BridgeJSRuntimeTests_makeAdder")
+public func _bjs_BridgeJSRuntimeTests_makeAdder(_ base: Int32) -> Int32 {
     #if arch(wasm32)
     let ret = makeAdder(base: Int.bridgeJSLiftParameter(base))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
@@ -9690,78 +9690,78 @@ public func _bjs_makeAdder(_ base: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripPointerFields")
-@_cdecl("bjs_roundTripPointerFields")
-public func _bjs_roundTripPointerFields() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripPointerFields")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripPointerFields")
+public func _bjs_BridgeJSRuntimeTests_roundTripPointerFields() -> Void {
     #if arch(wasm32)
-    let ret = roundTripPointerFields(_: PointerFields.bridgeJSLiftParameter())
+    let ret = roundTripPointerFields(_: BridgeJSRuntimeTests.PointerFields.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_testStructDefault")
-@_cdecl("bjs_testStructDefault")
-public func _bjs_testStructDefault() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_testStructDefault")
+@_cdecl("bjs_BridgeJSRuntimeTests_testStructDefault")
+public func _bjs_BridgeJSRuntimeTests_testStructDefault() -> Void {
     #if arch(wasm32)
-    let ret = testStructDefault(point: DataPoint.bridgeJSLiftParameter())
+    let ret = testStructDefault(point: BridgeJSRuntimeTests.DataPoint.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_cartToJSObject")
-@_cdecl("bjs_cartToJSObject")
-public func _bjs_cartToJSObject() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_cartToJSObject")
+@_cdecl("bjs_BridgeJSRuntimeTests_cartToJSObject")
+public func _bjs_BridgeJSRuntimeTests_cartToJSObject() -> Int32 {
     #if arch(wasm32)
-    let ret = cartToJSObject(_: CopyableCart.bridgeJSLiftParameter())
+    let ret = cartToJSObject(_: BridgeJSRuntimeTests.CopyableCart.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_nestedCartToJSObject")
-@_cdecl("bjs_nestedCartToJSObject")
-public func _bjs_nestedCartToJSObject() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_nestedCartToJSObject")
+@_cdecl("bjs_BridgeJSRuntimeTests_nestedCartToJSObject")
+public func _bjs_BridgeJSRuntimeTests_nestedCartToJSObject() -> Int32 {
     #if arch(wasm32)
-    let ret = nestedCartToJSObject(_: CopyableNestedCart.bridgeJSLiftParameter())
+    let ret = nestedCartToJSObject(_: BridgeJSRuntimeTests.CopyableNestedCart.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripDataPoint")
-@_cdecl("bjs_roundTripDataPoint")
-public func _bjs_roundTripDataPoint() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripDataPoint")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripDataPoint")
+public func _bjs_BridgeJSRuntimeTests_roundTripDataPoint() -> Void {
     #if arch(wasm32)
-    let ret = roundTripDataPoint(_: DataPoint.bridgeJSLiftParameter())
+    let ret = roundTripDataPoint(_: BridgeJSRuntimeTests.DataPoint.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripPublicPoint")
-@_cdecl("bjs_roundTripPublicPoint")
-public func _bjs_roundTripPublicPoint() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripPublicPoint")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripPublicPoint")
+public func _bjs_BridgeJSRuntimeTests_roundTripPublicPoint() -> Void {
     #if arch(wasm32)
-    let ret = roundTripPublicPoint(_: PublicPoint.bridgeJSLiftParameter())
+    let ret = roundTripPublicPoint(_: BridgeJSRuntimeTests.PublicPoint.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripPublicPoint")
-@_cdecl("bjs_asyncRoundTripPublicPoint")
-public func _bjs_asyncRoundTripPublicPoint() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPoint")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPoint")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPoint() -> Int32 {
     #if arch(wasm32)
-    let _tmp_point = PublicPoint.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
+    let _tmp_point = BridgeJSRuntimeTests.PublicPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_32BridgeJSRuntimeTests_PublicPointV, reject: Promise_reject) {
         return await asyncRoundTripPublicPoint(_: _tmp_point)
     }
     #else
@@ -9769,12 +9769,12 @@ public func _bjs_asyncRoundTripPublicPoint() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripPublicPointThrows")
-@_cdecl("bjs_asyncRoundTripPublicPointThrows")
-public func _bjs_asyncRoundTripPublicPointThrows() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointThrows")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointThrows")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointThrows() -> Int32 {
     #if arch(wasm32)
-    let _tmp_point = PublicPoint.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) { () async throws(JSException) -> PublicPoint in
+    let _tmp_point = BridgeJSRuntimeTests.PublicPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_32BridgeJSRuntimeTests_PublicPointV, reject: Promise_reject) { () async throws(JSException) -> BridgeJSRuntimeTests.PublicPoint in
         return try await asyncRoundTripPublicPointThrows(_: _tmp_point)
     }
     #else
@@ -9782,11 +9782,11 @@ public func _bjs_asyncRoundTripPublicPointThrows() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncStructOrThrow")
-@_cdecl("bjs_asyncStructOrThrow")
-public func _bjs_asyncStructOrThrow(_ shouldThrow: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncStructOrThrow")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncStructOrThrow")
+public func _bjs_BridgeJSRuntimeTests_asyncStructOrThrow(_ shouldThrow: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) { () async throws(JSException) -> PublicPoint in
+    return _bjs_makePromise(resolve: Promise_resolve_32BridgeJSRuntimeTests_PublicPointV, reject: Promise_reject) { () async throws(JSException) -> BridgeJSRuntimeTests.PublicPoint in
         return try await asyncStructOrThrow(_: Bool.bridgeJSLiftParameter(shouldThrow))
     }
     #else
@@ -9794,13 +9794,13 @@ public func _bjs_asyncStructOrThrow(_ shouldThrow: Int32) -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncCombinePublicPoints")
-@_cdecl("bjs_asyncCombinePublicPoints")
-public func _bjs_asyncCombinePublicPoints() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncCombinePublicPoints")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncCombinePublicPoints")
+public func _bjs_BridgeJSRuntimeTests_asyncCombinePublicPoints() -> Int32 {
     #if arch(wasm32)
-    let _tmp_b = PublicPoint.bridgeJSLiftParameter()
-    let _tmp_a = PublicPoint.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
+    let _tmp_b = BridgeJSRuntimeTests.PublicPoint.bridgeJSLiftParameter()
+    let _tmp_a = BridgeJSRuntimeTests.PublicPoint.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_32BridgeJSRuntimeTests_PublicPointV, reject: Promise_reject) {
         return await asyncCombinePublicPoints(_: _tmp_a, _: _tmp_b)
     }
     #else
@@ -9808,12 +9808,12 @@ public func _bjs_asyncCombinePublicPoints() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripContact")
-@_cdecl("bjs_asyncRoundTripContact")
-public func _bjs_asyncRoundTripContact() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripContact")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripContact")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripContact() -> Int32 {
     #if arch(wasm32)
-    let _tmp_contact = Contact.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_7ContactV, reject: Promise_reject) {
+    let _tmp_contact = BridgeJSRuntimeTests.Contact.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_28BridgeJSRuntimeTests_ContactV, reject: Promise_reject) {
         return await asyncRoundTripContact(_: _tmp_contact)
     }
     #else
@@ -9821,12 +9821,12 @@ public func _bjs_asyncRoundTripContact() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripPublicPointArray")
-@_cdecl("bjs_asyncRoundTripPublicPointArray")
-public func _bjs_asyncRoundTripPublicPointArray() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointArray")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointArray() -> Int32 {
     #if arch(wasm32)
-    let _tmp_points = [PublicPoint].bridgeJSStackPop()
-    return _bjs_makePromise(resolve: Promise_resolve_Sa11PublicPointV, reject: Promise_reject) {
+    let _tmp_points = [BridgeJSRuntimeTests.PublicPoint].bridgeJSStackPop()
+    return _bjs_makePromise(resolve: Promise_resolve_Sa32BridgeJSRuntimeTests_PublicPointV, reject: Promise_reject) {
         return await asyncRoundTripPublicPointArray(_: _tmp_points)
     }
     #else
@@ -9834,12 +9834,12 @@ public func _bjs_asyncRoundTripPublicPointArray() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripOptionalPublicPoint")
-@_cdecl("bjs_asyncRoundTripOptionalPublicPoint")
-public func _bjs_asyncRoundTripOptionalPublicPoint() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalPublicPoint")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalPublicPoint")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalPublicPoint() -> Int32 {
     #if arch(wasm32)
-    let _tmp_point = Optional<PublicPoint>.bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_Sq11PublicPointV, reject: Promise_reject) {
+    let _tmp_point = Optional<BridgeJSRuntimeTests.PublicPoint>.bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_Sq32BridgeJSRuntimeTests_PublicPointV, reject: Promise_reject) {
         return await asyncRoundTripOptionalPublicPoint(_: _tmp_point)
     }
     #else
@@ -9847,12 +9847,12 @@ public func _bjs_asyncRoundTripOptionalPublicPoint() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_asyncRoundTripPublicPointDict")
-@_cdecl("bjs_asyncRoundTripPublicPointDict")
-public func _bjs_asyncRoundTripPublicPointDict() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointDict")
+@_cdecl("bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointDict")
+public func _bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointDict() -> Int32 {
     #if arch(wasm32)
-    let _tmp_points = [String: PublicPoint].bridgeJSLiftParameter()
-    return _bjs_makePromise(resolve: Promise_resolve_SD11PublicPointV, reject: Promise_reject) {
+    let _tmp_points = [String: BridgeJSRuntimeTests.PublicPoint].bridgeJSLiftParameter()
+    return _bjs_makePromise(resolve: Promise_resolve_SD32BridgeJSRuntimeTests_PublicPointV, reject: Promise_reject) {
         return await asyncRoundTripPublicPointDict(_: _tmp_points)
     }
     #else
@@ -9860,78 +9860,78 @@ public func _bjs_asyncRoundTripPublicPointDict() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripContact")
-@_cdecl("bjs_roundTripContact")
-public func _bjs_roundTripContact() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripContact")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripContact")
+public func _bjs_BridgeJSRuntimeTests_roundTripContact() -> Void {
     #if arch(wasm32)
-    let ret = roundTripContact(_: Contact.bridgeJSLiftParameter())
+    let ret = roundTripContact(_: BridgeJSRuntimeTests.Contact.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripConfig")
-@_cdecl("bjs_roundTripConfig")
-public func _bjs_roundTripConfig() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripConfig")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripConfig")
+public func _bjs_BridgeJSRuntimeTests_roundTripConfig() -> Void {
     #if arch(wasm32)
-    let ret = roundTripConfig(_: Config.bridgeJSLiftParameter())
+    let ret = roundTripConfig(_: BridgeJSRuntimeTests.Config.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripSessionData")
-@_cdecl("bjs_roundTripSessionData")
-public func _bjs_roundTripSessionData() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripSessionData")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripSessionData")
+public func _bjs_BridgeJSRuntimeTests_roundTripSessionData() -> Void {
     #if arch(wasm32)
-    let ret = roundTripSessionData(_: SessionData.bridgeJSLiftParameter())
+    let ret = roundTripSessionData(_: BridgeJSRuntimeTests.SessionData.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripValidationReport")
-@_cdecl("bjs_roundTripValidationReport")
-public func _bjs_roundTripValidationReport() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripValidationReport")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripValidationReport")
+public func _bjs_BridgeJSRuntimeTests_roundTripValidationReport() -> Void {
     #if arch(wasm32)
-    let ret = roundTripValidationReport(_: ValidationReport.bridgeJSLiftParameter())
+    let ret = roundTripValidationReport(_: BridgeJSRuntimeTests.ValidationReport.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripAdvancedConfig")
-@_cdecl("bjs_roundTripAdvancedConfig")
-public func _bjs_roundTripAdvancedConfig() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripAdvancedConfig")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripAdvancedConfig")
+public func _bjs_BridgeJSRuntimeTests_roundTripAdvancedConfig() -> Void {
     #if arch(wasm32)
-    let ret = roundTripAdvancedConfig(_: AdvancedConfig.bridgeJSLiftParameter())
+    let ret = roundTripAdvancedConfig(_: BridgeJSRuntimeTests.AdvancedConfig.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripMeasurementConfig")
-@_cdecl("bjs_roundTripMeasurementConfig")
-public func _bjs_roundTripMeasurementConfig() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripMeasurementConfig")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripMeasurementConfig")
+public func _bjs_BridgeJSRuntimeTests_roundTripMeasurementConfig() -> Void {
     #if arch(wasm32)
-    let ret = roundTripMeasurementConfig(_: MeasurementConfig.bridgeJSLiftParameter())
+    let ret = roundTripMeasurementConfig(_: BridgeJSRuntimeTests.MeasurementConfig.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_updateValidationReport")
-@_cdecl("bjs_updateValidationReport")
-public func _bjs_updateValidationReport(_ newResultIsSome: Int32, _ newResultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_updateValidationReport")
+@_cdecl("bjs_BridgeJSRuntimeTests_updateValidationReport")
+public func _bjs_BridgeJSRuntimeTests_updateValidationReport(_ newResultIsSome: Int32, _ newResultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    let _tmp_report = ValidationReport.bridgeJSLiftParameter()
-    let _tmp_newResult = Optional<APIResult>.bridgeJSLiftParameter(newResultIsSome, newResultCaseId)
+    let _tmp_report = BridgeJSRuntimeTests.ValidationReport.bridgeJSLiftParameter()
+    let _tmp_newResult = Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftParameter(newResultIsSome, newResultCaseId)
     let ret = updateValidationReport(_: _tmp_newResult, _: _tmp_report)
     return ret.bridgeJSLowerReturn()
     #else
@@ -9939,56 +9939,56 @@ public func _bjs_updateValidationReport(_ newResultIsSome: Int32, _ newResultCas
     #endif
 }
 
-@_expose(wasm, "bjs_testContainerWithStruct")
-@_cdecl("bjs_testContainerWithStruct")
-public func _bjs_testContainerWithStruct() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_testContainerWithStruct")
+@_cdecl("bjs_BridgeJSRuntimeTests_testContainerWithStruct")
+public func _bjs_BridgeJSRuntimeTests_testContainerWithStruct() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = testContainerWithStruct(_: DataPoint.bridgeJSLiftParameter())
+    let ret = testContainerWithStruct(_: BridgeJSRuntimeTests.DataPoint.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripJSObjectContainer")
-@_cdecl("bjs_roundTripJSObjectContainer")
-public func _bjs_roundTripJSObjectContainer() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripJSObjectContainer")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripJSObjectContainer")
+public func _bjs_BridgeJSRuntimeTests_roundTripJSObjectContainer() -> Void {
     #if arch(wasm32)
-    let ret = roundTripJSObjectContainer(_: JSObjectContainer.bridgeJSLiftParameter())
+    let ret = roundTripJSObjectContainer(_: BridgeJSRuntimeTests.JSObjectContainer.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripFooContainer")
-@_cdecl("bjs_roundTripFooContainer")
-public func _bjs_roundTripFooContainer() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripFooContainer")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripFooContainer")
+public func _bjs_BridgeJSRuntimeTests_roundTripFooContainer() -> Void {
     #if arch(wasm32)
-    let ret = roundTripFooContainer(_: FooContainer.bridgeJSLiftParameter())
+    let ret = roundTripFooContainer(_: BridgeJSRuntimeTests.FooContainer.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_roundTripArrayMembers")
-@_cdecl("bjs_roundTripArrayMembers")
-public func _bjs_roundTripArrayMembers() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_roundTripArrayMembers")
+@_cdecl("bjs_BridgeJSRuntimeTests_roundTripArrayMembers")
+public func _bjs_BridgeJSRuntimeTests_roundTripArrayMembers() -> Void {
     #if arch(wasm32)
-    let ret = roundTripArrayMembers(_: ArrayMembers.bridgeJSLiftParameter())
+    let ret = roundTripArrayMembers(_: BridgeJSRuntimeTests.ArrayMembers.bridgeJSLiftParameter())
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_arrayMembersSum")
-@_cdecl("bjs_arrayMembersSum")
-public func _bjs_arrayMembersSum() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_arrayMembersSum")
+@_cdecl("bjs_BridgeJSRuntimeTests_arrayMembersSum")
+public func _bjs_BridgeJSRuntimeTests_arrayMembersSum() -> Int32 {
     #if arch(wasm32)
     let _tmp_values = [Int].bridgeJSStackPop()
-    let _tmp_value = ArrayMembers.bridgeJSLiftParameter()
+    let _tmp_value = BridgeJSRuntimeTests.ArrayMembers.bridgeJSLiftParameter()
     let ret = arrayMembersSum(_: _tmp_value, _: _tmp_values)
     return ret.bridgeJSLowerReturn()
     #else
@@ -9996,12 +9996,12 @@ public func _bjs_arrayMembersSum() -> Int32 {
     #endif
 }
 
-@_expose(wasm, "bjs_arrayMembersFirst")
-@_cdecl("bjs_arrayMembersFirst")
-public func _bjs_arrayMembersFirst() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_arrayMembersFirst")
+@_cdecl("bjs_BridgeJSRuntimeTests_arrayMembersFirst")
+public func _bjs_BridgeJSRuntimeTests_arrayMembersFirst() -> Void {
     #if arch(wasm32)
     let _tmp_values = [String].bridgeJSStackPop()
-    let _tmp_value = ArrayMembers.bridgeJSLiftParameter()
+    let _tmp_value = BridgeJSRuntimeTests.ArrayMembers.bridgeJSLiftParameter()
     let ret = arrayMembersFirst(_: _tmp_value, _: _tmp_values)
     return ret.bridgeJSLowerReturn()
     #else
@@ -10009,2121 +10009,2121 @@ public func _bjs_arrayMembersFirst() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_init")
-@_cdecl("bjs_PolygonReference_init")
-public func _bjs_PolygonReference_init(_ labelBytes: Int32, _ labelLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PolygonReference_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_PolygonReference_init")
+public func _bjs_BridgeJSRuntimeTests_PolygonReference_init(_ labelBytes: Int32, _ labelLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference(verticesData: [Double].bridgeJSStackPop(), label: String.bridgeJSLiftParameter(labelBytes, labelLength))
+    let ret = BridgeJSRuntimeTests.PolygonReference(verticesData: [Double].bridgeJSStackPop(), label: String.bridgeJSLiftParameter(labelBytes, labelLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_vertexCount")
-@_cdecl("bjs_PolygonReference_vertexCount")
-public func _bjs_PolygonReference_vertexCount(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PolygonReference_vertexCount")
+@_cdecl("bjs_BridgeJSRuntimeTests_PolygonReference_vertexCount")
+public func _bjs_BridgeJSRuntimeTests_PolygonReference_vertexCount(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PolygonReference.bridgeJSLiftParameter(_self).vertexCount()
+    let ret = BridgeJSRuntimeTests.PolygonReference.bridgeJSLiftParameter(_self).vertexCount()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_summary")
-@_cdecl("bjs_PolygonReference_summary")
-public func _bjs_PolygonReference_summary(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PolygonReference_summary")
+@_cdecl("bjs_BridgeJSRuntimeTests_PolygonReference_summary")
+public func _bjs_BridgeJSRuntimeTests_PolygonReference_summary(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PolygonReference.bridgeJSLiftParameter(_self).summary()
+    let ret = BridgeJSRuntimeTests.PolygonReference.bridgeJSLiftParameter(_self).summary()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_snapshot")
-@_cdecl("bjs_PolygonReference_snapshot")
-public func _bjs_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PolygonReference_snapshot")
+@_cdecl("bjs_BridgeJSRuntimeTests_PolygonReference_snapshot")
+public func _bjs_BridgeJSRuntimeTests_PolygonReference_snapshot(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference.bridgeJSLiftParameter(_self).snapshot()
+    let ret = BridgeJSRuntimeTests.PolygonReference.bridgeJSLiftParameter(_self).snapshot()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_merge")
-@_cdecl("bjs_PolygonReference_merge")
-public func _bjs_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ other: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PolygonReference_merge")
+@_cdecl("bjs_BridgeJSRuntimeTests_PolygonReference_merge")
+public func _bjs_BridgeJSRuntimeTests_PolygonReference_merge(_ _self: UnsafeMutableRawPointer, _ other: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference.bridgeJSLiftParameter(_self).merge(_: Polygon.bridgeJSLiftParameter(other))
+    let ret = BridgeJSRuntimeTests.PolygonReference.bridgeJSLiftParameter(_self).merge(_: BridgeJSRuntimeTests.Polygon.bridgeJSLiftParameter(other))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_static_origin")
-@_cdecl("bjs_PolygonReference_static_origin")
-public func _bjs_PolygonReference_static_origin(_ labelBytes: Int32, _ labelLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PolygonReference_static_origin")
+@_cdecl("bjs_BridgeJSRuntimeTests_PolygonReference_static_origin")
+public func _bjs_BridgeJSRuntimeTests_PolygonReference_static_origin(_ labelBytes: Int32, _ labelLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PolygonReference.origin(label: String.bridgeJSLiftParameter(labelBytes, labelLength))
+    let ret = BridgeJSRuntimeTests.PolygonReference.origin(label: String.bridgeJSLiftParameter(labelBytes, labelLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PolygonReference_deinit")
-@_cdecl("bjs_PolygonReference_deinit")
-public func _bjs_PolygonReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PolygonReference_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_PolygonReference_deinit")
+public func _bjs_BridgeJSRuntimeTests_PolygonReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PolygonReference>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.PolygonReference>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PolygonReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.PolygonReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_PolygonReference_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_PolygonReference_wrap")
-fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_PolygonReference_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_PolygonReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PolygonReference_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_PolygonReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_PolygonReference_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_TagReference_describe")
-@_cdecl("bjs_TagReference_describe")
-public func _bjs_TagReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TagReference_describe")
+@_cdecl("bjs_BridgeJSRuntimeTests_TagReference_describe")
+public func _bjs_BridgeJSRuntimeTests_TagReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = TagReference.bridgeJSLiftParameter(_self).describe()
+    let ret = BridgeJSRuntimeTests.TagReference.bridgeJSLiftParameter(_self).describe()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TagReference_deinit")
-@_cdecl("bjs_TagReference_deinit")
-public func _bjs_TagReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TagReference_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_TagReference_deinit")
+public func _bjs_BridgeJSRuntimeTests_TagReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<TagReference>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.TagReference>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension TagReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.TagReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_TagReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_TagReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_TagReference_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_TagReference_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_TagReference_wrap")
-fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_TagReference_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_TagReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_TagReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_TagReference_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_TagReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_TagReference_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_TagHolderReference_init")
-@_cdecl("bjs_TagHolderReference_init")
-public func _bjs_TagHolderReference_init(_ tag: UnsafeMutableRawPointer, _ version: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TagHolderReference_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_TagHolderReference_init")
+public func _bjs_BridgeJSRuntimeTests_TagHolderReference_init(_ tag: UnsafeMutableRawPointer, _ version: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = TagHolderReference(tag: Tag.bridgeJSLiftParameter(tag), version: Int.bridgeJSLiftParameter(version))
+    let ret = BridgeJSRuntimeTests.TagHolderReference(tag: BridgeJSRuntimeTests.Tag.bridgeJSLiftParameter(tag), version: Int.bridgeJSLiftParameter(version))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TagHolderReference_describe")
-@_cdecl("bjs_TagHolderReference_describe")
-public func _bjs_TagHolderReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TagHolderReference_describe")
+@_cdecl("bjs_BridgeJSRuntimeTests_TagHolderReference_describe")
+public func _bjs_BridgeJSRuntimeTests_TagHolderReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = TagHolderReference.bridgeJSLiftParameter(_self).describe()
+    let ret = BridgeJSRuntimeTests.TagHolderReference.bridgeJSLiftParameter(_self).describe()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TagHolderReference_tag_get")
-@_cdecl("bjs_TagHolderReference_tag_get")
-public func _bjs_TagHolderReference_tag_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TagHolderReference_tag_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_TagHolderReference_tag_get")
+public func _bjs_BridgeJSRuntimeTests_TagHolderReference_tag_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = TagHolderReference.bridgeJSLiftParameter(_self).tag
+    let ret = BridgeJSRuntimeTests.TagHolderReference.bridgeJSLiftParameter(_self).tag
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TagHolderReference_tag_set")
-@_cdecl("bjs_TagHolderReference_tag_set")
-public func _bjs_TagHolderReference_tag_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TagHolderReference_tag_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_TagHolderReference_tag_set")
+public func _bjs_BridgeJSRuntimeTests_TagHolderReference_tag_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    TagHolderReference.bridgeJSLiftParameter(_self).tag = Tag.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.TagHolderReference.bridgeJSLiftParameter(_self).tag = BridgeJSRuntimeTests.Tag.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TagHolderReference_version_get")
-@_cdecl("bjs_TagHolderReference_version_get")
-public func _bjs_TagHolderReference_version_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TagHolderReference_version_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_TagHolderReference_version_get")
+public func _bjs_BridgeJSRuntimeTests_TagHolderReference_version_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TagHolderReference.bridgeJSLiftParameter(_self).version
+    let ret = BridgeJSRuntimeTests.TagHolderReference.bridgeJSLiftParameter(_self).version
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TagHolderReference_version_set")
-@_cdecl("bjs_TagHolderReference_version_set")
-public func _bjs_TagHolderReference_version_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TagHolderReference_version_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_TagHolderReference_version_set")
+public func _bjs_BridgeJSRuntimeTests_TagHolderReference_version_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    TagHolderReference.bridgeJSLiftParameter(_self).version = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.TagHolderReference.bridgeJSLiftParameter(_self).version = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TagHolderReference_deinit")
-@_cdecl("bjs_TagHolderReference_deinit")
-public func _bjs_TagHolderReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TagHolderReference_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_TagHolderReference_deinit")
+public func _bjs_BridgeJSRuntimeTests_TagHolderReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<TagHolderReference>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.TagHolderReference>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension TagHolderReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.TagHolderReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_TagHolderReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_TagHolderReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_TagHolderReference_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_TagHolderReference_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_TagHolderReference_wrap")
-fileprivate func _bjs_TagHolderReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_TagHolderReference_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_TagHolderReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_TagHolderReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_TagHolderReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_TagHolderReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_TagHolderReference_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_TagHolderReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_TagHolderReference_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_PriorityReference_describe")
-@_cdecl("bjs_PriorityReference_describe")
-public func _bjs_PriorityReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PriorityReference_describe")
+@_cdecl("bjs_BridgeJSRuntimeTests_PriorityReference_describe")
+public func _bjs_BridgeJSRuntimeTests_PriorityReference_describe(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PriorityReference.bridgeJSLiftParameter(_self).describe()
+    let ret = BridgeJSRuntimeTests.PriorityReference.bridgeJSLiftParameter(_self).describe()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PriorityReference_weight")
-@_cdecl("bjs_PriorityReference_weight")
-public func _bjs_PriorityReference_weight(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PriorityReference_weight")
+@_cdecl("bjs_BridgeJSRuntimeTests_PriorityReference_weight")
+public func _bjs_BridgeJSRuntimeTests_PriorityReference_weight(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PriorityReference.bridgeJSLiftParameter(_self).weight()
+    let ret = BridgeJSRuntimeTests.PriorityReference.bridgeJSLiftParameter(_self).weight()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PriorityReference_static_low")
-@_cdecl("bjs_PriorityReference_static_low")
-public func _bjs_PriorityReference_static_low() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PriorityReference_static_low")
+@_cdecl("bjs_BridgeJSRuntimeTests_PriorityReference_static_low")
+public func _bjs_BridgeJSRuntimeTests_PriorityReference_static_low() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PriorityReference.low()
+    let ret = BridgeJSRuntimeTests.PriorityReference.low()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PriorityReference_static_medium")
-@_cdecl("bjs_PriorityReference_static_medium")
-public func _bjs_PriorityReference_static_medium() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PriorityReference_static_medium")
+@_cdecl("bjs_BridgeJSRuntimeTests_PriorityReference_static_medium")
+public func _bjs_BridgeJSRuntimeTests_PriorityReference_static_medium() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PriorityReference.medium()
+    let ret = BridgeJSRuntimeTests.PriorityReference.medium()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PriorityReference_static_high")
-@_cdecl("bjs_PriorityReference_static_high")
-public func _bjs_PriorityReference_static_high() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PriorityReference_static_high")
+@_cdecl("bjs_BridgeJSRuntimeTests_PriorityReference_static_high")
+public func _bjs_BridgeJSRuntimeTests_PriorityReference_static_high() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PriorityReference.high()
+    let ret = BridgeJSRuntimeTests.PriorityReference.high()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PriorityReference_deinit")
-@_cdecl("bjs_PriorityReference_deinit")
-public func _bjs_PriorityReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PriorityReference_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_PriorityReference_deinit")
+public func _bjs_BridgeJSRuntimeTests_PriorityReference_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PriorityReference>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.PriorityReference>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PriorityReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.PriorityReference: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PriorityReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_PriorityReference_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PriorityReference_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_PriorityReference_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_PriorityReference_wrap")
-fileprivate func _bjs_PriorityReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_PriorityReference_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_PriorityReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PriorityReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_PriorityReference_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PriorityReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PriorityReference_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_PriorityReference_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_PriorityReference_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ClosureSupportExports_static_makeIntToInt")
-@_cdecl("bjs_ClosureSupportExports_static_makeIntToInt")
-public func _bjs_ClosureSupportExports_static_makeIntToInt(_ base: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeIntToInt")
+@_cdecl("bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeIntToInt")
+public func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeIntToInt(_ base: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = ClosureSupportExports.makeIntToInt(_: Int.bridgeJSLiftParameter(base))
+    let ret = BridgeJSRuntimeTests.ClosureSupportExports.makeIntToInt(_: Int.bridgeJSLiftParameter(base))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClosureSupportExports_static_makeDoubleToDouble")
-@_cdecl("bjs_ClosureSupportExports_static_makeDoubleToDouble")
-public func _bjs_ClosureSupportExports_static_makeDoubleToDouble(_ base: Float64) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeDoubleToDouble")
+@_cdecl("bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeDoubleToDouble")
+public func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeDoubleToDouble(_ base: Float64) -> Int32 {
     #if arch(wasm32)
-    let ret = ClosureSupportExports.makeDoubleToDouble(_: Double.bridgeJSLiftParameter(base))
+    let ret = BridgeJSRuntimeTests.ClosureSupportExports.makeDoubleToDouble(_: Double.bridgeJSLiftParameter(base))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClosureSupportExports_static_makeStringToString")
-@_cdecl("bjs_ClosureSupportExports_static_makeStringToString")
-public func _bjs_ClosureSupportExports_static_makeStringToString(_ prefixBytes: Int32, _ prefixLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeStringToString")
+@_cdecl("bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeStringToString")
+public func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeStringToString(_ prefixBytes: Int32, _ prefixLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = ClosureSupportExports.makeStringToString(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength))
+    let ret = BridgeJSRuntimeTests.ClosureSupportExports.makeStringToString(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClosureSupportExports_static_makeJSIntToInt")
-@_cdecl("bjs_ClosureSupportExports_static_makeJSIntToInt")
-public func _bjs_ClosureSupportExports_static_makeJSIntToInt(_ base: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSIntToInt")
+@_cdecl("bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSIntToInt")
+public func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSIntToInt(_ base: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = ClosureSupportExports.makeJSIntToInt(_: Int.bridgeJSLiftParameter(base))
+    let ret = BridgeJSRuntimeTests.ClosureSupportExports.makeJSIntToInt(_: Int.bridgeJSLiftParameter(base))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClosureSupportExports_static_makeJSDoubleToDouble")
-@_cdecl("bjs_ClosureSupportExports_static_makeJSDoubleToDouble")
-public func _bjs_ClosureSupportExports_static_makeJSDoubleToDouble(_ base: Float64) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSDoubleToDouble")
+@_cdecl("bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSDoubleToDouble")
+public func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSDoubleToDouble(_ base: Float64) -> Int32 {
     #if arch(wasm32)
-    let ret = ClosureSupportExports.makeJSDoubleToDouble(_: Double.bridgeJSLiftParameter(base))
+    let ret = BridgeJSRuntimeTests.ClosureSupportExports.makeJSDoubleToDouble(_: Double.bridgeJSLiftParameter(base))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClosureSupportExports_static_makeJSStringToString")
-@_cdecl("bjs_ClosureSupportExports_static_makeJSStringToString")
-public func _bjs_ClosureSupportExports_static_makeJSStringToString(_ prefixBytes: Int32, _ prefixLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSStringToString")
+@_cdecl("bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSStringToString")
+public func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSStringToString(_ prefixBytes: Int32, _ prefixLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = ClosureSupportExports.makeJSStringToString(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength))
+    let ret = BridgeJSRuntimeTests.ClosureSupportExports.makeJSStringToString(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ClosureSupportExports_deinit")
-@_cdecl("bjs_ClosureSupportExports_deinit")
-public func _bjs_ClosureSupportExports_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ClosureSupportExports_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_ClosureSupportExports_deinit")
+public func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ClosureSupportExports>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.ClosureSupportExports>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ClosureSupportExports: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.ClosureSupportExports: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ClosureSupportExports_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_ClosureSupportExports_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ClosureSupportExports_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_ClosureSupportExports_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ClosureSupportExports_wrap")
-fileprivate func _bjs_ClosureSupportExports_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_ClosureSupportExports_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ClosureSupportExports_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ClosureSupportExports_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ClosureSupportExports_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_ClosureSupportExports_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_ClosureSupportExports_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_init")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_init")
-public func _bjs_DefaultArgumentConstructorDefaults_init(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ enabled: Int32, _ status: Int32, _ tagIsSome: Int32, _ tagBytes: Int32, _ tagLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_init")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_init(_ nameBytes: Int32, _ nameLength: Int32, _ count: Int32, _ enabled: Int32, _ status: Int32, _ tagIsSome: Int32, _ tagBytes: Int32, _ tagLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = DefaultArgumentConstructorDefaults(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), enabled: Bool.bridgeJSLiftParameter(enabled), status: Status.bridgeJSLiftParameter(status), tag: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
+    let ret = BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults(name: String.bridgeJSLiftParameter(nameBytes, nameLength), count: Int.bridgeJSLiftParameter(count), enabled: Bool.bridgeJSLiftParameter(enabled), status: BridgeJSRuntimeTests.Status.bridgeJSLiftParameter(status), tag: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_describe")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_describe")
-public func _bjs_DefaultArgumentConstructorDefaults_describe(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_describe")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_describe")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_describe(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).describe()
+    let ret = BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).describe()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_name_get")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_name_get")
-public func _bjs_DefaultArgumentConstructorDefaults_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_name_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_name_get")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).name
+    let ret = BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_name_set")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_name_set")
-public func _bjs_DefaultArgumentConstructorDefaults_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_name_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_name_set")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_count_get")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_count_get")
-public func _bjs_DefaultArgumentConstructorDefaults_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_count_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_count_get")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).count
+    let ret = BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).count
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_count_set")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_count_set")
-public func _bjs_DefaultArgumentConstructorDefaults_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_count_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_count_set")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_enabled_get")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_enabled_get")
-public func _bjs_DefaultArgumentConstructorDefaults_enabled_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_enabled_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_enabled_get")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_enabled_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).enabled
+    let ret = BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).enabled
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_enabled_set")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_enabled_set")
-public func _bjs_DefaultArgumentConstructorDefaults_enabled_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_enabled_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_enabled_set")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_enabled_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).enabled = Bool.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).enabled = Bool.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_status_get")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_status_get")
-public func _bjs_DefaultArgumentConstructorDefaults_status_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_status_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_status_get")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_status_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).status
+    let ret = BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).status
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_status_set")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_status_set")
-public func _bjs_DefaultArgumentConstructorDefaults_status_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_status_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_status_set")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_status_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).status = Status.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).status = BridgeJSRuntimeTests.Status.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_tag_get")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_tag_get")
-public func _bjs_DefaultArgumentConstructorDefaults_tag_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_tag_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_tag_get")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_tag_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).tag
+    let ret = BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).tag
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_tag_set")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_tag_set")
-public func _bjs_DefaultArgumentConstructorDefaults_tag_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_tag_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_tag_set")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_tag_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).tag = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults.bridgeJSLiftParameter(_self).tag = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DefaultArgumentConstructorDefaults_deinit")
-@_cdecl("bjs_DefaultArgumentConstructorDefaults_deinit")
-public func _bjs_DefaultArgumentConstructorDefaults_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_deinit")
+public func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<DefaultArgumentConstructorDefaults>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension DefaultArgumentConstructorDefaults: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_DefaultArgumentConstructorDefaults_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_DefaultArgumentConstructorDefaults_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DefaultArgumentConstructorDefaults_wrap")
-fileprivate func _bjs_DefaultArgumentConstructorDefaults_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_DefaultArgumentConstructorDefaults_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_DefaultArgumentConstructorDefaults_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_DefaultArgumentConstructorDefaults_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Greeter_init")
-@_cdecl("bjs_Greeter_init")
-public func _bjs_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_init")
+public func _bjs_BridgeJSRuntimeTests_Greeter_init(_ nameBytes: Int32, _ nameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    let ret = BridgeJSRuntimeTests.Greeter(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greet")
-@_cdecl("bjs_Greeter_greet")
-public func _bjs_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_greet")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_greet")
+public func _bjs_BridgeJSRuntimeTests_Greeter_greet(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greet()
+    let ret = BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).greet()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_changeName")
-@_cdecl("bjs_Greeter_changeName")
-public func _bjs_Greeter_changeName(_ _self: UnsafeMutableRawPointer, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_changeName")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_changeName")
+public func _bjs_BridgeJSRuntimeTests_Greeter_changeName(_ _self: UnsafeMutableRawPointer, _ nameBytes: Int32, _ nameLength: Int32) -> Void {
     #if arch(wasm32)
-    Greeter.bridgeJSLiftParameter(_self).changeName(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
+    BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).changeName(name: String.bridgeJSLiftParameter(nameBytes, nameLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greetWith")
-@_cdecl("bjs_Greeter_greetWith")
-public func _bjs_Greeter_greetWith(_ _self: UnsafeMutableRawPointer, _ greeter: UnsafeMutableRawPointer, _ customGreeting: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_greetWith")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_greetWith")
+public func _bjs_BridgeJSRuntimeTests_Greeter_greetWith(_ _self: UnsafeMutableRawPointer, _ greeter: UnsafeMutableRawPointer, _ customGreeting: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greetWith(greeter: Greeter.bridgeJSLiftParameter(greeter), customGreeting: _BJS_Closure_20BridgeJSRuntimeTests7GreeterC_SS.bridgeJSLift(customGreeting))
+    let ret = BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).greetWith(greeter: BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(greeter), customGreeting: _BJS_Closure_20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS.bridgeJSLift(customGreeting))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_makeFormatter")
-@_cdecl("bjs_Greeter_makeFormatter")
-public func _bjs_Greeter_makeFormatter(_ _self: UnsafeMutableRawPointer, _ suffixBytes: Int32, _ suffixLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_makeFormatter")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_makeFormatter")
+public func _bjs_BridgeJSRuntimeTests_Greeter_makeFormatter(_ _self: UnsafeMutableRawPointer, _ suffixBytes: Int32, _ suffixLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).makeFormatter(suffix: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    let ret = BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).makeFormatter(suffix: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_static_makeCreator")
-@_cdecl("bjs_Greeter_static_makeCreator")
-public func _bjs_Greeter_static_makeCreator(_ defaultNameBytes: Int32, _ defaultNameLength: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_static_makeCreator")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_static_makeCreator")
+public func _bjs_BridgeJSRuntimeTests_Greeter_static_makeCreator(_ defaultNameBytes: Int32, _ defaultNameLength: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = Greeter.makeCreator(defaultName: String.bridgeJSLiftParameter(defaultNameBytes, defaultNameLength))
+    let ret = BridgeJSRuntimeTests.Greeter.makeCreator(defaultName: String.bridgeJSLiftParameter(defaultNameBytes, defaultNameLength))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_makeCustomGreeter")
-@_cdecl("bjs_Greeter_makeCustomGreeter")
-public func _bjs_Greeter_makeCustomGreeter(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_makeCustomGreeter")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_makeCustomGreeter")
+public func _bjs_BridgeJSRuntimeTests_Greeter_makeCustomGreeter(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).makeCustomGreeter()
+    let ret = BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).makeCustomGreeter()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_greetEnthusiastically")
-@_cdecl("bjs_Greeter_greetEnthusiastically")
-public func _bjs_Greeter_greetEnthusiastically(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_greetEnthusiastically")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_greetEnthusiastically")
+public func _bjs_BridgeJSRuntimeTests_Greeter_greetEnthusiastically(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).greetEnthusiastically()
+    let ret = BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).greetEnthusiastically()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_static_greetAnonymously")
-@_cdecl("bjs_Greeter_static_greetAnonymously")
-public func _bjs_Greeter_static_greetAnonymously() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_static_greetAnonymously")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_static_greetAnonymously")
+public func _bjs_BridgeJSRuntimeTests_Greeter_static_greetAnonymously() -> Void {
     #if arch(wasm32)
-    let ret = Greeter.greetAnonymously()
+    let ret = BridgeJSRuntimeTests.Greeter.greetAnonymously()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_get")
-@_cdecl("bjs_Greeter_name_get")
-public func _bjs_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_name_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_name_get")
+public func _bjs_BridgeJSRuntimeTests_Greeter_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).name
+    let ret = BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_name_set")
-@_cdecl("bjs_Greeter_name_set")
-public func _bjs_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_name_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_name_set")
+public func _bjs_BridgeJSRuntimeTests_Greeter_name_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    Greeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).name = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_prefix_get")
-@_cdecl("bjs_Greeter_prefix_get")
-public func _bjs_Greeter_prefix_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_prefix_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_prefix_get")
+public func _bjs_BridgeJSRuntimeTests_Greeter_prefix_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).prefix
+    let ret = BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).prefix
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_nameCount_get")
-@_cdecl("bjs_Greeter_nameCount_get")
-public func _bjs_Greeter_nameCount_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_nameCount_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_nameCount_get")
+public func _bjs_BridgeJSRuntimeTests_Greeter_nameCount_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = Greeter.bridgeJSLiftParameter(_self).nameCount
+    let ret = BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(_self).nameCount
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_static_defaultGreeting_get")
-@_cdecl("bjs_Greeter_static_defaultGreeting_get")
-public func _bjs_Greeter_static_defaultGreeting_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_static_defaultGreeting_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_static_defaultGreeting_get")
+public func _bjs_BridgeJSRuntimeTests_Greeter_static_defaultGreeting_get() -> Void {
     #if arch(wasm32)
-    let ret = Greeter.defaultGreeting
+    let ret = BridgeJSRuntimeTests.Greeter.defaultGreeting
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Greeter_deinit")
-@_cdecl("bjs_Greeter_deinit")
-public func _bjs_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Greeter_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_Greeter_deinit")
+public func _bjs_BridgeJSRuntimeTests_Greeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Greeter>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.Greeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.Greeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     public var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_Greeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     public consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_Greeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Greeter_wrap")
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_Greeter_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_Greeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Greeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_Greeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_Greeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Calculator_square")
-@_cdecl("bjs_Calculator_square")
-public func _bjs_Calculator_square(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Calculator_square")
+@_cdecl("bjs_BridgeJSRuntimeTests_Calculator_square")
+public func _bjs_BridgeJSRuntimeTests_Calculator_square(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = Calculator.bridgeJSLiftParameter(_self).square(value: Int.bridgeJSLiftParameter(value))
+    let ret = BridgeJSRuntimeTests.Calculator.bridgeJSLiftParameter(_self).square(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Calculator_add")
-@_cdecl("bjs_Calculator_add")
-public func _bjs_Calculator_add(_ _self: UnsafeMutableRawPointer, _ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Calculator_add")
+@_cdecl("bjs_BridgeJSRuntimeTests_Calculator_add")
+public func _bjs_BridgeJSRuntimeTests_Calculator_add(_ _self: UnsafeMutableRawPointer, _ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = Calculator.bridgeJSLiftParameter(_self).add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
+    let ret = BridgeJSRuntimeTests.Calculator.bridgeJSLiftParameter(_self).add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Calculator_asyncMakePoint")
-@_cdecl("bjs_Calculator_asyncMakePoint")
-public func _bjs_Calculator_asyncMakePoint(_ _self: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Calculator_asyncMakePoint")
+@_cdecl("bjs_BridgeJSRuntimeTests_Calculator_asyncMakePoint")
+public func _bjs_BridgeJSRuntimeTests_Calculator_asyncMakePoint(_ _self: UnsafeMutableRawPointer, _ x: Int32, _ y: Int32) -> Int32 {
     #if arch(wasm32)
-    return _bjs_makePromise(resolve: Promise_resolve_11PublicPointV, reject: Promise_reject) {
-        return await Calculator.bridgeJSLiftParameter(_self).asyncMakePoint(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
+    return _bjs_makePromise(resolve: Promise_resolve_32BridgeJSRuntimeTests_PublicPointV, reject: Promise_reject) {
+        return await BridgeJSRuntimeTests.Calculator.bridgeJSLiftParameter(_self).asyncMakePoint(x: Int.bridgeJSLiftParameter(x), y: Int.bridgeJSLiftParameter(y))
     }
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Calculator_deinit")
-@_cdecl("bjs_Calculator_deinit")
-public func _bjs_Calculator_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Calculator_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_Calculator_deinit")
+public func _bjs_BridgeJSRuntimeTests_Calculator_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Calculator>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.Calculator>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Calculator: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.Calculator: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Calculator_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_Calculator_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Calculator_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_Calculator_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Calculator_wrap")
-fileprivate func _bjs_Calculator_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_Calculator_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_Calculator_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Calculator_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_Calculator_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Calculator_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Calculator_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_Calculator_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_Calculator_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_InternalGreeter_deinit")
-@_cdecl("bjs_InternalGreeter_deinit")
-public func _bjs_InternalGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_InternalGreeter_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_InternalGreeter_deinit")
+public func _bjs_BridgeJSRuntimeTests_InternalGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<InternalGreeter>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.InternalGreeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension InternalGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.InternalGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     internal var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_InternalGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_InternalGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     internal consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_InternalGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_InternalGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_InternalGreeter_wrap")
-fileprivate func _bjs_InternalGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_InternalGreeter_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_InternalGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_InternalGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_InternalGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_InternalGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_InternalGreeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_InternalGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_InternalGreeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_PublicGreeter_deinit")
-@_cdecl("bjs_PublicGreeter_deinit")
-public func _bjs_PublicGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PublicGreeter_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_PublicGreeter_deinit")
+public func _bjs_BridgeJSRuntimeTests_PublicGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PublicGreeter>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.PublicGreeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PublicGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.PublicGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     public var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PublicGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_PublicGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     public consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PublicGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_PublicGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_PublicGreeter_wrap")
-fileprivate func _bjs_PublicGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_PublicGreeter_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_PublicGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PublicGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_PublicGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PublicGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PublicGreeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_PublicGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_PublicGreeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_PackageGreeter_deinit")
-@_cdecl("bjs_PackageGreeter_deinit")
-public func _bjs_PackageGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PackageGreeter_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_PackageGreeter_deinit")
+public func _bjs_BridgeJSRuntimeTests_PackageGreeter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PackageGreeter>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.PackageGreeter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PackageGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.PackageGreeter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     package var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PackageGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_PackageGreeter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     package consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PackageGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_PackageGreeter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_PackageGreeter_wrap")
-fileprivate func _bjs_PackageGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_PackageGreeter_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_PackageGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PackageGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_PackageGreeter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PackageGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PackageGreeter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_PackageGreeter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_PackageGreeter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Utils_Converter_init")
-@_cdecl("bjs_Utils_Converter_init")
-public func _bjs_Utils_Converter_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Utils_Converter_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_Utils_Converter_init")
+public func _bjs_BridgeJSRuntimeTests_Utils_Converter_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Utils.Converter()
+    let ret = BridgeJSRuntimeTests.Utils.Converter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_toString")
-@_cdecl("bjs_Utils_Converter_toString")
-public func _bjs_Utils_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Utils_Converter_toString")
+@_cdecl("bjs_BridgeJSRuntimeTests_Utils_Converter_toString")
+public func _bjs_BridgeJSRuntimeTests_Utils_Converter_toString(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    let ret = Utils.Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
+    let ret = BridgeJSRuntimeTests.Utils.Converter.bridgeJSLiftParameter(_self).toString(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_precision_get")
-@_cdecl("bjs_Utils_Converter_precision_get")
-public func _bjs_Utils_Converter_precision_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Utils_Converter_precision_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_Utils_Converter_precision_get")
+public func _bjs_BridgeJSRuntimeTests_Utils_Converter_precision_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = Utils.Converter.bridgeJSLiftParameter(_self).precision
+    let ret = BridgeJSRuntimeTests.Utils.Converter.bridgeJSLiftParameter(_self).precision
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_precision_set")
-@_cdecl("bjs_Utils_Converter_precision_set")
-public func _bjs_Utils_Converter_precision_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Utils_Converter_precision_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_Utils_Converter_precision_set")
+public func _bjs_BridgeJSRuntimeTests_Utils_Converter_precision_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    Utils.Converter.bridgeJSLiftParameter(_self).precision = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.Utils.Converter.bridgeJSLiftParameter(_self).precision = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Utils_Converter_deinit")
-@_cdecl("bjs_Utils_Converter_deinit")
-public func _bjs_Utils_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Utils_Converter_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_Utils_Converter_deinit")
+public func _bjs_BridgeJSRuntimeTests_Utils_Converter_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Utils.Converter>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.Utils.Converter>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Utils.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.Utils.Converter: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_Utils_Converter_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Utils_Converter_wrap")
-fileprivate func _bjs_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_Utils_Converter_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_Utils_Converter_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Utils_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Utils_Converter_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_Utils_Converter_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_Utils_Converter_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Networking_API_HTTPServer_init")
-@_cdecl("bjs_Networking_API_HTTPServer_init")
-public func _bjs_Networking_API_HTTPServer_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_init")
+public func _bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Networking.API.HTTPServer()
+    let ret = BridgeJSRuntimeTests.Networking.API.HTTPServer()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_API_HTTPServer_call")
-@_cdecl("bjs_Networking_API_HTTPServer_call")
-public func _bjs_Networking_API_HTTPServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_call")
+@_cdecl("bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_call")
+public func _bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
     #if arch(wasm32)
-    Networking.API.HTTPServer.bridgeJSLiftParameter(_self).call(_: Networking.API.Method.bridgeJSLiftParameter(method))
+    BridgeJSRuntimeTests.Networking.API.HTTPServer.bridgeJSLiftParameter(_self).call(_: BridgeJSRuntimeTests.Networking.API.Method.bridgeJSLiftParameter(method))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_API_HTTPServer_deinit")
-@_cdecl("bjs_Networking_API_HTTPServer_deinit")
-public func _bjs_Networking_API_HTTPServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_deinit")
+public func _bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Networking.API.HTTPServer>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.Networking.API.HTTPServer>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Networking.API.HTTPServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.Networking.API.HTTPServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Networking_API_HTTPServer_wrap")
-fileprivate func _bjs_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Networking_API_HTTPServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Networking_API_HTTPServer_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_UUID_init")
-@_cdecl("bjs___Swift_Foundation_UUID_init")
-public func _bjs___Swift_Foundation_UUID_init(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_UUID_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_UUID_init")
+public func _bjs_BridgeJSRuntimeTests_UUID_init(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = UUID(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    let ret = BridgeJSRuntimeTests.UUID(value: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_UUID_uuidString")
-@_cdecl("bjs___Swift_Foundation_UUID_uuidString")
-public func _bjs___Swift_Foundation_UUID_uuidString(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_UUID_uuidString")
+@_cdecl("bjs_BridgeJSRuntimeTests_UUID_uuidString")
+public func _bjs_BridgeJSRuntimeTests_UUID_uuidString(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = UUID.bridgeJSLiftParameter(_self).uuidString()
+    let ret = BridgeJSRuntimeTests.UUID.bridgeJSLiftParameter(_self).uuidString()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_UUID_static_fromValue")
-@_cdecl("bjs___Swift_Foundation_UUID_static_fromValue")
-public func _bjs___Swift_Foundation_UUID_static_fromValue(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_UUID_static_fromValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_UUID_static_fromValue")
+public func _bjs_BridgeJSRuntimeTests_UUID_static_fromValue(_ valueBytes: Int32, _ valueLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = UUID.fromValue(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
+    let ret = BridgeJSRuntimeTests.UUID.fromValue(_: String.bridgeJSLiftParameter(valueBytes, valueLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_UUID_static_placeholder_get")
-@_cdecl("bjs___Swift_Foundation_UUID_static_placeholder_get")
-public func _bjs___Swift_Foundation_UUID_static_placeholder_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_UUID_static_placeholder_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_UUID_static_placeholder_get")
+public func _bjs_BridgeJSRuntimeTests_UUID_static_placeholder_get() -> Void {
     #if arch(wasm32)
-    let ret = UUID.placeholder
+    let ret = BridgeJSRuntimeTests.UUID.placeholder
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs___Swift_Foundation_UUID_deinit")
-@_cdecl("bjs___Swift_Foundation_UUID_deinit")
-public func _bjs___Swift_Foundation_UUID_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_UUID_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_UUID_deinit")
+public func _bjs_BridgeJSRuntimeTests_UUID_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<UUID>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.UUID>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension UUID: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.UUID: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs___Swift_Foundation_UUID_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_UUID_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs___Swift_Foundation_UUID_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_UUID_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs___Swift_Foundation_UUID_wrap")
-fileprivate func _bjs___Swift_Foundation_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_UUID_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs___Swift_Foundation_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_UUID_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs___Swift_Foundation_UUID_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs___Swift_Foundation_UUID_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_UUID_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_UUID_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Networking_APIV2_Internal_TestServer_init")
-@_cdecl("bjs_Networking_APIV2_Internal_TestServer_init")
-public func _bjs_Networking_APIV2_Internal_TestServer_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Internal_TestServer_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_Internal_TestServer_init")
+public func _bjs_BridgeJSRuntimeTests_Internal_TestServer_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = Internal.TestServer()
+    let ret = BridgeJSRuntimeTests.Internal.TestServer()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_APIV2_Internal_TestServer_call")
-@_cdecl("bjs_Networking_APIV2_Internal_TestServer_call")
-public func _bjs_Networking_APIV2_Internal_TestServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Internal_TestServer_call")
+@_cdecl("bjs_BridgeJSRuntimeTests_Internal_TestServer_call")
+public func _bjs_BridgeJSRuntimeTests_Internal_TestServer_call(_ _self: UnsafeMutableRawPointer, _ method: Int32) -> Void {
     #if arch(wasm32)
-    Internal.TestServer.bridgeJSLiftParameter(_self).call(_: Internal.SupportedMethod.bridgeJSLiftParameter(method))
+    BridgeJSRuntimeTests.Internal.TestServer.bridgeJSLiftParameter(_self).call(_: BridgeJSRuntimeTests.Internal.SupportedMethod.bridgeJSLiftParameter(method))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Networking_APIV2_Internal_TestServer_deinit")
-@_cdecl("bjs_Networking_APIV2_Internal_TestServer_deinit")
-public func _bjs_Networking_APIV2_Internal_TestServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Internal_TestServer_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_Internal_TestServer_deinit")
+public func _bjs_BridgeJSRuntimeTests_Internal_TestServer_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Internal.TestServer>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.Internal.TestServer>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Internal.TestServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.Internal.TestServer: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Networking_APIV2_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Networking_APIV2_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_Internal_TestServer_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Networking_APIV2_Internal_TestServer_wrap")
-fileprivate func _bjs_Networking_APIV2_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_Internal_TestServer_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Networking_APIV2_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_Internal_TestServer_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Networking_APIV2_Internal_TestServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Networking_APIV2_Internal_TestServer_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_Internal_TestServer_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_Internal_TestServer_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_SimplePropertyHolder_init")
-@_cdecl("bjs_SimplePropertyHolder_init")
-public func _bjs_SimplePropertyHolder_init(_ value: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SimplePropertyHolder_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_SimplePropertyHolder_init")
+public func _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_init(_ value: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = SimplePropertyHolder(value: Int.bridgeJSLiftParameter(value))
+    let ret = BridgeJSRuntimeTests.SimplePropertyHolder(value: Int.bridgeJSLiftParameter(value))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimplePropertyHolder_value_get")
-@_cdecl("bjs_SimplePropertyHolder_value_get")
-public func _bjs_SimplePropertyHolder_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SimplePropertyHolder_value_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SimplePropertyHolder_value_get")
+public func _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_value_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = SimplePropertyHolder.bridgeJSLiftParameter(_self).value
+    let ret = BridgeJSRuntimeTests.SimplePropertyHolder.bridgeJSLiftParameter(_self).value
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimplePropertyHolder_value_set")
-@_cdecl("bjs_SimplePropertyHolder_value_set")
-public func _bjs_SimplePropertyHolder_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SimplePropertyHolder_value_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SimplePropertyHolder_value_set")
+public func _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_value_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    SimplePropertyHolder.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.SimplePropertyHolder.bridgeJSLiftParameter(_self).value = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SimplePropertyHolder_deinit")
-@_cdecl("bjs_SimplePropertyHolder_deinit")
-public func _bjs_SimplePropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SimplePropertyHolder_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_SimplePropertyHolder_deinit")
+public func _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<SimplePropertyHolder>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.SimplePropertyHolder>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension SimplePropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.SimplePropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_SimplePropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_SimplePropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_SimplePropertyHolder_wrap")
-fileprivate func _bjs_SimplePropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_SimplePropertyHolder_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_SimplePropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_SimplePropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_SimplePropertyHolder_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_SimplePropertyHolder_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_PropertyHolder_init")
-@_cdecl("bjs_PropertyHolder_init")
-public func _bjs_PropertyHolder_init(_ intValue: Int32, _ floatValue: Float32, _ doubleValue: Float64, _ boolValue: Int32, _ stringValueBytes: Int32, _ stringValueLength: Int32, _ jsObject: Int32, _ sibling: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_init")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_init(_ intValue: Int32, _ floatValue: Float32, _ doubleValue: Float64, _ boolValue: Int32, _ stringValueBytes: Int32, _ stringValueLength: Int32, _ jsObject: Int32, _ sibling: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PropertyHolder(intValue: Int.bridgeJSLiftParameter(intValue), floatValue: Float.bridgeJSLiftParameter(floatValue), doubleValue: Double.bridgeJSLiftParameter(doubleValue), boolValue: Bool.bridgeJSLiftParameter(boolValue), stringValue: String.bridgeJSLiftParameter(stringValueBytes, stringValueLength), jsObject: JSObject.bridgeJSLiftParameter(jsObject), sibling: SimplePropertyHolder.bridgeJSLiftParameter(sibling))
+    let ret = BridgeJSRuntimeTests.PropertyHolder(intValue: Int.bridgeJSLiftParameter(intValue), floatValue: Float.bridgeJSLiftParameter(floatValue), doubleValue: Double.bridgeJSLiftParameter(doubleValue), boolValue: Bool.bridgeJSLiftParameter(boolValue), stringValue: String.bridgeJSLiftParameter(stringValueBytes, stringValueLength), jsObject: JSObject.bridgeJSLiftParameter(jsObject), sibling: BridgeJSRuntimeTests.SimplePropertyHolder.bridgeJSLiftParameter(sibling))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_getAllValues")
-@_cdecl("bjs_PropertyHolder_getAllValues")
-public func _bjs_PropertyHolder_getAllValues(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_getAllValues")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_getAllValues")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_getAllValues(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).getAllValues()
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).getAllValues()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_intValue_get")
-@_cdecl("bjs_PropertyHolder_intValue_get")
-public func _bjs_PropertyHolder_intValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_intValue_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_intValue_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_intValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).intValue
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).intValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_intValue_set")
-@_cdecl("bjs_PropertyHolder_intValue_set")
-public func _bjs_PropertyHolder_intValue_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_intValue_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_intValue_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_intValue_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).intValue = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).intValue = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_floatValue_get")
-@_cdecl("bjs_PropertyHolder_floatValue_get")
-public func _bjs_PropertyHolder_floatValue_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_floatValue_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_floatValue_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_floatValue_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).floatValue
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).floatValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_floatValue_set")
-@_cdecl("bjs_PropertyHolder_floatValue_set")
-public func _bjs_PropertyHolder_floatValue_set(_ _self: UnsafeMutableRawPointer, _ value: Float32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_floatValue_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_floatValue_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_floatValue_set(_ _self: UnsafeMutableRawPointer, _ value: Float32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).floatValue = Float.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).floatValue = Float.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_doubleValue_get")
-@_cdecl("bjs_PropertyHolder_doubleValue_get")
-public func _bjs_PropertyHolder_doubleValue_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_doubleValue_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_doubleValue_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_doubleValue_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).doubleValue
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).doubleValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_doubleValue_set")
-@_cdecl("bjs_PropertyHolder_doubleValue_set")
-public func _bjs_PropertyHolder_doubleValue_set(_ _self: UnsafeMutableRawPointer, _ value: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_doubleValue_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_doubleValue_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_doubleValue_set(_ _self: UnsafeMutableRawPointer, _ value: Float64) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).doubleValue = Double.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).doubleValue = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_boolValue_get")
-@_cdecl("bjs_PropertyHolder_boolValue_get")
-public func _bjs_PropertyHolder_boolValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_boolValue_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_boolValue_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_boolValue_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).boolValue
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).boolValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_boolValue_set")
-@_cdecl("bjs_PropertyHolder_boolValue_set")
-public func _bjs_PropertyHolder_boolValue_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_boolValue_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_boolValue_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_boolValue_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).boolValue = Bool.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).boolValue = Bool.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_stringValue_get")
-@_cdecl("bjs_PropertyHolder_stringValue_get")
-public func _bjs_PropertyHolder_stringValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_stringValue_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_stringValue_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_stringValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).stringValue
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).stringValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_stringValue_set")
-@_cdecl("bjs_PropertyHolder_stringValue_set")
-public func _bjs_PropertyHolder_stringValue_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_stringValue_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_stringValue_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_stringValue_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).stringValue = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).stringValue = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyInt_get")
-@_cdecl("bjs_PropertyHolder_readonlyInt_get")
-public func _bjs_PropertyHolder_readonlyInt_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyInt_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyInt_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyInt_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyInt
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).readonlyInt
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyFloat_get")
-@_cdecl("bjs_PropertyHolder_readonlyFloat_get")
-public func _bjs_PropertyHolder_readonlyFloat_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyFloat_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyFloat_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyFloat_get(_ _self: UnsafeMutableRawPointer) -> Float32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyFloat
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).readonlyFloat
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyDouble_get")
-@_cdecl("bjs_PropertyHolder_readonlyDouble_get")
-public func _bjs_PropertyHolder_readonlyDouble_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyDouble_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyDouble_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyDouble_get(_ _self: UnsafeMutableRawPointer) -> Float64 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyDouble
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).readonlyDouble
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyBool_get")
-@_cdecl("bjs_PropertyHolder_readonlyBool_get")
-public func _bjs_PropertyHolder_readonlyBool_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyBool_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyBool_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyBool_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyBool
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).readonlyBool
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_readonlyString_get")
-@_cdecl("bjs_PropertyHolder_readonlyString_get")
-public func _bjs_PropertyHolder_readonlyString_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyString_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyString_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_readonlyString_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).readonlyString
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).readonlyString
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_jsObject_get")
-@_cdecl("bjs_PropertyHolder_jsObject_get")
-public func _bjs_PropertyHolder_jsObject_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_jsObject_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_jsObject_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_jsObject_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).jsObject
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).jsObject
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_jsObject_set")
-@_cdecl("bjs_PropertyHolder_jsObject_set")
-public func _bjs_PropertyHolder_jsObject_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_jsObject_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_jsObject_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_jsObject_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).jsObject = JSObject.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).jsObject = JSObject.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_sibling_get")
-@_cdecl("bjs_PropertyHolder_sibling_get")
-public func _bjs_PropertyHolder_sibling_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_sibling_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_sibling_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_sibling_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).sibling
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).sibling
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_sibling_set")
-@_cdecl("bjs_PropertyHolder_sibling_set")
-public func _bjs_PropertyHolder_sibling_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_sibling_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_sibling_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_sibling_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).sibling = SimplePropertyHolder.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).sibling = BridgeJSRuntimeTests.SimplePropertyHolder.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_lazyValue_get")
-@_cdecl("bjs_PropertyHolder_lazyValue_get")
-public func _bjs_PropertyHolder_lazyValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_lazyValue_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_lazyValue_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_lazyValue_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).lazyValue
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).lazyValue
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_lazyValue_set")
-@_cdecl("bjs_PropertyHolder_lazyValue_set")
-public func _bjs_PropertyHolder_lazyValue_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_lazyValue_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_lazyValue_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_lazyValue_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).lazyValue = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).lazyValue = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_computedReadonly_get")
-@_cdecl("bjs_PropertyHolder_computedReadonly_get")
-public func _bjs_PropertyHolder_computedReadonly_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_computedReadonly_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_computedReadonly_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_computedReadonly_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).computedReadonly
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).computedReadonly
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_computedReadWrite_get")
-@_cdecl("bjs_PropertyHolder_computedReadWrite_get")
-public func _bjs_PropertyHolder_computedReadWrite_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_computedReadWrite_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_computedReadWrite_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_computedReadWrite_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).computedReadWrite
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).computedReadWrite
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_computedReadWrite_set")
-@_cdecl("bjs_PropertyHolder_computedReadWrite_set")
-public func _bjs_PropertyHolder_computedReadWrite_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_computedReadWrite_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_computedReadWrite_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_computedReadWrite_set(_ _self: UnsafeMutableRawPointer, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).computedReadWrite = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).computedReadWrite = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_observedProperty_get")
-@_cdecl("bjs_PropertyHolder_observedProperty_get")
-public func _bjs_PropertyHolder_observedProperty_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_observedProperty_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_observedProperty_get")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_observedProperty_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = PropertyHolder.bridgeJSLiftParameter(_self).observedProperty
+    let ret = BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).observedProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_observedProperty_set")
-@_cdecl("bjs_PropertyHolder_observedProperty_set")
-public func _bjs_PropertyHolder_observedProperty_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_observedProperty_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_observedProperty_set")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_observedProperty_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    PropertyHolder.bridgeJSLiftParameter(_self).observedProperty = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.PropertyHolder.bridgeJSLiftParameter(_self).observedProperty = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_PropertyHolder_deinit")
-@_cdecl("bjs_PropertyHolder_deinit")
-public func _bjs_PropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_PropertyHolder_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_PropertyHolder_deinit")
+public func _bjs_BridgeJSRuntimeTests_PropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<PropertyHolder>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.PropertyHolder>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension PropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.PropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_PropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_PropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_PropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_PropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_PropertyHolder_wrap")
-fileprivate func _bjs_PropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_PropertyHolder_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_PropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_PropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_PropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_PropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_PropertyHolder_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_PropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_PropertyHolder_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_MathUtils_static_add")
-@_cdecl("bjs_MathUtils_static_add")
-public func _bjs_MathUtils_static_add(_ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_MathUtils_static_add")
+@_cdecl("bjs_BridgeJSRuntimeTests_MathUtils_static_add")
+public func _bjs_BridgeJSRuntimeTests_MathUtils_static_add(_ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
+    let ret = BridgeJSRuntimeTests.MathUtils.add(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_static_substract")
-@_cdecl("bjs_MathUtils_static_substract")
-public func _bjs_MathUtils_static_substract(_ a: Int32, _ b: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_MathUtils_static_substract")
+@_cdecl("bjs_BridgeJSRuntimeTests_MathUtils_static_substract")
+public func _bjs_BridgeJSRuntimeTests_MathUtils_static_substract(_ a: Int32, _ b: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = MathUtils.substract(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
+    let ret = BridgeJSRuntimeTests.MathUtils.substract(a: Int.bridgeJSLiftParameter(a), b: Int.bridgeJSLiftParameter(b))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_MathUtils_deinit")
-@_cdecl("bjs_MathUtils_deinit")
-public func _bjs_MathUtils_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_MathUtils_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_MathUtils_deinit")
+public func _bjs_BridgeJSRuntimeTests_MathUtils_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<MathUtils>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.MathUtils>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension MathUtils: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.MathUtils: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_MathUtils_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_MathUtils_wrap")
-fileprivate func _bjs_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_MathUtils_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_MathUtils_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_MathUtils_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_MathUtils_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_MathUtils_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_MathUtils_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_init")
-@_cdecl("bjs_StaticPropertyHolder_init")
-public func _bjs_StaticPropertyHolder_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_init")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder()
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticConstant_get")
-@_cdecl("bjs_StaticPropertyHolder_static_staticConstant_get")
-public func _bjs_StaticPropertyHolder_static_staticConstant_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticConstant_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticConstant_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticConstant_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.staticConstant
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.staticConstant
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticVariable_get")
-@_cdecl("bjs_StaticPropertyHolder_static_staticVariable_get")
-public func _bjs_StaticPropertyHolder_static_staticVariable_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticVariable_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticVariable_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticVariable_get() -> Int32 {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.staticVariable
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.staticVariable
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticVariable_set")
-@_cdecl("bjs_StaticPropertyHolder_static_staticVariable_set")
-public func _bjs_StaticPropertyHolder_static_staticVariable_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticVariable_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticVariable_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticVariable_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyHolder.staticVariable = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.StaticPropertyHolder.staticVariable = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticString_get")
-@_cdecl("bjs_StaticPropertyHolder_static_staticString_get")
-public func _bjs_StaticPropertyHolder_static_staticString_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticString_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticString_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticString_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.staticString
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.staticString
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticString_set")
-@_cdecl("bjs_StaticPropertyHolder_static_staticString_set")
-public func _bjs_StaticPropertyHolder_static_staticString_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticString_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticString_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticString_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyHolder.staticString = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.StaticPropertyHolder.staticString = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticBool_get")
-@_cdecl("bjs_StaticPropertyHolder_static_staticBool_get")
-public func _bjs_StaticPropertyHolder_static_staticBool_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticBool_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticBool_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticBool_get() -> Int32 {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.staticBool
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.staticBool
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticBool_set")
-@_cdecl("bjs_StaticPropertyHolder_static_staticBool_set")
-public func _bjs_StaticPropertyHolder_static_staticBool_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticBool_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticBool_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticBool_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyHolder.staticBool = Bool.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.StaticPropertyHolder.staticBool = Bool.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticFloat_get")
-@_cdecl("bjs_StaticPropertyHolder_static_staticFloat_get")
-public func _bjs_StaticPropertyHolder_static_staticFloat_get() -> Float32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticFloat_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticFloat_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticFloat_get() -> Float32 {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.staticFloat
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.staticFloat
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticFloat_set")
-@_cdecl("bjs_StaticPropertyHolder_static_staticFloat_set")
-public func _bjs_StaticPropertyHolder_static_staticFloat_set(_ value: Float32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticFloat_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticFloat_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticFloat_set(_ value: Float32) -> Void {
     #if arch(wasm32)
-    StaticPropertyHolder.staticFloat = Float.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.StaticPropertyHolder.staticFloat = Float.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticDouble_get")
-@_cdecl("bjs_StaticPropertyHolder_static_staticDouble_get")
-public func _bjs_StaticPropertyHolder_static_staticDouble_get() -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticDouble_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticDouble_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticDouble_get() -> Float64 {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.staticDouble
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.staticDouble
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_staticDouble_set")
-@_cdecl("bjs_StaticPropertyHolder_static_staticDouble_set")
-public func _bjs_StaticPropertyHolder_static_staticDouble_set(_ value: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticDouble_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticDouble_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_staticDouble_set(_ value: Float64) -> Void {
     #if arch(wasm32)
-    StaticPropertyHolder.staticDouble = Double.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.StaticPropertyHolder.staticDouble = Double.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_computedProperty_get")
-@_cdecl("bjs_StaticPropertyHolder_static_computedProperty_get")
-public func _bjs_StaticPropertyHolder_static_computedProperty_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_computedProperty_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_computedProperty_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_computedProperty_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.computedProperty
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.computedProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_computedProperty_set")
-@_cdecl("bjs_StaticPropertyHolder_static_computedProperty_set")
-public func _bjs_StaticPropertyHolder_static_computedProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_computedProperty_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_computedProperty_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_computedProperty_set(_ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyHolder.computedProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
+    BridgeJSRuntimeTests.StaticPropertyHolder.computedProperty = String.bridgeJSLiftParameter(valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_readOnlyComputed_get")
-@_cdecl("bjs_StaticPropertyHolder_static_readOnlyComputed_get")
-public func _bjs_StaticPropertyHolder_static_readOnlyComputed_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_readOnlyComputed_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_readOnlyComputed_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_readOnlyComputed_get() -> Int32 {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.readOnlyComputed
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.readOnlyComputed
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_optionalString_get")
-@_cdecl("bjs_StaticPropertyHolder_static_optionalString_get")
-public func _bjs_StaticPropertyHolder_static_optionalString_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalString_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalString_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalString_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.optionalString
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.optionalString
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_optionalString_set")
-@_cdecl("bjs_StaticPropertyHolder_static_optionalString_set")
-public func _bjs_StaticPropertyHolder_static_optionalString_set(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalString_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalString_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalString_set(_ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyHolder.optionalString = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    BridgeJSRuntimeTests.StaticPropertyHolder.optionalString = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_optionalInt_get")
-@_cdecl("bjs_StaticPropertyHolder_static_optionalInt_get")
-public func _bjs_StaticPropertyHolder_static_optionalInt_get() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalInt_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalInt_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalInt_get() -> Void {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.optionalInt
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.optionalInt
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_optionalInt_set")
-@_cdecl("bjs_StaticPropertyHolder_static_optionalInt_set")
-public func _bjs_StaticPropertyHolder_static_optionalInt_set(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalInt_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalInt_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_optionalInt_set(_ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyHolder.optionalInt = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.StaticPropertyHolder.optionalInt = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_jsObjectProperty_get")
-@_cdecl("bjs_StaticPropertyHolder_static_jsObjectProperty_get")
-public func _bjs_StaticPropertyHolder_static_jsObjectProperty_get() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_jsObjectProperty_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_jsObjectProperty_get")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_jsObjectProperty_get() -> Int32 {
     #if arch(wasm32)
-    let ret = StaticPropertyHolder.jsObjectProperty
+    let ret = BridgeJSRuntimeTests.StaticPropertyHolder.jsObjectProperty
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_static_jsObjectProperty_set")
-@_cdecl("bjs_StaticPropertyHolder_static_jsObjectProperty_set")
-public func _bjs_StaticPropertyHolder_static_jsObjectProperty_set(_ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_jsObjectProperty_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_jsObjectProperty_set")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_static_jsObjectProperty_set(_ value: Int32) -> Void {
     #if arch(wasm32)
-    StaticPropertyHolder.jsObjectProperty = JSObject.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.StaticPropertyHolder.jsObjectProperty = JSObject.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_StaticPropertyHolder_deinit")
-@_cdecl("bjs_StaticPropertyHolder_deinit")
-public func _bjs_StaticPropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_StaticPropertyHolder_deinit")
+public func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<StaticPropertyHolder>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.StaticPropertyHolder>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension StaticPropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.StaticPropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_StaticPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_StaticPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_StaticPropertyHolder_wrap")
-fileprivate func _bjs_StaticPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_StaticPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_StaticPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_StaticPropertyHolder_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_StaticPropertyHolder_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_init")
-@_cdecl("bjs_DataProcessorManager_init")
-public func _bjs_DataProcessorManager_init(_ processor: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_init")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_init(_ processor: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = DataProcessorManager(processor: AnyDataProcessor.bridgeJSLiftParameter(processor))
+    let ret = BridgeJSRuntimeTests.DataProcessorManager(processor: AnyDataProcessor.bridgeJSLiftParameter(processor))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_incrementByAmount")
-@_cdecl("bjs_DataProcessorManager_incrementByAmount")
-public func _bjs_DataProcessorManager_incrementByAmount(_ _self: UnsafeMutableRawPointer, _ amount: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_incrementByAmount")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_incrementByAmount")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_incrementByAmount(_ _self: UnsafeMutableRawPointer, _ amount: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).incrementByAmount(_: Int.bridgeJSLiftParameter(amount))
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).incrementByAmount(_: Int.bridgeJSLiftParameter(amount))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_setProcessorLabel")
-@_cdecl("bjs_DataProcessorManager_setProcessorLabel")
-public func _bjs_DataProcessorManager_setProcessorLabel(_ _self: UnsafeMutableRawPointer, _ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorLabel")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorLabel")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorLabel(_ _self: UnsafeMutableRawPointer, _ prefixBytes: Int32, _ prefixLength: Int32, _ suffixBytes: Int32, _ suffixLength: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorLabel(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength), _: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorLabel(_: String.bridgeJSLiftParameter(prefixBytes, prefixLength), _: String.bridgeJSLiftParameter(suffixBytes, suffixLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_isProcessorEven")
-@_cdecl("bjs_DataProcessorManager_isProcessorEven")
-public func _bjs_DataProcessorManager_isProcessorEven(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_isProcessorEven")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_isProcessorEven")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_isProcessorEven(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).isProcessorEven()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).isProcessorEven()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_getProcessorLabel")
-@_cdecl("bjs_DataProcessorManager_getProcessorLabel")
-public func _bjs_DataProcessorManager_getProcessorLabel(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorLabel")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorLabel")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorLabel(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorLabel()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorLabel()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_getCurrentValue")
-@_cdecl("bjs_DataProcessorManager_getCurrentValue")
-public func _bjs_DataProcessorManager_getCurrentValue(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_getCurrentValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_getCurrentValue")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_getCurrentValue(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getCurrentValue()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).getCurrentValue()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_incrementBoth")
-@_cdecl("bjs_DataProcessorManager_incrementBoth")
-public func _bjs_DataProcessorManager_incrementBoth(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_incrementBoth")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_incrementBoth")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_incrementBoth(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).incrementBoth()
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).incrementBoth()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_getBackupValue")
-@_cdecl("bjs_DataProcessorManager_getBackupValue")
-public func _bjs_DataProcessorManager_getBackupValue(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_getBackupValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_getBackupValue")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_getBackupValue(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getBackupValue()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).getBackupValue()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_hasBackup")
-@_cdecl("bjs_DataProcessorManager_hasBackup")
-public func _bjs_DataProcessorManager_hasBackup(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_hasBackup")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_hasBackup")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_hasBackup(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).hasBackup()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).hasBackup()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_getProcessorOptionalTag")
-@_cdecl("bjs_DataProcessorManager_getProcessorOptionalTag")
-public func _bjs_DataProcessorManager_getProcessorOptionalTag(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorOptionalTag")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorOptionalTag")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorOptionalTag(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorOptionalTag()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorOptionalTag()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_setProcessorOptionalTag")
-@_cdecl("bjs_DataProcessorManager_setProcessorOptionalTag")
-public func _bjs_DataProcessorManager_setProcessorOptionalTag(_ _self: UnsafeMutableRawPointer, _ tagIsSome: Int32, _ tagBytes: Int32, _ tagLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorOptionalTag")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorOptionalTag")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorOptionalTag(_ _self: UnsafeMutableRawPointer, _ tagIsSome: Int32, _ tagBytes: Int32, _ tagLength: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorOptionalTag(_: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorOptionalTag(_: Optional<String>.bridgeJSLiftParameter(tagIsSome, tagBytes, tagLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_getProcessorOptionalCount")
-@_cdecl("bjs_DataProcessorManager_getProcessorOptionalCount")
-public func _bjs_DataProcessorManager_getProcessorOptionalCount(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorOptionalCount")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorOptionalCount")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorOptionalCount(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorOptionalCount()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorOptionalCount()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_setProcessorOptionalCount")
-@_cdecl("bjs_DataProcessorManager_setProcessorOptionalCount")
-public func _bjs_DataProcessorManager_setProcessorOptionalCount(_ _self: UnsafeMutableRawPointer, _ countIsSome: Int32, _ countValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorOptionalCount")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorOptionalCount")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorOptionalCount(_ _self: UnsafeMutableRawPointer, _ countIsSome: Int32, _ countValue: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorOptionalCount(_: Optional<Int>.bridgeJSLiftParameter(countIsSome, countValue))
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorOptionalCount(_: Optional<Int>.bridgeJSLiftParameter(countIsSome, countValue))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_getProcessorDirection")
-@_cdecl("bjs_DataProcessorManager_getProcessorDirection")
-public func _bjs_DataProcessorManager_getProcessorDirection(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorDirection")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorDirection(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorDirection()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorDirection()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_setProcessorDirection")
-@_cdecl("bjs_DataProcessorManager_setProcessorDirection")
-public func _bjs_DataProcessorManager_setProcessorDirection(_ _self: UnsafeMutableRawPointer, _ directionIsSome: Int32, _ directionValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorDirection")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorDirection(_ _self: UnsafeMutableRawPointer, _ directionIsSome: Int32, _ directionValue: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorDirection(_: Optional<Direction>.bridgeJSLiftParameter(directionIsSome, directionValue))
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorDirection(_: Optional<BridgeJSRuntimeTests.Direction>.bridgeJSLiftParameter(directionIsSome, directionValue))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_getProcessorTheme")
-@_cdecl("bjs_DataProcessorManager_getProcessorTheme")
-public func _bjs_DataProcessorManager_getProcessorTheme(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorTheme")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorTheme(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorTheme()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorTheme()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_setProcessorTheme")
-@_cdecl("bjs_DataProcessorManager_setProcessorTheme")
-public func _bjs_DataProcessorManager_setProcessorTheme(_ _self: UnsafeMutableRawPointer, _ themeIsSome: Int32, _ themeBytes: Int32, _ themeLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorTheme")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorTheme(_ _self: UnsafeMutableRawPointer, _ themeIsSome: Int32, _ themeBytes: Int32, _ themeLength: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorTheme(_: Optional<Theme>.bridgeJSLiftParameter(themeIsSome, themeBytes, themeLength))
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorTheme(_: Optional<BridgeJSRuntimeTests.Theme>.bridgeJSLiftParameter(themeIsSome, themeBytes, themeLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_getProcessorHttpStatus")
-@_cdecl("bjs_DataProcessorManager_getProcessorHttpStatus")
-public func _bjs_DataProcessorManager_getProcessorHttpStatus(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorHttpStatus")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorHttpStatus")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorHttpStatus(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorHttpStatus()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorHttpStatus()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_setProcessorHttpStatus")
-@_cdecl("bjs_DataProcessorManager_setProcessorHttpStatus")
-public func _bjs_DataProcessorManager_setProcessorHttpStatus(_ _self: UnsafeMutableRawPointer, _ statusIsSome: Int32, _ statusValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorHttpStatus")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorHttpStatus")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorHttpStatus(_ _self: UnsafeMutableRawPointer, _ statusIsSome: Int32, _ statusValue: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorHttpStatus(_: Optional<HttpStatus>.bridgeJSLiftParameter(statusIsSome, statusValue))
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorHttpStatus(_: Optional<BridgeJSRuntimeTests.HttpStatus>.bridgeJSLiftParameter(statusIsSome, statusValue))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_getProcessorAPIResult")
-@_cdecl("bjs_DataProcessorManager_getProcessorAPIResult")
-public func _bjs_DataProcessorManager_getProcessorAPIResult(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorAPIResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorAPIResult")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorAPIResult(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorAPIResult()
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).getProcessorAPIResult()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_setProcessorAPIResult")
-@_cdecl("bjs_DataProcessorManager_setProcessorAPIResult")
-public func _bjs_DataProcessorManager_setProcessorAPIResult(_ _self: UnsafeMutableRawPointer, _ apiResultIsSome: Int32, _ apiResultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorAPIResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorAPIResult")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorAPIResult(_ _self: UnsafeMutableRawPointer, _ apiResultIsSome: Int32, _ apiResultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorAPIResult(_: Optional<APIResult>.bridgeJSLiftParameter(apiResultIsSome, apiResultCaseId))
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).setProcessorAPIResult(_: Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftParameter(apiResultIsSome, apiResultCaseId))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_processor_get")
-@_cdecl("bjs_DataProcessorManager_processor_get")
-public func _bjs_DataProcessorManager_processor_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_processor_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_processor_get")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_processor_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).processor as! _BridgedSwiftProtocolExportable
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).processor as! _BridgedSwiftProtocolExportable
     return ret.bridgeJSLowerAsProtocolReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_processor_set")
-@_cdecl("bjs_DataProcessorManager_processor_set")
-public func _bjs_DataProcessorManager_processor_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_processor_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_processor_set")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_processor_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).processor = AnyDataProcessor.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).processor = AnyDataProcessor.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_backupProcessor_get")
-@_cdecl("bjs_DataProcessorManager_backupProcessor_get")
-public func _bjs_DataProcessorManager_backupProcessor_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_backupProcessor_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_backupProcessor_get")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_backupProcessor_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = DataProcessorManager.bridgeJSLiftParameter(_self).backupProcessor
+    let ret = BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).backupProcessor
     if let ret {
         _swift_js_return_optional_object(1, (ret as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
     } else {
@@ -12134,423 +12134,423 @@ public func _bjs_DataProcessorManager_backupProcessor_get(_ _self: UnsafeMutable
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_backupProcessor_set")
-@_cdecl("bjs_DataProcessorManager_backupProcessor_set")
-public func _bjs_DataProcessorManager_backupProcessor_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_backupProcessor_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_backupProcessor_set")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_backupProcessor_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
-    DataProcessorManager.bridgeJSLiftParameter(_self).backupProcessor = Optional<AnyDataProcessor>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.DataProcessorManager.bridgeJSLiftParameter(_self).backupProcessor = Optional<AnyDataProcessor>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_DataProcessorManager_deinit")
-@_cdecl("bjs_DataProcessorManager_deinit")
-public func _bjs_DataProcessorManager_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_DataProcessorManager_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_DataProcessorManager_deinit")
+public func _bjs_BridgeJSRuntimeTests_DataProcessorManager_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<DataProcessorManager>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.DataProcessorManager>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension DataProcessorManager: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.DataProcessorManager: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_DataProcessorManager_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_DataProcessorManager_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_DataProcessorManager_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_DataProcessorManager_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_DataProcessorManager_wrap")
-fileprivate func _bjs_DataProcessorManager_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_DataProcessorManager_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_DataProcessorManager_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_DataProcessorManager_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_DataProcessorManager_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_DataProcessorManager_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_DataProcessorManager_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_DataProcessorManager_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_DataProcessorManager_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_init")
-@_cdecl("bjs_SwiftDataProcessor_init")
-public func _bjs_SwiftDataProcessor_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_init")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor()
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_increment")
-@_cdecl("bjs_SwiftDataProcessor_increment")
-public func _bjs_SwiftDataProcessor_increment(_ _self: UnsafeMutableRawPointer, _ amount: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_increment")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_increment")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_increment(_ _self: UnsafeMutableRawPointer, _ amount: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).increment(by: Int.bridgeJSLiftParameter(amount))
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).increment(by: Int.bridgeJSLiftParameter(amount))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_getValue")
-@_cdecl("bjs_SwiftDataProcessor_getValue")
-public func _bjs_SwiftDataProcessor_getValue(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getValue")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getValue")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getValue(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).getValue()
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).getValue()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_setLabelElements")
-@_cdecl("bjs_SwiftDataProcessor_setLabelElements")
-public func _bjs_SwiftDataProcessor_setLabelElements(_ _self: UnsafeMutableRawPointer, _ labelPrefixBytes: Int32, _ labelPrefixLength: Int32, _ labelSuffixBytes: Int32, _ labelSuffixLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_setLabelElements")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_setLabelElements")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_setLabelElements(_ _self: UnsafeMutableRawPointer, _ labelPrefixBytes: Int32, _ labelPrefixLength: Int32, _ labelSuffixBytes: Int32, _ labelSuffixLength: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).setLabelElements(_: String.bridgeJSLiftParameter(labelPrefixBytes, labelPrefixLength), _: String.bridgeJSLiftParameter(labelSuffixBytes, labelSuffixLength))
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).setLabelElements(_: String.bridgeJSLiftParameter(labelPrefixBytes, labelPrefixLength), _: String.bridgeJSLiftParameter(labelSuffixBytes, labelSuffixLength))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_getLabel")
-@_cdecl("bjs_SwiftDataProcessor_getLabel")
-public func _bjs_SwiftDataProcessor_getLabel(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getLabel")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getLabel")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getLabel(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).getLabel()
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).getLabel()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_isEven")
-@_cdecl("bjs_SwiftDataProcessor_isEven")
-public func _bjs_SwiftDataProcessor_isEven(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_isEven")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_isEven")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_isEven(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).isEven()
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).isEven()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_processGreeter")
-@_cdecl("bjs_SwiftDataProcessor_processGreeter")
-public func _bjs_SwiftDataProcessor_processGreeter(_ _self: UnsafeMutableRawPointer, _ greeter: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_processGreeter")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_processGreeter")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_processGreeter(_ _self: UnsafeMutableRawPointer, _ greeter: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).processGreeter(_: Greeter.bridgeJSLiftParameter(greeter))
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).processGreeter(_: BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(greeter))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_createGreeter")
-@_cdecl("bjs_SwiftDataProcessor_createGreeter")
-public func _bjs_SwiftDataProcessor_createGreeter(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_createGreeter")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_createGreeter")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_createGreeter(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).createGreeter()
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).createGreeter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_processOptionalGreeter")
-@_cdecl("bjs_SwiftDataProcessor_processOptionalGreeter")
-public func _bjs_SwiftDataProcessor_processOptionalGreeter(_ _self: UnsafeMutableRawPointer, _ greeterIsSome: Int32, _ greeterValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_processOptionalGreeter")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_processOptionalGreeter")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_processOptionalGreeter(_ _self: UnsafeMutableRawPointer, _ greeterIsSome: Int32, _ greeterValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).processOptionalGreeter(_: Optional<Greeter>.bridgeJSLiftParameter(greeterIsSome, greeterValue))
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).processOptionalGreeter(_: Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(greeterIsSome, greeterValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_createOptionalGreeter")
-@_cdecl("bjs_SwiftDataProcessor_createOptionalGreeter")
-public func _bjs_SwiftDataProcessor_createOptionalGreeter(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_createOptionalGreeter")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_createOptionalGreeter")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_createOptionalGreeter(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).createOptionalGreeter()
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).createOptionalGreeter()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_handleAPIResult")
-@_cdecl("bjs_SwiftDataProcessor_handleAPIResult")
-public func _bjs_SwiftDataProcessor_handleAPIResult(_ _self: UnsafeMutableRawPointer, _ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_handleAPIResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_handleAPIResult")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_handleAPIResult(_ _self: UnsafeMutableRawPointer, _ resultIsSome: Int32, _ resultCaseId: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).handleAPIResult(_: Optional<APIResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).handleAPIResult(_: Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftParameter(resultIsSome, resultCaseId))
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_getAPIResult")
-@_cdecl("bjs_SwiftDataProcessor_getAPIResult")
-public func _bjs_SwiftDataProcessor_getAPIResult(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getAPIResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getAPIResult")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getAPIResult(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).getAPIResult()
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).getAPIResult()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_count_get")
-@_cdecl("bjs_SwiftDataProcessor_count_get")
-public func _bjs_SwiftDataProcessor_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_count_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_count_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_count_get(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).count
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).count
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_count_set")
-@_cdecl("bjs_SwiftDataProcessor_count_set")
-public func _bjs_SwiftDataProcessor_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_count_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_count_set")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_count_set(_ _self: UnsafeMutableRawPointer, _ value: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).count = Int.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_name_get")
-@_cdecl("bjs_SwiftDataProcessor_name_get")
-public func _bjs_SwiftDataProcessor_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_name_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_name_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_name_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).name
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).name
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_optionalTag_get")
-@_cdecl("bjs_SwiftDataProcessor_optionalTag_get")
-public func _bjs_SwiftDataProcessor_optionalTag_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTag_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTag_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTag_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalTag
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalTag
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_optionalTag_set")
-@_cdecl("bjs_SwiftDataProcessor_optionalTag_set")
-public func _bjs_SwiftDataProcessor_optionalTag_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTag_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTag_set")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTag_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalTag = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalTag = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_optionalCount_get")
-@_cdecl("bjs_SwiftDataProcessor_optionalCount_get")
-public func _bjs_SwiftDataProcessor_optionalCount_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalCount_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalCount_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalCount_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalCount
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalCount
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_optionalCount_set")
-@_cdecl("bjs_SwiftDataProcessor_optionalCount_set")
-public func _bjs_SwiftDataProcessor_optionalCount_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalCount_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalCount_set")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalCount_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalCount = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalCount = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_direction_get")
-@_cdecl("bjs_SwiftDataProcessor_direction_get")
-public func _bjs_SwiftDataProcessor_direction_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_direction_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_direction_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_direction_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).direction
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).direction
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_direction_set")
-@_cdecl("bjs_SwiftDataProcessor_direction_set")
-public func _bjs_SwiftDataProcessor_direction_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_direction_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_direction_set")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_direction_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).direction = Optional<Direction>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).direction = Optional<BridgeJSRuntimeTests.Direction>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_optionalTheme_get")
-@_cdecl("bjs_SwiftDataProcessor_optionalTheme_get")
-public func _bjs_SwiftDataProcessor_optionalTheme_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTheme_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTheme_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTheme_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalTheme
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalTheme
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_optionalTheme_set")
-@_cdecl("bjs_SwiftDataProcessor_optionalTheme_set")
-public func _bjs_SwiftDataProcessor_optionalTheme_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTheme_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTheme_set")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalTheme_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalTheme = Optional<Theme>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalTheme = Optional<BridgeJSRuntimeTests.Theme>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_httpStatus_get")
-@_cdecl("bjs_SwiftDataProcessor_httpStatus_get")
-public func _bjs_SwiftDataProcessor_httpStatus_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_httpStatus_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_httpStatus_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_httpStatus_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).httpStatus
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).httpStatus
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_httpStatus_set")
-@_cdecl("bjs_SwiftDataProcessor_httpStatus_set")
-public func _bjs_SwiftDataProcessor_httpStatus_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_httpStatus_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_httpStatus_set")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_httpStatus_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).httpStatus = Optional<HttpStatus>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).httpStatus = Optional<BridgeJSRuntimeTests.HttpStatus>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_apiResult_get")
-@_cdecl("bjs_SwiftDataProcessor_apiResult_get")
-public func _bjs_SwiftDataProcessor_apiResult_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_apiResult_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_apiResult_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_apiResult_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).apiResult
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).apiResult
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_apiResult_set")
-@_cdecl("bjs_SwiftDataProcessor_apiResult_set")
-public func _bjs_SwiftDataProcessor_apiResult_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_apiResult_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_apiResult_set")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_apiResult_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).apiResult = Optional<APIResult>.bridgeJSLiftParameter(valueIsSome, valueCaseId)
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).apiResult = Optional<BridgeJSRuntimeTests.APIResult>.bridgeJSLiftParameter(valueIsSome, valueCaseId)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_helper_get")
-@_cdecl("bjs_SwiftDataProcessor_helper_get")
-public func _bjs_SwiftDataProcessor_helper_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_helper_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_helper_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_helper_get(_ _self: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).helper
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).helper
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_helper_set")
-@_cdecl("bjs_SwiftDataProcessor_helper_set")
-public func _bjs_SwiftDataProcessor_helper_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_helper_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_helper_set")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_helper_set(_ _self: UnsafeMutableRawPointer, _ value: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).helper = Greeter.bridgeJSLiftParameter(value)
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).helper = BridgeJSRuntimeTests.Greeter.bridgeJSLiftParameter(value)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_optionalHelper_get")
-@_cdecl("bjs_SwiftDataProcessor_optionalHelper_get")
-public func _bjs_SwiftDataProcessor_optionalHelper_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalHelper_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalHelper_get")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalHelper_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalHelper
+    let ret = BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalHelper
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_optionalHelper_set")
-@_cdecl("bjs_SwiftDataProcessor_optionalHelper_set")
-public func _bjs_SwiftDataProcessor_optionalHelper_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalHelper_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalHelper_set")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_optionalHelper_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalHelper = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.SwiftDataProcessor.bridgeJSLiftParameter(_self).optionalHelper = Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_SwiftDataProcessor_deinit")
-@_cdecl("bjs_SwiftDataProcessor_deinit")
-public func _bjs_SwiftDataProcessor_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_SwiftDataProcessor_deinit")
+public func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<SwiftDataProcessor>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.SwiftDataProcessor>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension SwiftDataProcessor: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.SwiftDataProcessor: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_SwiftDataProcessor_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_SwiftDataProcessor_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_SwiftDataProcessor_wrap")
-fileprivate func _bjs_SwiftDataProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_SwiftDataProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_SwiftDataProcessor_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_SwiftDataProcessor_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_SwiftDataProcessor_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_ProtocolReturnTests_static_createNativeProcessor")
-@_cdecl("bjs_ProtocolReturnTests_static_createNativeProcessor")
-public func _bjs_ProtocolReturnTests_static_createNativeProcessor() -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessor")
+@_cdecl("bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessor")
+public func _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessor() -> Int32 {
     #if arch(wasm32)
-    let ret = ProtocolReturnTests.createNativeProcessor() as! _BridgedSwiftProtocolExportable
+    let ret = BridgeJSRuntimeTests.ProtocolReturnTests.createNativeProcessor() as! _BridgedSwiftProtocolExportable
     return ret.bridgeJSLowerAsProtocolReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_ProtocolReturnTests_static_createNativeProcessorOptional")
-@_cdecl("bjs_ProtocolReturnTests_static_createNativeProcessorOptional")
-public func _bjs_ProtocolReturnTests_static_createNativeProcessorOptional() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorOptional")
+@_cdecl("bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorOptional")
+public func _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorOptional() -> Void {
     #if arch(wasm32)
-    let ret = ProtocolReturnTests.createNativeProcessorOptional()
+    let ret = BridgeJSRuntimeTests.ProtocolReturnTests.createNativeProcessorOptional()
     if let ret {
         _swift_js_return_optional_object(1, (ret as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
     } else {
@@ -12561,11 +12561,11 @@ public func _bjs_ProtocolReturnTests_static_createNativeProcessorOptional() -> V
     #endif
 }
 
-@_expose(wasm, "bjs_ProtocolReturnTests_static_createNativeProcessorNil")
-@_cdecl("bjs_ProtocolReturnTests_static_createNativeProcessorNil")
-public func _bjs_ProtocolReturnTests_static_createNativeProcessorNil() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorNil")
+@_cdecl("bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorNil")
+public func _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorNil() -> Void {
     #if arch(wasm32)
-    let ret = ProtocolReturnTests.createNativeProcessorNil()
+    let ret = BridgeJSRuntimeTests.ProtocolReturnTests.createNativeProcessorNil()
     if let ret {
         _swift_js_return_optional_object(1, (ret as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
     } else {
@@ -12576,11 +12576,11 @@ public func _bjs_ProtocolReturnTests_static_createNativeProcessorNil() -> Void {
     #endif
 }
 
-@_expose(wasm, "bjs_ProtocolReturnTests_static_createNativeProcessorArray")
-@_cdecl("bjs_ProtocolReturnTests_static_createNativeProcessorArray")
-public func _bjs_ProtocolReturnTests_static_createNativeProcessorArray() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorArray")
+@_cdecl("bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorArray")
+public func _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorArray() -> Void {
     #if arch(wasm32)
-    let ret = ProtocolReturnTests.createNativeProcessorArray()
+    let ret = BridgeJSRuntimeTests.ProtocolReturnTests.createNativeProcessorArray()
     for __bjs_elem_ret in ret {
         _swift_js_push_i32((__bjs_elem_ret as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
     }
@@ -12590,11 +12590,11 @@ public func _bjs_ProtocolReturnTests_static_createNativeProcessorArray() -> Void
     #endif
 }
 
-@_expose(wasm, "bjs_ProtocolReturnTests_static_createNativeProcessorDictionary")
-@_cdecl("bjs_ProtocolReturnTests_static_createNativeProcessorDictionary")
-public func _bjs_ProtocolReturnTests_static_createNativeProcessorDictionary() -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorDictionary")
+@_cdecl("bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorDictionary")
+public func _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorDictionary() -> Void {
     #if arch(wasm32)
-    let ret = ProtocolReturnTests.createNativeProcessorDictionary()
+    let ret = BridgeJSRuntimeTests.ProtocolReturnTests.createNativeProcessorDictionary()
     for __bjs_kv_ret in ret {
         __bjs_kv_ret.key.bridgeJSStackPush()
         _swift_js_push_i32((__bjs_kv_ret.value as! _BridgedSwiftProtocolExportable).bridgeJSLowerAsProtocolReturn())
@@ -12605,733 +12605,733 @@ public func _bjs_ProtocolReturnTests_static_createNativeProcessorDictionary() ->
     #endif
 }
 
-@_expose(wasm, "bjs_ProtocolReturnTests_deinit")
-@_cdecl("bjs_ProtocolReturnTests_deinit")
-public func _bjs_ProtocolReturnTests_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_ProtocolReturnTests_deinit")
+public func _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<ProtocolReturnTests>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.ProtocolReturnTests>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension ProtocolReturnTests: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.ProtocolReturnTests: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_ProtocolReturnTests_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_ProtocolReturnTests_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_ProtocolReturnTests_wrap")
-fileprivate func _bjs_ProtocolReturnTests_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_ProtocolReturnTests_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_ProtocolReturnTests_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_ProtocolReturnTests_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_ProtocolReturnTests_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_TextProcessor_init")
-@_cdecl("bjs_TextProcessor_init")
-public func _bjs_TextProcessor_init(_ transform: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_init")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_init(_ transform: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = TextProcessor(transform: _BJS_Closure_20BridgeJSRuntimeTestsSS_SS.bridgeJSLift(transform))
+    let ret = BridgeJSRuntimeTests.TextProcessor(transform: _BJS_Closure_20BridgeJSRuntimeTestsSS_SS.bridgeJSLift(transform))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_process")
-@_cdecl("bjs_TextProcessor_process")
-public func _bjs_TextProcessor_process(_ _self: UnsafeMutableRawPointer, _ textBytes: Int32, _ textLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_process")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_process")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_process(_ _self: UnsafeMutableRawPointer, _ textBytes: Int32, _ textLength: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).process(_: String.bridgeJSLiftParameter(textBytes, textLength))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).process(_: String.bridgeJSLiftParameter(textBytes, textLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processWithCustom")
-@_cdecl("bjs_TextProcessor_processWithCustom")
-public func _bjs_TextProcessor_processWithCustom(_ _self: UnsafeMutableRawPointer, _ textBytes: Int32, _ textLength: Int32, _ customTransform: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processWithCustom")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processWithCustom")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processWithCustom(_ _self: UnsafeMutableRawPointer, _ textBytes: Int32, _ textLength: Int32, _ customTransform: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processWithCustom(_: String.bridgeJSLiftParameter(textBytes, textLength), customTransform: _BJS_Closure_20BridgeJSRuntimeTestsSiSSSd_SS.bridgeJSLift(customTransform))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processWithCustom(_: String.bridgeJSLiftParameter(textBytes, textLength), customTransform: _BJS_Closure_20BridgeJSRuntimeTestsSiSSSd_SS.bridgeJSLift(customTransform))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_getTransform")
-@_cdecl("bjs_TextProcessor_getTransform")
-public func _bjs_TextProcessor_getTransform(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_getTransform")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_getTransform")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_getTransform(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).getTransform()
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).getTransform()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processOptionalString")
-@_cdecl("bjs_TextProcessor_processOptionalString")
-public func _bjs_TextProcessor_processOptionalString(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalString")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalString")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalString(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalString(_: _BJS_Closure_20BridgeJSRuntimeTestsSqSS_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processOptionalString(_: _BJS_Closure_20BridgeJSRuntimeTestsSqSS_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processOptionalInt")
-@_cdecl("bjs_TextProcessor_processOptionalInt")
-public func _bjs_TextProcessor_processOptionalInt(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalInt")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalInt")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalInt(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalInt(_: _BJS_Closure_20BridgeJSRuntimeTestsSqSi_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processOptionalInt(_: _BJS_Closure_20BridgeJSRuntimeTestsSqSi_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processOptionalGreeter")
-@_cdecl("bjs_TextProcessor_processOptionalGreeter")
-public func _bjs_TextProcessor_processOptionalGreeter(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalGreeter")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalGreeter")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalGreeter(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalGreeter(_: _BJS_Closure_20BridgeJSRuntimeTestsSq7GreeterC_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processOptionalGreeter(_: _BJS_Closure_20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_makeOptionalStringFormatter")
-@_cdecl("bjs_TextProcessor_makeOptionalStringFormatter")
-public func _bjs_TextProcessor_makeOptionalStringFormatter(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalStringFormatter")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalStringFormatter")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalStringFormatter(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).makeOptionalStringFormatter()
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).makeOptionalStringFormatter()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_makeOptionalGreeterCreator")
-@_cdecl("bjs_TextProcessor_makeOptionalGreeterCreator")
-public func _bjs_TextProcessor_makeOptionalGreeterCreator(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalGreeterCreator")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalGreeterCreator")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalGreeterCreator(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).makeOptionalGreeterCreator()
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).makeOptionalGreeterCreator()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processDirection")
-@_cdecl("bjs_TextProcessor_processDirection")
-public func _bjs_TextProcessor_processDirection(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processDirection")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processDirection(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processDirection(_: _BJS_Closure_20BridgeJSRuntimeTests9DirectionO_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processDirection(_: _BJS_Closure_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processTheme")
-@_cdecl("bjs_TextProcessor_processTheme")
-public func _bjs_TextProcessor_processTheme(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processTheme")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processTheme(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processTheme(_: _BJS_Closure_20BridgeJSRuntimeTests5ThemeO_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processTheme(_: _BJS_Closure_20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processHttpStatus")
-@_cdecl("bjs_TextProcessor_processHttpStatus")
-public func _bjs_TextProcessor_processHttpStatus(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processHttpStatus")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processHttpStatus")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processHttpStatus(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processHttpStatus(_: _BJS_Closure_20BridgeJSRuntimeTests10HttpStatusO_Si.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processHttpStatus(_: _BJS_Closure_20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processAPIResult")
-@_cdecl("bjs_TextProcessor_processAPIResult")
-public func _bjs_TextProcessor_processAPIResult(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processAPIResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processAPIResult")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processAPIResult(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processAPIResult(_: _BJS_Closure_20BridgeJSRuntimeTests9APIResultO_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processAPIResult(_: _BJS_Closure_20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_makeDirectionChecker")
-@_cdecl("bjs_TextProcessor_makeDirectionChecker")
-public func _bjs_TextProcessor_makeDirectionChecker(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_makeDirectionChecker")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_makeDirectionChecker")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_makeDirectionChecker(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).makeDirectionChecker()
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).makeDirectionChecker()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_makeThemeValidator")
-@_cdecl("bjs_TextProcessor_makeThemeValidator")
-public func _bjs_TextProcessor_makeThemeValidator(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_makeThemeValidator")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_makeThemeValidator")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_makeThemeValidator(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).makeThemeValidator()
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).makeThemeValidator()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_makeStatusCodeExtractor")
-@_cdecl("bjs_TextProcessor_makeStatusCodeExtractor")
-public func _bjs_TextProcessor_makeStatusCodeExtractor(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_makeStatusCodeExtractor")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_makeStatusCodeExtractor")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_makeStatusCodeExtractor(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).makeStatusCodeExtractor()
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).makeStatusCodeExtractor()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_makeAPIResultHandler")
-@_cdecl("bjs_TextProcessor_makeAPIResultHandler")
-public func _bjs_TextProcessor_makeAPIResultHandler(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_makeAPIResultHandler")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_makeAPIResultHandler")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_makeAPIResultHandler(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).makeAPIResultHandler()
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).makeAPIResultHandler()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processOptionalDirection")
-@_cdecl("bjs_TextProcessor_processOptionalDirection")
-public func _bjs_TextProcessor_processOptionalDirection(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalDirection")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalDirection")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalDirection(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalDirection(_: _BJS_Closure_20BridgeJSRuntimeTestsSq9DirectionO_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processOptionalDirection(_: _BJS_Closure_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processOptionalTheme")
-@_cdecl("bjs_TextProcessor_processOptionalTheme")
-public func _bjs_TextProcessor_processOptionalTheme(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalTheme")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalTheme")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalTheme(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalTheme(_: _BJS_Closure_20BridgeJSRuntimeTestsSq5ThemeO_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processOptionalTheme(_: _BJS_Closure_20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processOptionalAPIResult")
-@_cdecl("bjs_TextProcessor_processOptionalAPIResult")
-public func _bjs_TextProcessor_processOptionalAPIResult(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalAPIResult")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalAPIResult")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalAPIResult(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalAPIResult(_: _BJS_Closure_20BridgeJSRuntimeTestsSq9APIResultO_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processOptionalAPIResult(_: _BJS_Closure_20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_makeOptionalDirectionFormatter")
-@_cdecl("bjs_TextProcessor_makeOptionalDirectionFormatter")
-public func _bjs_TextProcessor_makeOptionalDirectionFormatter(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalDirectionFormatter")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalDirectionFormatter")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalDirectionFormatter(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).makeOptionalDirectionFormatter()
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).makeOptionalDirectionFormatter()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processDataProcessor")
-@_cdecl("bjs_TextProcessor_processDataProcessor")
-public func _bjs_TextProcessor_processDataProcessor(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processDataProcessor")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processDataProcessor")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processDataProcessor(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processDataProcessor(_: _BJS_Closure_20BridgeJSRuntimeTests13DataProcessorP_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processDataProcessor(_: _BJS_Closure_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_makeDataProcessorFactory")
-@_cdecl("bjs_TextProcessor_makeDataProcessorFactory")
-public func _bjs_TextProcessor_makeDataProcessorFactory(_ _self: UnsafeMutableRawPointer) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_makeDataProcessorFactory")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_makeDataProcessorFactory")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_makeDataProcessorFactory(_ _self: UnsafeMutableRawPointer) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).makeDataProcessorFactory()
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).makeDataProcessorFactory()
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_roundtripDataProcessor")
-@_cdecl("bjs_TextProcessor_roundtripDataProcessor")
-public func _bjs_TextProcessor_roundtripDataProcessor(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Int32 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_roundtripDataProcessor")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_roundtripDataProcessor")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_roundtripDataProcessor(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Int32 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).roundtripDataProcessor(_: _BJS_Closure_20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).roundtripDataProcessor(_: _BJS_Closure_20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP.bridgeJSLift(callback))
     return JSTypedClosure(ret).bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processOptionalDataProcessor")
-@_cdecl("bjs_TextProcessor_processOptionalDataProcessor")
-public func _bjs_TextProcessor_processOptionalDataProcessor(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalDataProcessor")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalDataProcessor")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalDataProcessor(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalDataProcessor(_: _BJS_Closure_20BridgeJSRuntimeTestsSq13DataProcessorP_SS.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processOptionalDataProcessor(_: _BJS_Closure_20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processVector")
-@_cdecl("bjs_TextProcessor_processVector")
-public func _bjs_TextProcessor_processVector(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Float64 {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processVector")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processVector")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processVector(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Float64 {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processVector(_: _BJS_Closure_20BridgeJSRuntimeTestsSd_8Vector2DV.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processVector(_: _BJS_Closure_20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_processOptionalVector")
-@_cdecl("bjs_TextProcessor_processOptionalVector")
-public func _bjs_TextProcessor_processOptionalVector(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalVector")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalVector")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalVector(_ _self: UnsafeMutableRawPointer, _ callback: Int32) -> Void {
     #if arch(wasm32)
-    let ret = TextProcessor.bridgeJSLiftParameter(_self).processOptionalVector(_: _BJS_Closure_20BridgeJSRuntimeTestsSd_Sq8Vector2DV.bridgeJSLift(callback))
+    let ret = BridgeJSRuntimeTests.TextProcessor.bridgeJSLiftParameter(_self).processOptionalVector(_: _BJS_Closure_20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV.bridgeJSLift(callback))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_TextProcessor_deinit")
-@_cdecl("bjs_TextProcessor_deinit")
-public func _bjs_TextProcessor_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_TextProcessor_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_TextProcessor_deinit")
+public func _bjs_BridgeJSRuntimeTests_TextProcessor_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<TextProcessor>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.TextProcessor>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension TextProcessor: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.TextProcessor: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_TextProcessor_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_TextProcessor_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_TextProcessor_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_TextProcessor_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_TextProcessor_wrap")
-fileprivate func _bjs_TextProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_TextProcessor_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_TextProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_TextProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_TextProcessor_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_TextProcessor_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_TextProcessor_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_TextProcessor_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_TextProcessor_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_NestedTypeHost_init")
-@_cdecl("bjs_NestedTypeHost_init")
-public func _bjs_NestedTypeHost_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_NestedTypeHost_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_NestedTypeHost_init")
+public func _bjs_BridgeJSRuntimeTests_NestedTypeHost_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = NestedTypeHost()
+    let ret = BridgeJSRuntimeTests.NestedTypeHost()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_NestedTypeHost_describe")
-@_cdecl("bjs_NestedTypeHost_describe")
-public func _bjs_NestedTypeHost_describe(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_NestedTypeHost_describe")
+@_cdecl("bjs_BridgeJSRuntimeTests_NestedTypeHost_describe")
+public func _bjs_BridgeJSRuntimeTests_NestedTypeHost_describe(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = NestedTypeHost.bridgeJSLiftParameter(_self).describe()
+    let ret = BridgeJSRuntimeTests.NestedTypeHost.bridgeJSLiftParameter(_self).describe()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_NestedTypeHost_deinit")
-@_cdecl("bjs_NestedTypeHost_deinit")
-public func _bjs_NestedTypeHost_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_NestedTypeHost_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_NestedTypeHost_deinit")
+public func _bjs_BridgeJSRuntimeTests_NestedTypeHost_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<NestedTypeHost>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.NestedTypeHost>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension NestedTypeHost: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.NestedTypeHost: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_NestedTypeHost_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_NestedTypeHost_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_NestedTypeHost_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_NestedTypeHost_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_NestedTypeHost_wrap")
-fileprivate func _bjs_NestedTypeHost_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_NestedTypeHost_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_NestedTypeHost_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_NestedTypeHost_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_NestedTypeHost_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_NestedTypeHost_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_NestedTypeHost_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_NestedTypeHost_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_NestedTypeHost_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_OptionalHolder_init")
-@_cdecl("bjs_OptionalHolder_init")
-public func _bjs_OptionalHolder_init(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalHolder_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalHolder_init")
+public func _bjs_BridgeJSRuntimeTests_OptionalHolder_init(_ nullableGreeterIsSome: Int32, _ nullableGreeterValue: UnsafeMutableRawPointer, _ undefinedNumberIsSome: Int32, _ undefinedNumberValue: Float64) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = OptionalHolder(nullableGreeter: Optional<Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
+    let ret = BridgeJSRuntimeTests.OptionalHolder(nullableGreeter: Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(nullableGreeterIsSome, nullableGreeterValue), undefinedNumber: JSUndefinedOr<Double>.bridgeJSLiftParameter(undefinedNumberIsSome, undefinedNumberValue))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalHolder_nullableGreeter_get")
-@_cdecl("bjs_OptionalHolder_nullableGreeter_get")
-public func _bjs_OptionalHolder_nullableGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalHolder_nullableGreeter_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalHolder_nullableGreeter_get")
+public func _bjs_BridgeJSRuntimeTests_OptionalHolder_nullableGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter
+    let ret = BridgeJSRuntimeTests.OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalHolder_nullableGreeter_set")
-@_cdecl("bjs_OptionalHolder_nullableGreeter_set")
-public func _bjs_OptionalHolder_nullableGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalHolder_nullableGreeter_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalHolder_nullableGreeter_set")
+public func _bjs_BridgeJSRuntimeTests_OptionalHolder_nullableGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.OptionalHolder.bridgeJSLiftParameter(_self).nullableGreeter = Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalHolder_undefinedNumber_get")
-@_cdecl("bjs_OptionalHolder_undefinedNumber_get")
-public func _bjs_OptionalHolder_undefinedNumber_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalHolder_undefinedNumber_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalHolder_undefinedNumber_get")
+public func _bjs_BridgeJSRuntimeTests_OptionalHolder_undefinedNumber_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalHolder.bridgeJSLiftParameter(_self).undefinedNumber
+    let ret = BridgeJSRuntimeTests.OptionalHolder.bridgeJSLiftParameter(_self).undefinedNumber
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalHolder_undefinedNumber_set")
-@_cdecl("bjs_OptionalHolder_undefinedNumber_set")
-public func _bjs_OptionalHolder_undefinedNumber_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Float64) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalHolder_undefinedNumber_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalHolder_undefinedNumber_set")
+public func _bjs_BridgeJSRuntimeTests_OptionalHolder_undefinedNumber_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Float64) -> Void {
     #if arch(wasm32)
-    OptionalHolder.bridgeJSLiftParameter(_self).undefinedNumber = JSUndefinedOr<Double>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.OptionalHolder.bridgeJSLiftParameter(_self).undefinedNumber = JSUndefinedOr<Double>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalHolder_deinit")
-@_cdecl("bjs_OptionalHolder_deinit")
-public func _bjs_OptionalHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalHolder_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalHolder_deinit")
+public func _bjs_BridgeJSRuntimeTests_OptionalHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<OptionalHolder>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.OptionalHolder>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension OptionalHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.OptionalHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_OptionalHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_OptionalHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_OptionalHolder_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_OptionalHolder_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalHolder_wrap")
-fileprivate func _bjs_OptionalHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_OptionalHolder_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_OptionalHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_OptionalHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_OptionalHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_OptionalHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_OptionalHolder_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_OptionalHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_OptionalHolder_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_init")
-@_cdecl("bjs_OptionalPropertyHolder_init")
-public func _bjs_OptionalPropertyHolder_init(_ optionalNameIsSome: Int32, _ optionalNameBytes: Int32, _ optionalNameLength: Int32) -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_init")
+public func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_init(_ optionalNameIsSome: Int32, _ optionalNameBytes: Int32, _ optionalNameLength: Int32) -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = OptionalPropertyHolder(optionalName: Optional<String>.bridgeJSLiftParameter(optionalNameIsSome, optionalNameBytes, optionalNameLength))
+    let ret = BridgeJSRuntimeTests.OptionalPropertyHolder(optionalName: Optional<String>.bridgeJSLiftParameter(optionalNameIsSome, optionalNameBytes, optionalNameLength))
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalName_get")
-@_cdecl("bjs_OptionalPropertyHolder_optionalName_get")
-public func _bjs_OptionalPropertyHolder_optionalName_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalName_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalName_get")
+public func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalName_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName
+    let ret = BridgeJSRuntimeTests.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalName_set")
-@_cdecl("bjs_OptionalPropertyHolder_optionalName_set")
-public func _bjs_OptionalPropertyHolder_optionalName_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalName_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalName_set")
+public func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalName_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
+    BridgeJSRuntimeTests.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalName = Optional<String>.bridgeJSLiftParameter(valueIsSome, valueBytes, valueLength)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalAge_get")
-@_cdecl("bjs_OptionalPropertyHolder_optionalAge_get")
-public func _bjs_OptionalPropertyHolder_optionalAge_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalAge_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalAge_get")
+public func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalAge_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge
+    let ret = BridgeJSRuntimeTests.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalAge_set")
-@_cdecl("bjs_OptionalPropertyHolder_optionalAge_set")
-public func _bjs_OptionalPropertyHolder_optionalAge_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalAge_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalAge_set")
+public func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalAge_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalAge = Optional<Int>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_get")
-@_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_get")
-public func _bjs_OptionalPropertyHolder_optionalGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalGreeter_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalGreeter_get")
+public func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalGreeter_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter
+    let ret = BridgeJSRuntimeTests.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_optionalGreeter_set")
-@_cdecl("bjs_OptionalPropertyHolder_optionalGreeter_set")
-public func _bjs_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalGreeter_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalGreeter_set")
+public func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_optionalGreeter_set(_ _self: UnsafeMutableRawPointer, _ valueIsSome: Int32, _ valueValue: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
+    BridgeJSRuntimeTests.OptionalPropertyHolder.bridgeJSLiftParameter(_self).optionalGreeter = Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftParameter(valueIsSome, valueValue)
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_OptionalPropertyHolder_deinit")
-@_cdecl("bjs_OptionalPropertyHolder_deinit")
-public func _bjs_OptionalPropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_deinit")
+public func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<OptionalPropertyHolder>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.OptionalPropertyHolder>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension OptionalPropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.OptionalPropertyHolder: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_OptionalPropertyHolder_wrap")
-fileprivate func _bjs_OptionalPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_OptionalPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_OptionalPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_OptionalPropertyHolder_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_Container_init")
-@_cdecl("bjs_Container_init")
-public func _bjs_Container_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Container_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_Container_init")
+public func _bjs_BridgeJSRuntimeTests_Container_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let _tmp_config = Optional<Config>.bridgeJSLiftParameter()
-    let _tmp_location = DataPoint.bridgeJSLiftParameter()
-    let ret = Container(location: _tmp_location, config: _tmp_config)
+    let _tmp_config = Optional<BridgeJSRuntimeTests.Config>.bridgeJSLiftParameter()
+    let _tmp_location = BridgeJSRuntimeTests.DataPoint.bridgeJSLiftParameter()
+    let ret = BridgeJSRuntimeTests.Container(location: _tmp_location, config: _tmp_config)
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Container_location_get")
-@_cdecl("bjs_Container_location_get")
-public func _bjs_Container_location_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Container_location_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_Container_location_get")
+public func _bjs_BridgeJSRuntimeTests_Container_location_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Container.bridgeJSLiftParameter(_self).location
+    let ret = BridgeJSRuntimeTests.Container.bridgeJSLiftParameter(_self).location
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Container_location_set")
-@_cdecl("bjs_Container_location_set")
-public func _bjs_Container_location_set(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Container_location_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_Container_location_set")
+public func _bjs_BridgeJSRuntimeTests_Container_location_set(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Container.bridgeJSLiftParameter(_self).location = DataPoint.bridgeJSLiftParameter()
+    BridgeJSRuntimeTests.Container.bridgeJSLiftParameter(_self).location = BridgeJSRuntimeTests.DataPoint.bridgeJSLiftParameter()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Container_config_get")
-@_cdecl("bjs_Container_config_get")
-public func _bjs_Container_config_get(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Container_config_get")
+@_cdecl("bjs_BridgeJSRuntimeTests_Container_config_get")
+public func _bjs_BridgeJSRuntimeTests_Container_config_get(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    let ret = Container.bridgeJSLiftParameter(_self).config
+    let ret = BridgeJSRuntimeTests.Container.bridgeJSLiftParameter(_self).config
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Container_config_set")
-@_cdecl("bjs_Container_config_set")
-public func _bjs_Container_config_set(_ _self: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Container_config_set")
+@_cdecl("bjs_BridgeJSRuntimeTests_Container_config_set")
+public func _bjs_BridgeJSRuntimeTests_Container_config_set(_ _self: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Container.bridgeJSLiftParameter(_self).config = Optional<Config>.bridgeJSLiftParameter()
+    BridgeJSRuntimeTests.Container.bridgeJSLiftParameter(_self).config = Optional<BridgeJSRuntimeTests.Config>.bridgeJSLiftParameter()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_Container_deinit")
-@_cdecl("bjs_Container_deinit")
-public func _bjs_Container_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_Container_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_Container_deinit")
+public func _bjs_BridgeJSRuntimeTests_Container_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<Container>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.Container>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension Container: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.Container: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_Container_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_Container_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_Container_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_Container_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Container_wrap")
-fileprivate func _bjs_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_Container_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_Container_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_Container_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_Container_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_Container_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_Container_wrap_extern(pointer)
 }
 
-@_expose(wasm, "bjs_LeakCheck_init")
-@_cdecl("bjs_LeakCheck_init")
-public func _bjs_LeakCheck_init() -> UnsafeMutableRawPointer {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_LeakCheck_init")
+@_cdecl("bjs_BridgeJSRuntimeTests_LeakCheck_init")
+public func _bjs_BridgeJSRuntimeTests_LeakCheck_init() -> UnsafeMutableRawPointer {
     #if arch(wasm32)
-    let ret = LeakCheck()
+    let ret = BridgeJSRuntimeTests.LeakCheck()
     return ret.bridgeJSLowerReturn()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-@_expose(wasm, "bjs_LeakCheck_deinit")
-@_cdecl("bjs_LeakCheck_deinit")
-public func _bjs_LeakCheck_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
+@_expose(wasm, "bjs_BridgeJSRuntimeTests_LeakCheck_deinit")
+@_cdecl("bjs_BridgeJSRuntimeTests_LeakCheck_deinit")
+public func _bjs_BridgeJSRuntimeTests_LeakCheck_deinit(_ pointer: UnsafeMutableRawPointer) -> Void {
     #if arch(wasm32)
-    Unmanaged<LeakCheck>.fromOpaque(pointer).release()
+    Unmanaged<BridgeJSRuntimeTests.LeakCheck>.fromOpaque(pointer).release()
     #else
     fatalError("Only available on WebAssembly")
     #endif
 }
 
-extension LeakCheck: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
+extension BridgeJSRuntimeTests.LeakCheck: ConvertibleToJSValue, _BridgedSwiftHeapObject, _BridgedSwiftProtocolExportable {
     public var jsValue: JSValue {
-        return .object(JSObject(id: UInt32(bitPattern: _bjs_LeakCheck_wrap(Unmanaged.passRetained(self).toOpaque()))))
+        return .object(JSObject(id: UInt32(bitPattern: _bjs_BridgeJSRuntimeTests_LeakCheck_wrap(Unmanaged.passRetained(self).toOpaque()))))
     }
     public consuming func bridgeJSLowerAsProtocolReturn() -> Int32 {
-        _bjs_LeakCheck_wrap(Unmanaged.passRetained(self).toOpaque())
+        _bjs_BridgeJSRuntimeTests_LeakCheck_wrap(Unmanaged.passRetained(self).toOpaque())
     }
 }
 
 #if arch(wasm32)
-@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_LeakCheck_wrap")
-fileprivate func _bjs_LeakCheck_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
+@_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_BridgeJSRuntimeTests_LeakCheck_wrap")
+fileprivate func _bjs_BridgeJSRuntimeTests_LeakCheck_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32
 #else
-fileprivate func _bjs_LeakCheck_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+fileprivate func _bjs_BridgeJSRuntimeTests_LeakCheck_wrap_extern(_ pointer: UnsafeMutableRawPointer) -> Int32 {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func _bjs_LeakCheck_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
-    return _bjs_LeakCheck_wrap_extern(pointer)
+@inline(never) fileprivate func _bjs_BridgeJSRuntimeTests_LeakCheck_wrap(_ pointer: UnsafeMutableRawPointer) -> Int32 {
+    return _bjs_BridgeJSRuntimeTests_LeakCheck_wrap_extern(pointer)
 }
 
 @JSFunction func Promise_reject(_ promise: JSObject, _ value: JSValue) throws(JSException)
@@ -13481,24 +13481,24 @@ func _$Promise_resolve_Sb(_ promise: JSObject, _ value: Bool) throws(JSException
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_7GreeterC(_ promise: JSObject, _ value: Greeter) throws(JSException)
+@JSFunction func Promise_resolve_28BridgeJSRuntimeTests_GreeterC(_ promise: JSObject, _ value: BridgeJSRuntimeTests.Greeter) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_7GreeterC")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_GreeterC")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_GreeterC_extern(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_7GreeterC(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_7GreeterC_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_GreeterC(_ promise: Int32, _ value: UnsafeMutableRawPointer) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_GreeterC_extern(promise, value)
 }
 
-func _$Promise_resolve_7GreeterC(_ promise: JSObject, _ value: Greeter) throws(JSException) -> Void {
+func _$Promise_resolve_28BridgeJSRuntimeTests_GreeterC(_ promise: JSObject, _ value: BridgeJSRuntimeTests.Greeter) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valuePointer = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_7GreeterC(promiseValue, valuePointer)
+    promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_GreeterC(promiseValue, valuePointer)
     if let error = _swift_js_take_exception() { throw error }
 }
 
@@ -13523,407 +13523,407 @@ func _$Promise_resolve_8JSObjectC(_ promise: JSObject, _ value: JSObject) throws
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_5ThemeO(_ promise: JSObject, _ value: Theme) throws(JSException)
+@JSFunction func Promise_resolve_26BridgeJSRuntimeTests_ThemeO(_ promise: JSObject, _ value: BridgeJSRuntimeTests.Theme) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_5ThemeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_26BridgeJSRuntimeTests_ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_26BridgeJSRuntimeTests_ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_26BridgeJSRuntimeTests_ThemeO_extern(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_5ThemeO(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_5ThemeO_extern(promise, valueBytes, valueLength)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_26BridgeJSRuntimeTests_ThemeO(_ promise: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_26BridgeJSRuntimeTests_ThemeO_extern(promise, valueBytes, valueLength)
 }
 
-func _$Promise_resolve_5ThemeO(_ promise: JSObject, _ value: Theme) throws(JSException) -> Void {
+func _$Promise_resolve_26BridgeJSRuntimeTests_ThemeO(_ promise: JSObject, _ value: BridgeJSRuntimeTests.Theme) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
-        promise_resolve_BridgeJSRuntimeTests_5ThemeO(promiseValue, valueBytes, valueLength)
+        promise_resolve_BridgeJSRuntimeTests_26BridgeJSRuntimeTests_ThemeO(promiseValue, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_9DirectionO(_ promise: JSObject, _ value: Direction) throws(JSException)
+@JSFunction func Promise_resolve_30BridgeJSRuntimeTests_DirectionO(_ promise: JSObject, _ value: BridgeJSRuntimeTests.Direction) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_9DirectionO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DirectionO_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_9DirectionO(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_9DirectionO_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DirectionO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DirectionO_extern(promise, value)
 }
 
-func _$Promise_resolve_9DirectionO(_ promise: JSObject, _ value: Direction) throws(JSException) -> Void {
+func _$Promise_resolve_30BridgeJSRuntimeTests_DirectionO(_ promise: JSObject, _ value: BridgeJSRuntimeTests.Direction) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_9DirectionO(promiseValue, valueValue)
+    promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DirectionO(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sq5ThemeO(_ promise: JSObject, _ value: Optional<Theme>) throws(JSException)
+@JSFunction func Promise_resolve_Sq26BridgeJSRuntimeTests_ThemeO(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.Theme>) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq26BridgeJSRuntimeTests_ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq26BridgeJSRuntimeTests_ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq26BridgeJSRuntimeTests_ThemeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO_extern(promise, valueIsSome, valueBytes, valueLength)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq26BridgeJSRuntimeTests_ThemeO(_ promise: Int32, _ valueIsSome: Int32, _ valueBytes: Int32, _ valueLength: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq26BridgeJSRuntimeTests_ThemeO_extern(promise, valueIsSome, valueBytes, valueLength)
 }
 
-func _$Promise_resolve_Sq5ThemeO(_ promise: JSObject, _ value: Optional<Theme>) throws(JSException) -> Void {
+func _$Promise_resolve_Sq26BridgeJSRuntimeTests_ThemeO(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.Theme>) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
-        promise_resolve_BridgeJSRuntimeTests_Sq5ThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
+        promise_resolve_BridgeJSRuntimeTests_Sq26BridgeJSRuntimeTests_ThemeO(promiseValue, valueIsSome, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sq9DirectionO(_ promise: JSObject, _ value: Optional<Direction>) throws(JSException)
+@JSFunction func Promise_resolve_Sq30BridgeJSRuntimeTests_DirectionO(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.Direction>) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq30BridgeJSRuntimeTests_DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq30BridgeJSRuntimeTests_DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq30BridgeJSRuntimeTests_DirectionO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO_extern(promise, valueIsSome, valueValue)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq30BridgeJSRuntimeTests_DirectionO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq30BridgeJSRuntimeTests_DirectionO_extern(promise, valueIsSome, valueValue)
 }
 
-func _$Promise_resolve_Sq9DirectionO(_ promise: JSObject, _ value: Optional<Direction>) throws(JSException) -> Void {
+func _$Promise_resolve_Sq30BridgeJSRuntimeTests_DirectionO(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.Direction>) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sq9DirectionO(promiseValue, valueIsSome, valueValue)
+    promise_resolve_BridgeJSRuntimeTests_Sq30BridgeJSRuntimeTests_DirectionO(promiseValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sa9DirectionO(_ promise: JSObject, _ value: [Direction]) throws(JSException)
+@JSFunction func Promise_resolve_Sa30BridgeJSRuntimeTests_DirectionO(_ promise: JSObject, _ value: [BridgeJSRuntimeTests.Direction]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa30BridgeJSRuntimeTests_DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa30BridgeJSRuntimeTests_DirectionO_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa30BridgeJSRuntimeTests_DirectionO_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO_extern(promise)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa30BridgeJSRuntimeTests_DirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sa30BridgeJSRuntimeTests_DirectionO_extern(promise)
 }
 
-func _$Promise_resolve_Sa9DirectionO(_ promise: JSObject, _ value: [Direction]) throws(JSException) -> Void {
+func _$Promise_resolve_Sa30BridgeJSRuntimeTests_DirectionO(_ promise: JSObject, _ value: [BridgeJSRuntimeTests.Direction]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sa9DirectionO(promiseValue)
+    promise_resolve_BridgeJSRuntimeTests_Sa30BridgeJSRuntimeTests_DirectionO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_SD9DirectionO(_ promise: JSObject, _ value: [String: Direction]) throws(JSException)
+@JSFunction func Promise_resolve_SD30BridgeJSRuntimeTests_DirectionO(_ promise: JSObject, _ value: [String: BridgeJSRuntimeTests.Direction]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD9DirectionO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD30BridgeJSRuntimeTests_DirectionO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD30BridgeJSRuntimeTests_DirectionO_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD30BridgeJSRuntimeTests_DirectionO_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD9DirectionO(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_SD9DirectionO_extern(promise)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD30BridgeJSRuntimeTests_DirectionO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SD30BridgeJSRuntimeTests_DirectionO_extern(promise)
 }
 
-func _$Promise_resolve_SD9DirectionO(_ promise: JSObject, _ value: [String: Direction]) throws(JSException) -> Void {
+func _$Promise_resolve_SD30BridgeJSRuntimeTests_DirectionO(_ promise: JSObject, _ value: [String: BridgeJSRuntimeTests.Direction]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_SD9DirectionO(promiseValue)
+    promise_resolve_BridgeJSRuntimeTests_SD30BridgeJSRuntimeTests_DirectionO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sa5ThemeO(_ promise: JSObject, _ value: [Theme]) throws(JSException)
+@JSFunction func Promise_resolve_Sa26BridgeJSRuntimeTests_ThemeO(_ promise: JSObject, _ value: [BridgeJSRuntimeTests.Theme]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa26BridgeJSRuntimeTests_ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa26BridgeJSRuntimeTests_ThemeO_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa26BridgeJSRuntimeTests_ThemeO_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO_extern(promise)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa26BridgeJSRuntimeTests_ThemeO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sa26BridgeJSRuntimeTests_ThemeO_extern(promise)
 }
 
-func _$Promise_resolve_Sa5ThemeO(_ promise: JSObject, _ value: [Theme]) throws(JSException) -> Void {
+func _$Promise_resolve_Sa26BridgeJSRuntimeTests_ThemeO(_ promise: JSObject, _ value: [BridgeJSRuntimeTests.Theme]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sa5ThemeO(promiseValue)
+    promise_resolve_BridgeJSRuntimeTests_Sa26BridgeJSRuntimeTests_ThemeO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_SD5ThemeO(_ promise: JSObject, _ value: [String: Theme]) throws(JSException)
+@JSFunction func Promise_resolve_SD26BridgeJSRuntimeTests_ThemeO(_ promise: JSObject, _ value: [String: BridgeJSRuntimeTests.Theme]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD5ThemeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD26BridgeJSRuntimeTests_ThemeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD26BridgeJSRuntimeTests_ThemeO_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD26BridgeJSRuntimeTests_ThemeO_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD5ThemeO(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_SD5ThemeO_extern(promise)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD26BridgeJSRuntimeTests_ThemeO(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SD26BridgeJSRuntimeTests_ThemeO_extern(promise)
 }
 
-func _$Promise_resolve_SD5ThemeO(_ promise: JSObject, _ value: [String: Theme]) throws(JSException) -> Void {
+func _$Promise_resolve_SD26BridgeJSRuntimeTests_ThemeO(_ promise: JSObject, _ value: [String: BridgeJSRuntimeTests.Theme]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_SD5ThemeO(promiseValue)
+    promise_resolve_BridgeJSRuntimeTests_SD26BridgeJSRuntimeTests_ThemeO(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_8FileSizeO(_ promise: JSObject, _ value: FileSize) throws(JSException)
+@JSFunction func Promise_resolve_29BridgeJSRuntimeTests_FileSizeO(_ promise: JSObject, _ value: BridgeJSRuntimeTests.FileSize) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_8FileSizeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_29BridgeJSRuntimeTests_FileSizeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_29BridgeJSRuntimeTests_FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_29BridgeJSRuntimeTests_FileSizeO_extern(_ promise: Int32, _ value: Int64) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_8FileSizeO(_ promise: Int32, _ value: Int64) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_8FileSizeO_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_29BridgeJSRuntimeTests_FileSizeO(_ promise: Int32, _ value: Int64) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_29BridgeJSRuntimeTests_FileSizeO_extern(promise, value)
 }
 
-func _$Promise_resolve_8FileSizeO(_ promise: JSObject, _ value: FileSize) throws(JSException) -> Void {
+func _$Promise_resolve_29BridgeJSRuntimeTests_FileSizeO(_ promise: JSObject, _ value: BridgeJSRuntimeTests.FileSize) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueValue = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_8FileSizeO(promiseValue, valueValue)
+    promise_resolve_BridgeJSRuntimeTests_29BridgeJSRuntimeTests_FileSizeO(promiseValue, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sq8FileSizeO(_ promise: JSObject, _ value: Optional<FileSize>) throws(JSException)
+@JSFunction func Promise_resolve_Sq29BridgeJSRuntimeTests_FileSizeO(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.FileSize>) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq29BridgeJSRuntimeTests_FileSizeO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq29BridgeJSRuntimeTests_FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq29BridgeJSRuntimeTests_FileSizeO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO_extern(promise, valueIsSome, valueValue)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq29BridgeJSRuntimeTests_FileSizeO(_ promise: Int32, _ valueIsSome: Int32, _ valueValue: Int64) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq29BridgeJSRuntimeTests_FileSizeO_extern(promise, valueIsSome, valueValue)
 }
 
-func _$Promise_resolve_Sq8FileSizeO(_ promise: JSObject, _ value: Optional<FileSize>) throws(JSException) -> Void {
+func _$Promise_resolve_Sq29BridgeJSRuntimeTests_FileSizeO(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.FileSize>) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sq8FileSizeO(promiseValue, valueIsSome, valueValue)
+    promise_resolve_BridgeJSRuntimeTests_Sq29BridgeJSRuntimeTests_FileSizeO(promiseValue, valueIsSome, valueValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException)
+@JSFunction func Promise_resolve_39BridgeJSRuntimeTests_AsyncPayloadResultO(_ promise: JSObject, _ value: BridgeJSRuntimeTests.AsyncPayloadResult) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_39BridgeJSRuntimeTests_AsyncPayloadResultO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_39BridgeJSRuntimeTests_AsyncPayloadResultO(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(promise, value)
 }
 
-func _$Promise_resolve_18AsyncPayloadResultO(_ promise: JSObject, _ value: AsyncPayloadResult) throws(JSException) -> Void {
+func _$Promise_resolve_39BridgeJSRuntimeTests_AsyncPayloadResultO(_ promise: JSObject, _ value: BridgeJSRuntimeTests.AsyncPayloadResult) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueCaseId = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_18AsyncPayloadResultO(promiseValue, valueCaseId)
+    promise_resolve_BridgeJSRuntimeTests_39BridgeJSRuntimeTests_AsyncPayloadResultO(promiseValue, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException)
+@JSFunction func Promise_resolve_Sq39BridgeJSRuntimeTests_AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.AsyncPayloadResult>) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq39BridgeJSRuntimeTests_AsyncPayloadResultO")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO_extern(promise, valueIsSome, valueCaseId)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq39BridgeJSRuntimeTests_AsyncPayloadResultO(_ promise: Int32, _ valueIsSome: Int32, _ valueCaseId: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq39BridgeJSRuntimeTests_AsyncPayloadResultO_extern(promise, valueIsSome, valueCaseId)
 }
 
-func _$Promise_resolve_Sq18AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<AsyncPayloadResult>) throws(JSException) -> Void {
+func _$Promise_resolve_Sq39BridgeJSRuntimeTests_AsyncPayloadResultO(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.AsyncPayloadResult>) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sq18AsyncPayloadResultO(promiseValue, valueIsSome, valueCaseId)
+    promise_resolve_BridgeJSRuntimeTests_Sq39BridgeJSRuntimeTests_AsyncPayloadResultO(promiseValue, valueIsSome, valueCaseId)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_11PublicPointV(_ promise: JSObject, _ value: PublicPoint) throws(JSException)
+@JSFunction func Promise_resolve_32BridgeJSRuntimeTests_PublicPointV(_ promise: JSObject, _ value: BridgeJSRuntimeTests.PublicPoint) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_11PublicPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_32BridgeJSRuntimeTests_PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_32BridgeJSRuntimeTests_PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_32BridgeJSRuntimeTests_PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_11PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_11PublicPointV_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_32BridgeJSRuntimeTests_PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_32BridgeJSRuntimeTests_PublicPointV_extern(promise, value)
 }
 
-func _$Promise_resolve_11PublicPointV(_ promise: JSObject, _ value: PublicPoint) throws(JSException) -> Void {
+func _$Promise_resolve_32BridgeJSRuntimeTests_PublicPointV(_ promise: JSObject, _ value: BridgeJSRuntimeTests.PublicPoint) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_11PublicPointV(promiseValue, valueObjectId)
+    promise_resolve_BridgeJSRuntimeTests_32BridgeJSRuntimeTests_PublicPointV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_7ContactV(_ promise: JSObject, _ value: Contact) throws(JSException)
+@JSFunction func Promise_resolve_28BridgeJSRuntimeTests_ContactV(_ promise: JSObject, _ value: BridgeJSRuntimeTests.Contact) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_7ContactV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_ContactV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_ContactV_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_ContactV_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_7ContactV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_7ContactV_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_ContactV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_ContactV_extern(promise, value)
 }
 
-func _$Promise_resolve_7ContactV(_ promise: JSObject, _ value: Contact) throws(JSException) -> Void {
+func _$Promise_resolve_28BridgeJSRuntimeTests_ContactV(_ promise: JSObject, _ value: BridgeJSRuntimeTests.Contact) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_7ContactV(promiseValue, valueObjectId)
+    promise_resolve_BridgeJSRuntimeTests_28BridgeJSRuntimeTests_ContactV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoint]) throws(JSException)
+@JSFunction func Promise_resolve_Sa32BridgeJSRuntimeTests_PublicPointV(_ promise: JSObject, _ value: [BridgeJSRuntimeTests.PublicPoint]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sa32BridgeJSRuntimeTests_PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa32BridgeJSRuntimeTests_PublicPointV_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa32BridgeJSRuntimeTests_PublicPointV_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV_extern(promise)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sa32BridgeJSRuntimeTests_PublicPointV(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sa32BridgeJSRuntimeTests_PublicPointV_extern(promise)
 }
 
-func _$Promise_resolve_Sa11PublicPointV(_ promise: JSObject, _ value: [PublicPoint]) throws(JSException) -> Void {
+func _$Promise_resolve_Sa32BridgeJSRuntimeTests_PublicPointV(_ promise: JSObject, _ value: [BridgeJSRuntimeTests.PublicPoint]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sa11PublicPointV(promiseValue)
+    promise_resolve_BridgeJSRuntimeTests_Sa32BridgeJSRuntimeTests_PublicPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException)
+@JSFunction func Promise_resolve_Sq32BridgeJSRuntimeTests_PublicPointV(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.PublicPoint>) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_Sq32BridgeJSRuntimeTests_PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq32BridgeJSRuntimeTests_PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq32BridgeJSRuntimeTests_PublicPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_Sq32BridgeJSRuntimeTests_PublicPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_Sq32BridgeJSRuntimeTests_PublicPointV_extern(promise, value)
 }
 
-func _$Promise_resolve_Sq11PublicPointV(_ promise: JSObject, _ value: Optional<PublicPoint>) throws(JSException) -> Void {
+func _$Promise_resolve_Sq32BridgeJSRuntimeTests_PublicPointV(_ promise: JSObject, _ value: Optional<BridgeJSRuntimeTests.PublicPoint>) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueIsSome = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_Sq11PublicPointV(promiseValue, valueIsSome)
+    promise_resolve_BridgeJSRuntimeTests_Sq32BridgeJSRuntimeTests_PublicPointV(promiseValue, valueIsSome)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: PublicPoint]) throws(JSException)
+@JSFunction func Promise_resolve_SD32BridgeJSRuntimeTests_PublicPointV(_ promise: JSObject, _ value: [String: BridgeJSRuntimeTests.PublicPoint]) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(_ promise: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_SD32BridgeJSRuntimeTests_PublicPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD32BridgeJSRuntimeTests_PublicPointV_extern(_ promise: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(_ promise: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_SD32BridgeJSRuntimeTests_PublicPointV_extern(_ promise: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV(_ promise: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV_extern(promise)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_SD32BridgeJSRuntimeTests_PublicPointV(_ promise: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_SD32BridgeJSRuntimeTests_PublicPointV_extern(promise)
 }
 
-func _$Promise_resolve_SD11PublicPointV(_ promise: JSObject, _ value: [String: PublicPoint]) throws(JSException) -> Void {
+func _$Promise_resolve_SD32BridgeJSRuntimeTests_PublicPointV(_ promise: JSObject, _ value: [String: BridgeJSRuntimeTests.PublicPoint]) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let _ = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_SD11PublicPointV(promiseValue)
+    promise_resolve_BridgeJSRuntimeTests_SD32BridgeJSRuntimeTests_PublicPointV(promiseValue)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-@JSFunction func Promise_resolve_9DataPointV(_ promise: JSObject, _ value: DataPoint) throws(JSException)
+@JSFunction func Promise_resolve_30BridgeJSRuntimeTests_DataPointV(_ promise: JSObject, _ value: BridgeJSRuntimeTests.DataPoint) throws(JSException)
 
 #if arch(wasm32)
-@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_9DataPointV")
-fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void
+@_extern(wasm, module: "bjs", name: "promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DataPointV")
+fileprivate func promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void
 #else
-fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
+fileprivate func promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DataPointV_extern(_ promise: Int32, _ value: Int32) -> Void {
     fatalError("Only available on WebAssembly")
 }
 #endif
-@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_9DataPointV(_ promise: Int32, _ value: Int32) -> Void {
-    return promise_resolve_BridgeJSRuntimeTests_9DataPointV_extern(promise, value)
+@inline(never) fileprivate func promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DataPointV(_ promise: Int32, _ value: Int32) -> Void {
+    return promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DataPointV_extern(promise, value)
 }
 
-func _$Promise_resolve_9DataPointV(_ promise: JSObject, _ value: DataPoint) throws(JSException) -> Void {
+func _$Promise_resolve_30BridgeJSRuntimeTests_DataPointV(_ promise: JSObject, _ value: BridgeJSRuntimeTests.DataPoint) throws(JSException) -> Void {
     let promiseValue = promise.bridgeJSLowerParameter()
     let valueObjectId = value.bridgeJSLowerParameter()
-    promise_resolve_BridgeJSRuntimeTests_9DataPointV(promiseValue, valueObjectId)
+    promise_resolve_BridgeJSRuntimeTests_30BridgeJSRuntimeTests_DataPointV(promiseValue, valueObjectId)
     if let error = _swift_js_take_exception() { throw error }
 }
 
-extension Polygon: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension BridgeJSRuntimeTests.Polygon: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension Tag: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension BridgeJSRuntimeTests.Tag: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension TagHolder: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension BridgeJSRuntimeTests.TagHolder: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension Coordinate: _BridgedSwiftAlias, _BridgedSwiftStruct {}
+extension BridgeJSRuntimeTests.Coordinate: _BridgedSwiftAlias, _BridgedSwiftStruct {}
 
-extension Priority: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension BridgeJSRuntimeTests.Priority: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension Alert: _BridgedSwiftAlias, _BridgedSwiftCaseEnum {}
+extension BridgeJSRuntimeTests.Alert: _BridgedSwiftAlias, _BridgedSwiftCaseEnum {}
 
-extension UserId: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension BridgeJSRuntimeTests.UserId: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension Tagged: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension BridgeJSRuntimeTests.Tagged: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension Canvas: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension BridgeJSRuntimeTests.Canvas: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
-extension AliasedTag: _BridgedSwiftAlias, _BridgedSwiftAssociatedValueEnum {}
+extension BridgeJSRuntimeTests.AliasedTag: _BridgedSwiftAlias, _BridgedSwiftAssociatedValueEnum {}
 
-extension Boxed: _BridgedSwiftAlias, _BridgedSwiftStackType {}
+extension BridgeJSRuntimeTests.Boxed: _BridgedSwiftAlias, _BridgedSwiftStackType {}
 
 #if arch(wasm32)
 @_extern(wasm, module: "BridgeJSRuntimeTests", name: "bjs_Surface_init")
@@ -14066,7 +14066,7 @@ fileprivate func bjs_AliasImports_jsRoundTripOptionalUserId_static_extern(_ valu
     return bjs_AliasImports_jsRoundTripOptionalUserId_static_extern(valueIsSome, valueValue)
 }
 
-func _$AliasImports_jsRoundTripTagged(_ value: Tagged) throws(JSException) -> Tagged {
+func _$AliasImports_jsRoundTripTagged(_ value: BridgeJSRuntimeTests.Tagged) throws(JSException) -> BridgeJSRuntimeTests.Tagged {
     let ret0 = value.bridgeJSWithLoweredParameter { (valueBytes, valueLength) in
         let ret = bjs_AliasImports_jsRoundTripTagged_static(valueBytes, valueLength)
         return ret
@@ -14075,72 +14075,72 @@ func _$AliasImports_jsRoundTripTagged(_ value: Tagged) throws(JSException) -> Ta
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Tagged.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.Tagged.bridgeJSLiftReturn(ret)
 }
 
-func _$AliasImports_jsRoundTripOptionalTagged(_ value: Optional<Tagged>) throws(JSException) -> Optional<Tagged> {
+func _$AliasImports_jsRoundTripOptionalTagged(_ value: Optional<BridgeJSRuntimeTests.Tagged>) throws(JSException) -> Optional<BridgeJSRuntimeTests.Tagged> {
     value.bridgeJSWithLoweredParameter { (valueIsSome, valueBytes, valueLength) in
         bjs_AliasImports_jsRoundTripOptionalTagged_static(valueIsSome, valueBytes, valueLength)
     }
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<Tagged>.bridgeJSLiftReturnFromSideChannel()
+    return Optional<BridgeJSRuntimeTests.Tagged>.bridgeJSLiftReturnFromSideChannel()
 }
 
-func _$AliasImports_jsProduceOptionalCanvas(_ label: Optional<String>) throws(JSException) -> Optional<Canvas> {
+func _$AliasImports_jsProduceOptionalCanvas(_ label: Optional<String>) throws(JSException) -> Optional<BridgeJSRuntimeTests.Canvas> {
     label.bridgeJSWithLoweredParameter { (labelIsSome, labelBytes, labelLength) in
         bjs_AliasImports_jsProduceOptionalCanvas_static(labelIsSome, labelBytes, labelLength)
     }
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<Canvas>.bridgeJSLiftReturn()
+    return Optional<BridgeJSRuntimeTests.Canvas>.bridgeJSLiftReturn()
 }
 
-func _$AliasImports_jsRoundTripAliasedTags(_ values: [Optional<AliasedTag>]) throws(JSException) -> [Optional<AliasedTag>] {
+func _$AliasImports_jsRoundTripAliasedTags(_ values: [Optional<BridgeJSRuntimeTests.AliasedTag>]) throws(JSException) -> [Optional<BridgeJSRuntimeTests.AliasedTag>] {
     let _ = values.bridgeJSLowerParameter()
     bjs_AliasImports_jsRoundTripAliasedTags_static()
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return [Optional<AliasedTag>].bridgeJSLiftReturn()
+    return [Optional<BridgeJSRuntimeTests.AliasedTag>].bridgeJSLiftReturn()
 }
 
-func _$AliasImports_jsRoundTripPolygon(_ value: Polygon) throws(JSException) -> Polygon {
+func _$AliasImports_jsRoundTripPolygon(_ value: BridgeJSRuntimeTests.Polygon) throws(JSException) -> BridgeJSRuntimeTests.Polygon {
     let valuePointer = value.bridgeJSLowerParameter()
     let ret = bjs_AliasImports_jsRoundTripPolygon_static(valuePointer)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Polygon.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.Polygon.bridgeJSLiftReturn(ret)
 }
 
-func _$AliasImports_jsRoundTripCoordinate(_ value: Coordinate) throws(JSException) -> Coordinate {
+func _$AliasImports_jsRoundTripCoordinate(_ value: BridgeJSRuntimeTests.Coordinate) throws(JSException) -> BridgeJSRuntimeTests.Coordinate {
     let valueObjectId = value.bridgeJSLowerParameter()
     let ret = bjs_AliasImports_jsRoundTripCoordinate_static(valueObjectId)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Coordinate.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.Coordinate.bridgeJSLiftReturn(ret)
 }
 
-func _$AliasImports_jsRoundTripUserId(_ value: UserId) throws(JSException) -> UserId {
+func _$AliasImports_jsRoundTripUserId(_ value: BridgeJSRuntimeTests.UserId) throws(JSException) -> BridgeJSRuntimeTests.UserId {
     let valueValue = value.bridgeJSLowerParameter()
     let ret = bjs_AliasImports_jsRoundTripUserId_static(valueValue)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return UserId.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.UserId.bridgeJSLiftReturn(ret)
 }
 
-func _$AliasImports_jsRoundTripOptionalUserId(_ value: Optional<UserId>) throws(JSException) -> Optional<UserId> {
+func _$AliasImports_jsRoundTripOptionalUserId(_ value: Optional<BridgeJSRuntimeTests.UserId>) throws(JSException) -> Optional<BridgeJSRuntimeTests.UserId> {
     let (valueIsSome, valueValue) = value.bridgeJSLowerParameter()
     bjs_AliasImports_jsRoundTripOptionalUserId_static(valueIsSome, valueValue)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<UserId>.bridgeJSLiftReturnFromSideChannel()
+    return Optional<BridgeJSRuntimeTests.UserId>.bridgeJSLiftReturnFromSideChannel()
 }
 
 #if arch(wasm32)
@@ -14794,9 +14794,9 @@ func _$AsyncImportImports_jsAsyncRoundTripStringArray(_ values: [String]) async 
     return resolved
 }
 
-func _$AsyncImportImports_jsAsyncRoundTripFeatureFlag(_ v: FeatureFlag) async throws(JSException) -> FeatureFlag {
+func _$AsyncImportImports_jsAsyncRoundTripFeatureFlag(_ v: BridgeJSRuntimeTests.FeatureFlag) async throws(JSException) -> BridgeJSRuntimeTests.FeatureFlag {
     let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
-            JSTypedClosure<(sending FeatureFlag) -> Void>($0)
+            JSTypedClosure<(sending BridgeJSRuntimeTests.FeatureFlag) -> Void>($0)
         }, makeRejectClosure: {
             JSTypedClosure<(sending JSValue) -> Void>($0)
         }) { resolveRef, rejectRef in
@@ -14807,9 +14807,9 @@ func _$AsyncImportImports_jsAsyncRoundTripFeatureFlag(_ v: FeatureFlag) async th
     return resolved
 }
 
-func _$AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum(_ v: AsyncImportedPayloadResult) async throws(JSException) -> AsyncImportedPayloadResult {
+func _$AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum(_ v: BridgeJSRuntimeTests.AsyncImportedPayloadResult) async throws(JSException) -> BridgeJSRuntimeTests.AsyncImportedPayloadResult {
     let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
-            JSTypedClosure<(sending AsyncImportedPayloadResult) -> Void>($0)
+            JSTypedClosure<(sending BridgeJSRuntimeTests.AsyncImportedPayloadResult) -> Void>($0)
         }, makeRejectClosure: {
             JSTypedClosure<(sending JSValue) -> Void>($0)
         }) { resolveRef, rejectRef in
@@ -14819,9 +14819,9 @@ func _$AsyncImportImports_jsAsyncRoundTripAssociatedValueEnum(_ v: AsyncImported
     return resolved
 }
 
-func _$AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum(_ v: Optional<AsyncImportedPayloadResult>) async throws(JSException) -> Optional<AsyncImportedPayloadResult> {
+func _$AsyncImportImports_jsAsyncRoundTripOptionalAssociatedValueEnum(_ v: Optional<BridgeJSRuntimeTests.AsyncImportedPayloadResult>) async throws(JSException) -> Optional<BridgeJSRuntimeTests.AsyncImportedPayloadResult> {
     let resolved = try await _bjs_awaitPromise(makeResolveClosure: {
-            JSTypedClosure<(sending Optional<AsyncImportedPayloadResult>) -> Void>($0)
+            JSTypedClosure<(sending Optional<BridgeJSRuntimeTests.AsyncImportedPayloadResult>) -> Void>($0)
         }, makeRejectClosure: {
             JSTypedClosure<(sending JSValue) -> Void>($0)
         }) { resolveRef, rejectRef in
@@ -15665,7 +15665,7 @@ fileprivate func bjs_jsRoundTripFeatureFlag_extern(_ flagBytes: Int32, _ flagLen
     return bjs_jsRoundTripFeatureFlag_extern(flagBytes, flagLength)
 }
 
-func _$jsRoundTripFeatureFlag(_ flag: FeatureFlag) throws(JSException) -> FeatureFlag {
+func _$jsRoundTripFeatureFlag(_ flag: BridgeJSRuntimeTests.FeatureFlag) throws(JSException) -> BridgeJSRuntimeTests.FeatureFlag {
     let ret0 = flag.bridgeJSWithLoweredParameter { (flagBytes, flagLength) in
         let ret = bjs_jsRoundTripFeatureFlag(flagBytes, flagLength)
         return ret
@@ -15674,7 +15674,7 @@ func _$jsRoundTripFeatureFlag(_ flag: FeatureFlag) throws(JSException) -> Featur
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return FeatureFlag.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.FeatureFlag.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)
@@ -16400,13 +16400,13 @@ fileprivate func bjs_jsRoundTripLightColor_extern(_ value: Int32) -> Int32 {
     return bjs_jsRoundTripLightColor_extern(value)
 }
 
-func _$jsRoundTripLightColor(_ value: LightColor) throws(JSException) -> LightColor {
+func _$jsRoundTripLightColor(_ value: BridgeJSRuntimeTests.LightColor) throws(JSException) -> BridgeJSRuntimeTests.LightColor {
     let valueValue = value.bridgeJSLowerParameter()
     let ret = bjs_jsRoundTripLightColor(valueValue)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return LightColor.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.LightColor.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)
@@ -16421,13 +16421,13 @@ fileprivate func bjs_jsRoundTripImportedPayloadSignal_extern(_ value: Int32) -> 
     return bjs_jsRoundTripImportedPayloadSignal_extern(value)
 }
 
-func _$jsRoundTripImportedPayloadSignal(_ value: ImportedPayloadSignal) throws(JSException) -> ImportedPayloadSignal {
+func _$jsRoundTripImportedPayloadSignal(_ value: BridgeJSRuntimeTests.ImportedPayloadSignal) throws(JSException) -> BridgeJSRuntimeTests.ImportedPayloadSignal {
     let valueCaseId = value.bridgeJSLowerParameter()
     let ret = bjs_jsRoundTripImportedPayloadSignal(valueCaseId)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return ImportedPayloadSignal.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.ImportedPayloadSignal.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)
@@ -16442,13 +16442,13 @@ fileprivate func bjs_jsRoundTripOptionalImportedPayloadSignal_extern(_ valueIsSo
     return bjs_jsRoundTripOptionalImportedPayloadSignal_extern(valueIsSome, valueCaseId)
 }
 
-func _$jsRoundTripOptionalImportedPayloadSignal(_ value: Optional<ImportedPayloadSignal>) throws(JSException) -> Optional<ImportedPayloadSignal> {
+func _$jsRoundTripOptionalImportedPayloadSignal(_ value: Optional<BridgeJSRuntimeTests.ImportedPayloadSignal>) throws(JSException) -> Optional<BridgeJSRuntimeTests.ImportedPayloadSignal> {
     let (valueIsSome, valueCaseId) = value.bridgeJSLowerParameter()
     let ret = bjs_jsRoundTripOptionalImportedPayloadSignal(valueIsSome, valueCaseId)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<ImportedPayloadSignal>.bridgeJSLiftReturn(ret)
+    return Optional<BridgeJSRuntimeTests.ImportedPayloadSignal>.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)
@@ -16463,7 +16463,7 @@ fileprivate func bjs_jsTranslatePoint_extern(_ point: Int32, _ dx: Int32, _ dy: 
     return bjs_jsTranslatePoint_extern(point, dx, dy)
 }
 
-func _$jsTranslatePoint(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException) -> Point {
+func _$jsTranslatePoint(_ point: BridgeJSRuntimeTests.Point, _ dx: Int, _ dy: Int) throws(JSException) -> BridgeJSRuntimeTests.Point {
     let pointObjectId = point.bridgeJSLowerParameter()
     let dxValue = dx.bridgeJSLowerParameter()
     let dyValue = dy.bridgeJSLowerParameter()
@@ -16471,7 +16471,7 @@ func _$jsTranslatePoint(_ point: Point, _ dx: Int, _ dy: Int) throws(JSException
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Point.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.Point.bridgeJSLiftReturn(ret)
 }
 
 #if arch(wasm32)
@@ -16486,13 +16486,13 @@ fileprivate func bjs_jsRoundTripOptionalPoint_extern(_ point: Int32) -> Void {
     return bjs_jsRoundTripOptionalPoint_extern(point)
 }
 
-func _$jsRoundTripOptionalPoint(_ point: Optional<Point>) throws(JSException) -> Optional<Point> {
+func _$jsRoundTripOptionalPoint(_ point: Optional<BridgeJSRuntimeTests.Point>) throws(JSException) -> Optional<BridgeJSRuntimeTests.Point> {
     let pointIsSome = point.bridgeJSLowerParameter()
     bjs_jsRoundTripOptionalPoint(pointIsSome)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<Point>.bridgeJSLiftReturn()
+    return Optional<BridgeJSRuntimeTests.Point>.bridgeJSLiftReturn()
 }
 
 #if arch(wasm32)
@@ -17485,34 +17485,34 @@ fileprivate func bjs_SwiftClassSupportImports_jsConsumeOptionalLeakCheck_static_
     return bjs_SwiftClassSupportImports_jsConsumeOptionalLeakCheck_static_extern(valueIsSome, valuePointer)
 }
 
-func _$SwiftClassSupportImports_jsRoundTripGreeter(_ greeter: Greeter) throws(JSException) -> Greeter {
+func _$SwiftClassSupportImports_jsRoundTripGreeter(_ greeter: BridgeJSRuntimeTests.Greeter) throws(JSException) -> BridgeJSRuntimeTests.Greeter {
     let greeterPointer = greeter.bridgeJSLowerParameter()
     let ret = bjs_SwiftClassSupportImports_jsRoundTripGreeter_static(greeterPointer)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Greeter.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.Greeter.bridgeJSLiftReturn(ret)
 }
 
-func _$SwiftClassSupportImports_jsRoundTripUUID(_ uuid: UUID) throws(JSException) -> UUID {
+func _$SwiftClassSupportImports_jsRoundTripUUID(_ uuid: BridgeJSRuntimeTests.UUID) throws(JSException) -> BridgeJSRuntimeTests.UUID {
     let uuidPointer = uuid.bridgeJSLowerParameter()
     let ret = bjs_SwiftClassSupportImports_jsRoundTripUUID_static(uuidPointer)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return UUID.bridgeJSLiftReturn(ret)
+    return BridgeJSRuntimeTests.UUID.bridgeJSLiftReturn(ret)
 }
 
-func _$SwiftClassSupportImports_jsRoundTripOptionalGreeter(_ greeter: Optional<Greeter>) throws(JSException) -> Optional<Greeter> {
+func _$SwiftClassSupportImports_jsRoundTripOptionalGreeter(_ greeter: Optional<BridgeJSRuntimeTests.Greeter>) throws(JSException) -> Optional<BridgeJSRuntimeTests.Greeter> {
     let (greeterIsSome, greeterPointer) = greeter.bridgeJSLowerParameter()
     let ret = bjs_SwiftClassSupportImports_jsRoundTripOptionalGreeter_static(greeterIsSome, greeterPointer)
     if let error = _swift_js_take_exception() {
         throw error
     }
-    return Optional<Greeter>.bridgeJSLiftReturn(ret)
+    return Optional<BridgeJSRuntimeTests.Greeter>.bridgeJSLiftReturn(ret)
 }
 
-func _$SwiftClassSupportImports_jsConsumeLeakCheck(_ value: LeakCheck) throws(JSException) -> Void {
+func _$SwiftClassSupportImports_jsConsumeLeakCheck(_ value: BridgeJSRuntimeTests.LeakCheck) throws(JSException) -> Void {
     let valuePointer = value.bridgeJSLowerParameter()
     bjs_SwiftClassSupportImports_jsConsumeLeakCheck_static(valuePointer)
     if let error = _swift_js_take_exception() {
@@ -17520,7 +17520,7 @@ func _$SwiftClassSupportImports_jsConsumeLeakCheck(_ value: LeakCheck) throws(JS
     }
 }
 
-func _$SwiftClassSupportImports_jsConsumeOptionalLeakCheck(_ value: Optional<LeakCheck>) throws(JSException) -> Void {
+func _$SwiftClassSupportImports_jsConsumeOptionalLeakCheck(_ value: Optional<BridgeJSRuntimeTests.LeakCheck>) throws(JSException) -> Void {
     let (valueIsSome, valuePointer) = value.bridgeJSLowerParameter()
     bjs_SwiftClassSupportImports_jsConsumeOptionalLeakCheck_static(valueIsSome, valuePointer)
     if let error = _swift_js_take_exception() {

--- a/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
+++ b/Tests/BridgeJSRuntimeTests/Generated/JavaScript/BridgeJS.json
@@ -2,55 +2,55 @@
   "exported" : {
     "aliases" : [
       {
-        "swiftCallName" : "Polygon",
+        "swiftCallName" : "BridgeJSRuntimeTests.Polygon",
         "underlying" : {
           "swiftHeapObject" : {
-            "_0" : "PolygonReference"
+            "_0" : "BridgeJSRuntimeTests.PolygonReference"
           }
         }
       },
       {
-        "swiftCallName" : "Tag",
+        "swiftCallName" : "BridgeJSRuntimeTests.Tag",
         "underlying" : {
           "swiftHeapObject" : {
-            "_0" : "TagReference"
+            "_0" : "BridgeJSRuntimeTests.TagReference"
           }
         }
       },
       {
-        "swiftCallName" : "TagHolder",
+        "swiftCallName" : "BridgeJSRuntimeTests.TagHolder",
         "underlying" : {
           "swiftHeapObject" : {
-            "_0" : "TagHolderReference"
+            "_0" : "BridgeJSRuntimeTests.TagHolderReference"
           }
         }
       },
       {
-        "swiftCallName" : "Coordinate",
+        "swiftCallName" : "BridgeJSRuntimeTests.Coordinate",
         "underlying" : {
           "swiftStruct" : {
-            "_0" : "JSCoordinate"
+            "_0" : "BridgeJSRuntimeTests.JSCoordinate"
           }
         }
       },
       {
-        "swiftCallName" : "Priority",
+        "swiftCallName" : "BridgeJSRuntimeTests.Priority",
         "underlying" : {
           "swiftHeapObject" : {
-            "_0" : "PriorityReference"
+            "_0" : "BridgeJSRuntimeTests.PriorityReference"
           }
         }
       },
       {
-        "swiftCallName" : "Alert",
+        "swiftCallName" : "BridgeJSRuntimeTests.Alert",
         "underlying" : {
           "caseEnum" : {
-            "_0" : "Severity"
+            "_0" : "BridgeJSRuntimeTests.Severity"
           }
         }
       },
       {
-        "swiftCallName" : "UserId",
+        "swiftCallName" : "BridgeJSRuntimeTests.UserId",
         "underlying" : {
           "integer" : {
             "_0" : {
@@ -61,7 +61,7 @@
         }
       },
       {
-        "swiftCallName" : "Tagged",
+        "swiftCallName" : "BridgeJSRuntimeTests.Tagged",
         "underlying" : {
           "string" : {
 
@@ -69,7 +69,7 @@
         }
       },
       {
-        "swiftCallName" : "Canvas",
+        "swiftCallName" : "BridgeJSRuntimeTests.Canvas",
         "underlying" : {
           "jsObject" : {
             "_0" : "Surface"
@@ -77,15 +77,15 @@
         }
       },
       {
-        "swiftCallName" : "AliasedTag",
+        "swiftCallName" : "BridgeJSRuntimeTests.AliasedTag",
         "underlying" : {
           "associatedValueEnum" : {
-            "_0" : "InnerTag"
+            "_0" : "BridgeJSRuntimeTests.InnerTag"
           }
         }
       },
       {
-        "swiftCallName" : "Boxed",
+        "swiftCallName" : "BridgeJSRuntimeTests.Boxed",
         "underlying" : {
           "jsValue" : {
 
@@ -96,7 +96,7 @@
     "classes" : [
       {
         "constructor" : {
-          "abiName" : "bjs_PolygonReference_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_PolygonReference_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -129,7 +129,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_PolygonReference_vertexCount",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PolygonReference_vertexCount",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -149,7 +149,7 @@
             }
           },
           {
-            "abiName" : "bjs_PolygonReference_summary",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PolygonReference_summary",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -166,7 +166,7 @@
             }
           },
           {
-            "abiName" : "bjs_PolygonReference_snapshot",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PolygonReference_snapshot",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -178,17 +178,17 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_PolygonReference_merge",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PolygonReference_merge",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -201,10 +201,10 @@
                 "name" : "other",
                 "type" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "BridgeJSRuntimeTests.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "BridgeJSRuntimeTests.PolygonReference"
                       }
                     }
                   }
@@ -213,17 +213,17 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
             }
           },
           {
-            "abiName" : "bjs_PolygonReference_static_origin",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PolygonReference_static_origin",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -243,17 +243,17 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "PolygonReference"
+                "_0" : "BridgeJSRuntimeTests_PolygonReference"
               }
             }
           }
@@ -262,12 +262,12 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PolygonReference"
+        "swiftCallName" : "BridgeJSRuntimeTests.PolygonReference"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_TagReference_describe",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TagReference_describe",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -288,11 +288,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "TagReference"
+        "swiftCallName" : "BridgeJSRuntimeTests.TagReference"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_TagHolderReference_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_TagHolderReference_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -304,10 +304,10 @@
               "name" : "tag",
               "type" : {
                 "alias" : {
-                  "name" : "Tag",
+                  "name" : "BridgeJSRuntimeTests.Tag",
                   "underlying" : {
                     "swiftHeapObject" : {
-                      "_0" : "TagReference"
+                      "_0" : "BridgeJSRuntimeTests.TagReference"
                     }
                   }
                 }
@@ -329,7 +329,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_TagHolderReference_describe",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TagHolderReference_describe",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -354,10 +354,10 @@
             "name" : "tag",
             "type" : {
               "alias" : {
-                "name" : "Tag",
+                "name" : "BridgeJSRuntimeTests.Tag",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "TagReference"
+                    "_0" : "BridgeJSRuntimeTests.TagReference"
                   }
                 }
               }
@@ -377,12 +377,12 @@
             }
           }
         ],
-        "swiftCallName" : "TagHolderReference"
+        "swiftCallName" : "BridgeJSRuntimeTests.TagHolderReference"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_PriorityReference_describe",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PriorityReference_describe",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -399,7 +399,7 @@
             }
           },
           {
-            "abiName" : "bjs_PriorityReference_weight",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PriorityReference_weight",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -419,7 +419,7 @@
             }
           },
           {
-            "abiName" : "bjs_PriorityReference_static_low",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PriorityReference_static_low",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -431,22 +431,22 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Priority",
+                "name" : "BridgeJSRuntimeTests.Priority",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PriorityReference"
+                    "_0" : "BridgeJSRuntimeTests.PriorityReference"
                   }
                 }
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "PriorityReference"
+                "_0" : "BridgeJSRuntimeTests_PriorityReference"
               }
             }
           },
           {
-            "abiName" : "bjs_PriorityReference_static_medium",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PriorityReference_static_medium",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -458,22 +458,22 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Priority",
+                "name" : "BridgeJSRuntimeTests.Priority",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PriorityReference"
+                    "_0" : "BridgeJSRuntimeTests.PriorityReference"
                   }
                 }
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "PriorityReference"
+                "_0" : "BridgeJSRuntimeTests_PriorityReference"
               }
             }
           },
           {
-            "abiName" : "bjs_PriorityReference_static_high",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PriorityReference_static_high",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -485,17 +485,17 @@
             ],
             "returnType" : {
               "alias" : {
-                "name" : "Priority",
+                "name" : "BridgeJSRuntimeTests.Priority",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PriorityReference"
+                    "_0" : "BridgeJSRuntimeTests.PriorityReference"
                   }
                 }
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "PriorityReference"
+                "_0" : "BridgeJSRuntimeTests_PriorityReference"
               }
             }
           }
@@ -504,12 +504,12 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PriorityReference"
+        "swiftCallName" : "BridgeJSRuntimeTests.PriorityReference"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_ClosureSupportExports_static_makeIntToInt",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeIntToInt",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -562,12 +562,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ClosureSupportExports"
+                "_0" : "BridgeJSRuntimeTests_ClosureSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ClosureSupportExports_static_makeDoubleToDouble",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeDoubleToDouble",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -611,12 +611,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ClosureSupportExports"
+                "_0" : "BridgeJSRuntimeTests_ClosureSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ClosureSupportExports_static_makeStringToString",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeStringToString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -660,12 +660,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ClosureSupportExports"
+                "_0" : "BridgeJSRuntimeTests_ClosureSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ClosureSupportExports_static_makeJSIntToInt",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSIntToInt",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -718,12 +718,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ClosureSupportExports"
+                "_0" : "BridgeJSRuntimeTests_ClosureSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ClosureSupportExports_static_makeJSDoubleToDouble",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSDoubleToDouble",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -767,12 +767,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ClosureSupportExports"
+                "_0" : "BridgeJSRuntimeTests_ClosureSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ClosureSupportExports_static_makeJSStringToString",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ClosureSupportExports_static_makeJSStringToString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -816,7 +816,7 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ClosureSupportExports"
+                "_0" : "BridgeJSRuntimeTests_ClosureSupportExports"
               }
             }
           }
@@ -825,11 +825,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ClosureSupportExports"
+        "swiftCallName" : "BridgeJSRuntimeTests.ClosureSupportExports"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_DefaultArgumentConstructorDefaults_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -884,7 +884,7 @@
             {
               "defaultValue" : {
                 "enumCase" : {
-                  "_0" : "Status",
+                  "_0" : "BridgeJSRuntimeTests.Status",
                   "_1" : "success"
                 }
               },
@@ -892,7 +892,7 @@
               "name" : "status",
               "type" : {
                 "caseEnum" : {
-                  "_0" : "Status"
+                  "_0" : "BridgeJSRuntimeTests.Status"
                 }
               }
             },
@@ -919,7 +919,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_DefaultArgumentConstructorDefaults_describe",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentConstructorDefaults_describe",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -977,7 +977,7 @@
             "name" : "status",
             "type" : {
               "caseEnum" : {
-                "_0" : "Status"
+                "_0" : "BridgeJSRuntimeTests.Status"
               }
             }
           },
@@ -997,11 +997,11 @@
             }
           }
         ],
-        "swiftCallName" : "DefaultArgumentConstructorDefaults"
+        "swiftCallName" : "BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Greeter_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_Greeter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1022,7 +1022,7 @@
         "explicitAccessControl" : "public",
         "methods" : [
           {
-            "abiName" : "bjs_Greeter_greet",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Greeter_greet",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1039,7 +1039,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_changeName",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Greeter_changeName",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1064,7 +1064,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_greetWith",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Greeter_greetWith",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1077,7 +1077,7 @@
                 "name" : "greeter",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 }
               },
@@ -1089,12 +1089,12 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTests7GreeterC_SS",
+                      "mangleName" : "20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "swiftHeapObject" : {
-                            "_0" : "Greeter"
+                            "_0" : "BridgeJSRuntimeTests.Greeter"
                           }
                         }
                       ],
@@ -1117,7 +1117,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_makeFormatter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Greeter_makeFormatter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1161,7 +1161,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_static_makeCreator",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Greeter_static_makeCreator",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -1184,7 +1184,7 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTestsSS_7GreeterC",
+                  "mangleName" : "20BridgeJSRuntimeTestsSS_28BridgeJSRuntimeTests_GreeterC",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
                     {
@@ -1195,7 +1195,7 @@
                   ],
                   "returnType" : {
                     "swiftHeapObject" : {
-                      "_0" : "Greeter"
+                      "_0" : "BridgeJSRuntimeTests.Greeter"
                     }
                   },
                   "sendingParameters" : false
@@ -1205,12 +1205,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests_Greeter"
               }
             }
           },
           {
-            "abiName" : "bjs_Greeter_makeCustomGreeter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Greeter_makeCustomGreeter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1225,12 +1225,12 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTests7GreeterC_SS",
+                  "mangleName" : "20BridgeJSRuntimeTests28BridgeJSRuntimeTests_GreeterC_SS",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
                     {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     }
                   ],
@@ -1246,7 +1246,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_greetEnthusiastically",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Greeter_greetEnthusiastically",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1263,7 +1263,7 @@
             }
           },
           {
-            "abiName" : "bjs_Greeter_static_greetAnonymously",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Greeter_static_greetAnonymously",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -1280,7 +1280,7 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests_Greeter"
               }
             }
           }
@@ -1326,7 +1326,7 @@
             "name" : "defaultGreeting",
             "staticContext" : {
               "className" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests_Greeter"
               }
             },
             "type" : {
@@ -1336,12 +1336,12 @@
             }
           }
         ],
-        "swiftCallName" : "Greeter"
+        "swiftCallName" : "BridgeJSRuntimeTests.Greeter"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_Calculator_square",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Calculator_square",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1372,7 +1372,7 @@
             }
           },
           {
-            "abiName" : "bjs_Calculator_add",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Calculator_add",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1415,7 +1415,7 @@
             }
           },
           {
-            "abiName" : "bjs_Calculator_asyncMakePoint",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Calculator_asyncMakePoint",
             "effects" : {
               "isAsync" : true,
               "isStatic" : false,
@@ -1450,7 +1450,7 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "PublicPoint"
+                "_0" : "BridgeJSRuntimeTests.PublicPoint"
               }
             }
           }
@@ -1459,7 +1459,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Calculator"
+        "swiftCallName" : "BridgeJSRuntimeTests.Calculator"
       },
       {
         "explicitAccessControl" : "internal",
@@ -1470,7 +1470,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "InternalGreeter"
+        "swiftCallName" : "BridgeJSRuntimeTests.InternalGreeter"
       },
       {
         "explicitAccessControl" : "public",
@@ -1481,7 +1481,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PublicGreeter"
+        "swiftCallName" : "BridgeJSRuntimeTests.PublicGreeter"
       },
       {
         "explicitAccessControl" : "package",
@@ -1492,11 +1492,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "PackageGreeter"
+        "swiftCallName" : "BridgeJSRuntimeTests.PackageGreeter"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Utils_Converter_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_Utils_Converter_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1508,7 +1508,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Utils_Converter_toString",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Utils_Converter_toString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1561,11 +1561,11 @@
             }
           }
         ],
-        "swiftCallName" : "Utils.Converter"
+        "swiftCallName" : "BridgeJSRuntimeTests.Utils.Converter"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Networking_API_HTTPServer_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1577,7 +1577,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Networking_API_HTTPServer_call",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Networking_API_HTTPServer_call",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1594,7 +1594,7 @@
                 "name" : "method",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Networking.API.Method"
+                    "_0" : "BridgeJSRuntimeTests.Networking.API.Method"
                   }
                 }
               }
@@ -1614,11 +1614,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Networking.API.HTTPServer"
+        "swiftCallName" : "BridgeJSRuntimeTests.Networking.API.HTTPServer"
       },
       {
         "constructor" : {
-          "abiName" : "bjs___Swift_Foundation_UUID_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_UUID_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1638,7 +1638,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs___Swift_Foundation_UUID_uuidString",
+            "abiName" : "bjs_BridgeJSRuntimeTests_UUID_uuidString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1655,7 +1655,7 @@
             }
           },
           {
-            "abiName" : "bjs___Swift_Foundation_UUID_static_fromValue",
+            "abiName" : "bjs_BridgeJSRuntimeTests_UUID_static_fromValue",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -1675,12 +1675,12 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "UUID"
+                "_0" : "BridgeJSRuntimeTests.UUID"
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "__Swift_Foundation_UUID"
+                "_0" : "BridgeJSRuntimeTests_UUID"
               }
             }
           }
@@ -1697,7 +1697,7 @@
             "name" : "placeholder",
             "staticContext" : {
               "className" : {
-                "_0" : "__Swift_Foundation_UUID"
+                "_0" : "BridgeJSRuntimeTests_UUID"
               }
             },
             "type" : {
@@ -1707,11 +1707,11 @@
             }
           }
         ],
-        "swiftCallName" : "UUID"
+        "swiftCallName" : "BridgeJSRuntimeTests.UUID"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Networking_APIV2_Internal_TestServer_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_Internal_TestServer_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1723,7 +1723,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Networking_APIV2_Internal_TestServer_call",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Internal_TestServer_call",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -1741,7 +1741,7 @@
                 "name" : "method",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Internal.SupportedMethod"
+                    "_0" : "BridgeJSRuntimeTests.Internal.SupportedMethod"
                   }
                 }
               }
@@ -1762,11 +1762,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "Internal.TestServer"
+        "swiftCallName" : "BridgeJSRuntimeTests.Internal.TestServer"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_SimplePropertyHolder_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_SimplePropertyHolder_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1806,11 +1806,11 @@
             }
           }
         ],
-        "swiftCallName" : "SimplePropertyHolder"
+        "swiftCallName" : "BridgeJSRuntimeTests.SimplePropertyHolder"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_PropertyHolder_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_PropertyHolder_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -1879,7 +1879,7 @@
               "name" : "sibling",
               "type" : {
                 "swiftHeapObject" : {
-                  "_0" : "SimplePropertyHolder"
+                  "_0" : "BridgeJSRuntimeTests.SimplePropertyHolder"
                 }
               }
             }
@@ -1887,7 +1887,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_PropertyHolder_getAllValues",
+            "abiName" : "bjs_BridgeJSRuntimeTests_PropertyHolder_getAllValues",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2028,7 +2028,7 @@
             "name" : "sibling",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "SimplePropertyHolder"
+                "_0" : "BridgeJSRuntimeTests.SimplePropertyHolder"
               }
             }
           },
@@ -2079,12 +2079,12 @@
             }
           }
         ],
-        "swiftCallName" : "PropertyHolder"
+        "swiftCallName" : "BridgeJSRuntimeTests.PropertyHolder"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_MathUtils_static_add",
+            "abiName" : "bjs_BridgeJSRuntimeTests_MathUtils_static_add",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -2127,12 +2127,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "BridgeJSRuntimeTests_MathUtils"
               }
             }
           },
           {
-            "abiName" : "bjs_MathUtils_static_substract",
+            "abiName" : "bjs_BridgeJSRuntimeTests_MathUtils_static_substract",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -2175,7 +2175,7 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "MathUtils"
+                "_0" : "BridgeJSRuntimeTests_MathUtils"
               }
             }
           }
@@ -2184,11 +2184,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "MathUtils"
+        "swiftCallName" : "BridgeJSRuntimeTests.MathUtils"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_StaticPropertyHolder_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_StaticPropertyHolder_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -2209,7 +2209,7 @@
             "name" : "staticConstant",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2224,7 +2224,7 @@
             "name" : "staticVariable",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2242,7 +2242,7 @@
             "name" : "staticString",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2257,7 +2257,7 @@
             "name" : "staticBool",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2272,7 +2272,7 @@
             "name" : "staticFloat",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2287,7 +2287,7 @@
             "name" : "staticDouble",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2302,7 +2302,7 @@
             "name" : "computedProperty",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2317,7 +2317,7 @@
             "name" : "readOnlyComputed",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2335,7 +2335,7 @@
             "name" : "optionalString",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2355,7 +2355,7 @@
             "name" : "optionalInt",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2378,7 +2378,7 @@
             "name" : "jsObjectProperty",
             "staticContext" : {
               "className" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests_StaticPropertyHolder"
               }
             },
             "type" : {
@@ -2388,11 +2388,11 @@
             }
           }
         ],
-        "swiftCallName" : "StaticPropertyHolder"
+        "swiftCallName" : "BridgeJSRuntimeTests.StaticPropertyHolder"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_DataProcessorManager_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -2404,7 +2404,7 @@
               "name" : "processor",
               "type" : {
                 "swiftProtocol" : {
-                  "_0" : "DataProcessor"
+                  "_0" : "BridgeJSRuntimeTests.DataProcessor"
                 }
               }
             }
@@ -2412,7 +2412,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_DataProcessorManager_incrementByAmount",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_incrementByAmount",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2440,7 +2440,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_setProcessorLabel",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorLabel",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2474,7 +2474,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_isProcessorEven",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_isProcessorEven",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2491,7 +2491,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_getProcessorLabel",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorLabel",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2508,7 +2508,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_getCurrentValue",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_getCurrentValue",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2528,7 +2528,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_incrementBoth",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_incrementBoth",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2545,7 +2545,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_getBackupValue",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_getBackupValue",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2570,7 +2570,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_hasBackup",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_hasBackup",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2587,7 +2587,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_getProcessorOptionalTag",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorOptionalTag",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2609,7 +2609,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_setProcessorOptionalTag",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorOptionalTag",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2639,7 +2639,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_getProcessorOptionalCount",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorOptionalCount",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2664,7 +2664,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_setProcessorOptionalCount",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorOptionalCount",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2697,7 +2697,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_getProcessorDirection",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorDirection",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2711,7 +2711,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 },
                 "_1" : "null"
@@ -2719,7 +2719,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_setProcessorDirection",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorDirection",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2734,7 +2734,7 @@
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "BridgeJSRuntimeTests.Direction"
                       }
                     },
                     "_1" : "null"
@@ -2749,7 +2749,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_getProcessorTheme",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorTheme",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2763,7 +2763,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 },
@@ -2772,7 +2772,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_setProcessorTheme",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorTheme",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2787,7 +2787,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "Theme",
+                        "_0" : "BridgeJSRuntimeTests.Theme",
                         "_1" : "String"
                       }
                     },
@@ -2803,7 +2803,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_getProcessorHttpStatus",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorHttpStatus",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2817,7 +2817,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "HttpStatus",
+                    "_0" : "BridgeJSRuntimeTests.HttpStatus",
                     "_1" : "Int"
                   }
                 },
@@ -2826,7 +2826,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_setProcessorHttpStatus",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorHttpStatus",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2841,7 +2841,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "HttpStatus",
+                        "_0" : "BridgeJSRuntimeTests.HttpStatus",
                         "_1" : "Int"
                       }
                     },
@@ -2857,7 +2857,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_getProcessorAPIResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_getProcessorAPIResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2871,7 +2871,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -2879,7 +2879,7 @@
             }
           },
           {
-            "abiName" : "bjs_DataProcessorManager_setProcessorAPIResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataProcessorManager_setProcessorAPIResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2894,7 +2894,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "BridgeJSRuntimeTests.APIResult"
                       }
                     },
                     "_1" : "null"
@@ -2917,7 +2917,7 @@
             "name" : "processor",
             "type" : {
               "swiftProtocol" : {
-                "_0" : "DataProcessor"
+                "_0" : "BridgeJSRuntimeTests.DataProcessor"
               }
             }
           },
@@ -2929,7 +2929,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "DataProcessor"
+                    "_0" : "BridgeJSRuntimeTests.DataProcessor"
                   }
                 },
                 "_1" : "null"
@@ -2937,11 +2937,11 @@
             }
           }
         ],
-        "swiftCallName" : "DataProcessorManager"
+        "swiftCallName" : "BridgeJSRuntimeTests.DataProcessorManager"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_SwiftDataProcessor_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -2953,7 +2953,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_SwiftDataProcessor_increment",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_increment",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -2981,7 +2981,7 @@
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_getValue",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getValue",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3001,7 +3001,7 @@
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_setLabelElements",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_setLabelElements",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3035,7 +3035,7 @@
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_getLabel",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getLabel",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3052,7 +3052,7 @@
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_isEven",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_isEven",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3069,7 +3069,7 @@
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_processGreeter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_processGreeter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3082,7 +3082,7 @@
                 "name" : "greeter",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 }
               }
@@ -3094,7 +3094,7 @@
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_createGreeter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_createGreeter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3106,12 +3106,12 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests.Greeter"
               }
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_processOptionalGreeter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_processOptionalGreeter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3126,7 +3126,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     },
                     "_1" : "null"
@@ -3141,7 +3141,7 @@
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_createOptionalGreeter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_createOptionalGreeter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3155,7 +3155,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -3163,7 +3163,7 @@
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_handleAPIResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_handleAPIResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3178,7 +3178,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "BridgeJSRuntimeTests.APIResult"
                       }
                     },
                     "_1" : "null"
@@ -3193,7 +3193,7 @@
             }
           },
           {
-            "abiName" : "bjs_SwiftDataProcessor_getAPIResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_SwiftDataProcessor_getAPIResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3207,7 +3207,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -3281,7 +3281,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 },
                 "_1" : "null"
@@ -3296,7 +3296,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 },
@@ -3312,7 +3312,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "HttpStatus",
+                    "_0" : "BridgeJSRuntimeTests.HttpStatus",
                     "_1" : "Int"
                   }
                 },
@@ -3328,7 +3328,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -3341,7 +3341,7 @@
             "name" : "helper",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests.Greeter"
               }
             }
           },
@@ -3353,7 +3353,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -3361,12 +3361,12 @@
             }
           }
         ],
-        "swiftCallName" : "SwiftDataProcessor"
+        "swiftCallName" : "BridgeJSRuntimeTests.SwiftDataProcessor"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_ProtocolReturnTests_static_createNativeProcessor",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessor",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -3378,17 +3378,17 @@
             ],
             "returnType" : {
               "swiftProtocol" : {
-                "_0" : "DataProcessor"
+                "_0" : "BridgeJSRuntimeTests.DataProcessor"
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ProtocolReturnTests"
+                "_0" : "BridgeJSRuntimeTests_ProtocolReturnTests"
               }
             }
           },
           {
-            "abiName" : "bjs_ProtocolReturnTests_static_createNativeProcessorOptional",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorOptional",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -3402,7 +3402,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "DataProcessor"
+                    "_0" : "BridgeJSRuntimeTests.DataProcessor"
                   }
                 },
                 "_1" : "null"
@@ -3410,12 +3410,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ProtocolReturnTests"
+                "_0" : "BridgeJSRuntimeTests_ProtocolReturnTests"
               }
             }
           },
           {
-            "abiName" : "bjs_ProtocolReturnTests_static_createNativeProcessorNil",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorNil",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -3429,7 +3429,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "DataProcessor"
+                    "_0" : "BridgeJSRuntimeTests.DataProcessor"
                   }
                 },
                 "_1" : "null"
@@ -3437,12 +3437,12 @@
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ProtocolReturnTests"
+                "_0" : "BridgeJSRuntimeTests_ProtocolReturnTests"
               }
             }
           },
           {
-            "abiName" : "bjs_ProtocolReturnTests_static_createNativeProcessorArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -3456,19 +3456,19 @@
               "array" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "DataProcessor"
+                    "_0" : "BridgeJSRuntimeTests.DataProcessor"
                   }
                 }
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ProtocolReturnTests"
+                "_0" : "BridgeJSRuntimeTests_ProtocolReturnTests"
               }
             }
           },
           {
-            "abiName" : "bjs_ProtocolReturnTests_static_createNativeProcessorDictionary",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ProtocolReturnTests_static_createNativeProcessorDictionary",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -3482,14 +3482,14 @@
               "dictionary" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "DataProcessor"
+                    "_0" : "BridgeJSRuntimeTests.DataProcessor"
                   }
                 }
               }
             },
             "staticContext" : {
               "className" : {
-                "_0" : "ProtocolReturnTests"
+                "_0" : "BridgeJSRuntimeTests_ProtocolReturnTests"
               }
             }
           }
@@ -3498,11 +3498,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "ProtocolReturnTests"
+        "swiftCallName" : "BridgeJSRuntimeTests.ProtocolReturnTests"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_TextProcessor_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -3541,7 +3541,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_TextProcessor_process",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_process",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3566,7 +3566,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processWithCustom",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processWithCustom",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3632,7 +3632,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_getTransform",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_getTransform",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3668,7 +3668,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processOptionalString",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3717,7 +3717,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processOptionalInt",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalInt",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3769,7 +3769,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processOptionalGreeter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalGreeter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3785,14 +3785,14 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTestsSq7GreeterC_SS",
+                      "mangleName" : "20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "nullable" : {
                             "_0" : {
                               "swiftHeapObject" : {
-                                "_0" : "Greeter"
+                                "_0" : "BridgeJSRuntimeTests.Greeter"
                               }
                             },
                             "_1" : "null"
@@ -3818,7 +3818,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_makeOptionalStringFormatter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalStringFormatter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3859,7 +3859,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_makeOptionalGreeterCreator",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalGreeterCreator",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3874,7 +3874,7 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTestsy_Sq7GreeterC",
+                  "mangleName" : "20BridgeJSRuntimeTestsy_Sq28BridgeJSRuntimeTests_GreeterC",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
 
@@ -3883,7 +3883,7 @@
                     "nullable" : {
                       "_0" : {
                         "swiftHeapObject" : {
-                          "_0" : "Greeter"
+                          "_0" : "BridgeJSRuntimeTests.Greeter"
                         }
                       },
                       "_1" : "null"
@@ -3896,7 +3896,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processDirection",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processDirection",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3912,12 +3912,12 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTests9DirectionO_SS",
+                      "mangleName" : "20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "caseEnum" : {
-                            "_0" : "Direction"
+                            "_0" : "BridgeJSRuntimeTests.Direction"
                           }
                         }
                       ],
@@ -3940,7 +3940,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processTheme",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processTheme",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -3956,12 +3956,12 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTests5ThemeO_SS",
+                      "mangleName" : "20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "rawValueEnum" : {
-                            "_0" : "Theme",
+                            "_0" : "BridgeJSRuntimeTests.Theme",
                             "_1" : "String"
                           }
                         }
@@ -3985,7 +3985,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processHttpStatus",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processHttpStatus",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4001,12 +4001,12 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTests10HttpStatusO_Si",
+                      "mangleName" : "20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "rawValueEnum" : {
-                            "_0" : "HttpStatus",
+                            "_0" : "BridgeJSRuntimeTests.HttpStatus",
                             "_1" : "Int"
                           }
                         }
@@ -4036,7 +4036,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processAPIResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processAPIResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4052,12 +4052,12 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTests9APIResultO_SS",
+                      "mangleName" : "20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "associatedValueEnum" : {
-                            "_0" : "APIResult"
+                            "_0" : "BridgeJSRuntimeTests.APIResult"
                           }
                         }
                       ],
@@ -4080,7 +4080,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_makeDirectionChecker",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_makeDirectionChecker",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4095,12 +4095,12 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTests9DirectionO_Sb",
+                  "mangleName" : "20BridgeJSRuntimeTests30BridgeJSRuntimeTests_DirectionO_Sb",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
                     {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "BridgeJSRuntimeTests.Direction"
                       }
                     }
                   ],
@@ -4116,7 +4116,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_makeThemeValidator",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_makeThemeValidator",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4131,12 +4131,12 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTests5ThemeO_Sb",
+                  "mangleName" : "20BridgeJSRuntimeTests26BridgeJSRuntimeTests_ThemeO_Sb",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
                     {
                       "rawValueEnum" : {
-                        "_0" : "Theme",
+                        "_0" : "BridgeJSRuntimeTests.Theme",
                         "_1" : "String"
                       }
                     }
@@ -4153,7 +4153,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_makeStatusCodeExtractor",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_makeStatusCodeExtractor",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4168,12 +4168,12 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTests10HttpStatusO_Si",
+                  "mangleName" : "20BridgeJSRuntimeTests31BridgeJSRuntimeTests_HttpStatusO_Si",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
                     {
                       "rawValueEnum" : {
-                        "_0" : "HttpStatus",
+                        "_0" : "BridgeJSRuntimeTests.HttpStatus",
                         "_1" : "Int"
                       }
                     }
@@ -4193,7 +4193,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_makeAPIResultHandler",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_makeAPIResultHandler",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4208,12 +4208,12 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTests9APIResultO_SS",
+                  "mangleName" : "20BridgeJSRuntimeTests30BridgeJSRuntimeTests_APIResultO_SS",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
                     {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "BridgeJSRuntimeTests.APIResult"
                       }
                     }
                   ],
@@ -4229,7 +4229,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processOptionalDirection",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalDirection",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4245,14 +4245,14 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTestsSq9DirectionO_SS",
+                      "mangleName" : "20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "nullable" : {
                             "_0" : {
                               "caseEnum" : {
-                                "_0" : "Direction"
+                                "_0" : "BridgeJSRuntimeTests.Direction"
                               }
                             },
                             "_1" : "null"
@@ -4278,7 +4278,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processOptionalTheme",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalTheme",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4294,14 +4294,14 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTestsSq5ThemeO_SS",
+                      "mangleName" : "20BridgeJSRuntimeTestsSq26BridgeJSRuntimeTests_ThemeO_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "nullable" : {
                             "_0" : {
                               "rawValueEnum" : {
-                                "_0" : "Theme",
+                                "_0" : "BridgeJSRuntimeTests.Theme",
                                 "_1" : "String"
                               }
                             },
@@ -4328,7 +4328,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processOptionalAPIResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalAPIResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4344,14 +4344,14 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTestsSq9APIResultO_SS",
+                      "mangleName" : "20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_APIResultO_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "nullable" : {
                             "_0" : {
                               "associatedValueEnum" : {
-                                "_0" : "APIResult"
+                                "_0" : "BridgeJSRuntimeTests.APIResult"
                               }
                             },
                             "_1" : "null"
@@ -4377,7 +4377,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_makeOptionalDirectionFormatter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_makeOptionalDirectionFormatter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4392,14 +4392,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTestsSq9DirectionO_SS",
+                  "mangleName" : "20BridgeJSRuntimeTestsSq30BridgeJSRuntimeTests_DirectionO_SS",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
                     {
                       "nullable" : {
                         "_0" : {
                           "caseEnum" : {
-                            "_0" : "Direction"
+                            "_0" : "BridgeJSRuntimeTests.Direction"
                           }
                         },
                         "_1" : "null"
@@ -4418,7 +4418,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processDataProcessor",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processDataProcessor",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4434,12 +4434,12 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTests13DataProcessorP_SS",
+                      "mangleName" : "20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "swiftProtocol" : {
-                            "_0" : "DataProcessor"
+                            "_0" : "BridgeJSRuntimeTests.DataProcessor"
                           }
                         }
                       ],
@@ -4462,7 +4462,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_makeDataProcessorFactory",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_makeDataProcessorFactory",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4477,14 +4477,14 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTestsy_13DataProcessorP",
+                  "mangleName" : "20BridgeJSRuntimeTestsy_34BridgeJSRuntimeTests_DataProcessorP",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
 
                   ],
                   "returnType" : {
                     "swiftProtocol" : {
-                      "_0" : "DataProcessor"
+                      "_0" : "BridgeJSRuntimeTests.DataProcessor"
                     }
                   },
                   "sendingParameters" : false
@@ -4494,7 +4494,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_roundtripDataProcessor",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_roundtripDataProcessor",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4510,18 +4510,18 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP",
+                      "mangleName" : "20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "swiftProtocol" : {
-                            "_0" : "DataProcessor"
+                            "_0" : "BridgeJSRuntimeTests.DataProcessor"
                           }
                         }
                       ],
                       "returnType" : {
                         "swiftProtocol" : {
-                          "_0" : "DataProcessor"
+                          "_0" : "BridgeJSRuntimeTests.DataProcessor"
                         }
                       },
                       "sendingParameters" : false
@@ -4536,18 +4536,18 @@
                 "_0" : {
                   "isAsync" : false,
                   "isThrows" : false,
-                  "mangleName" : "20BridgeJSRuntimeTests13DataProcessorP_13DataProcessorP",
+                  "mangleName" : "20BridgeJSRuntimeTests34BridgeJSRuntimeTests_DataProcessorP_34BridgeJSRuntimeTests_DataProcessorP",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
                     {
                       "swiftProtocol" : {
-                        "_0" : "DataProcessor"
+                        "_0" : "BridgeJSRuntimeTests.DataProcessor"
                       }
                     }
                   ],
                   "returnType" : {
                     "swiftProtocol" : {
-                      "_0" : "DataProcessor"
+                      "_0" : "BridgeJSRuntimeTests.DataProcessor"
                     }
                   },
                   "sendingParameters" : false
@@ -4557,7 +4557,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processOptionalDataProcessor",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalDataProcessor",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4573,14 +4573,14 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTestsSq13DataProcessorP_SS",
+                      "mangleName" : "20BridgeJSRuntimeTestsSq34BridgeJSRuntimeTests_DataProcessorP_SS",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "nullable" : {
                             "_0" : {
                               "swiftProtocol" : {
-                                "_0" : "DataProcessor"
+                                "_0" : "BridgeJSRuntimeTests.DataProcessor"
                               }
                             },
                             "_1" : "null"
@@ -4606,7 +4606,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processVector",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processVector",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4622,7 +4622,7 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTestsSd_8Vector2DV",
+                      "mangleName" : "20BridgeJSRuntimeTestsSd_29BridgeJSRuntimeTests_Vector2DV",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
@@ -4633,7 +4633,7 @@
                       ],
                       "returnType" : {
                         "swiftStruct" : {
-                          "_0" : "Vector2D"
+                          "_0" : "BridgeJSRuntimeTests.Vector2D"
                         }
                       },
                       "sendingParameters" : false
@@ -4650,7 +4650,7 @@
             }
           },
           {
-            "abiName" : "bjs_TextProcessor_processOptionalVector",
+            "abiName" : "bjs_BridgeJSRuntimeTests_TextProcessor_processOptionalVector",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4666,7 +4666,7 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTestsSd_Sq8Vector2DV",
+                      "mangleName" : "20BridgeJSRuntimeTestsSd_Sq29BridgeJSRuntimeTests_Vector2DV",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
@@ -4679,7 +4679,7 @@
                         "nullable" : {
                           "_0" : {
                             "swiftStruct" : {
-                              "_0" : "Vector2D"
+                              "_0" : "BridgeJSRuntimeTests.Vector2D"
                             }
                           },
                           "_1" : "null"
@@ -4703,11 +4703,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "TextProcessor"
+        "swiftCallName" : "BridgeJSRuntimeTests.TextProcessor"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_NestedTypeHost_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_NestedTypeHost_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -4719,7 +4719,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_NestedTypeHost_describe",
+            "abiName" : "bjs_BridgeJSRuntimeTests_NestedTypeHost_describe",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -4740,11 +4740,11 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "NestedTypeHost"
+        "swiftCallName" : "BridgeJSRuntimeTests.NestedTypeHost"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_OptionalHolder_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_OptionalHolder_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -4758,7 +4758,7 @@
                 "nullable" : {
                   "_0" : {
                     "swiftHeapObject" : {
-                      "_0" : "Greeter"
+                      "_0" : "BridgeJSRuntimeTests.Greeter"
                     }
                   },
                   "_1" : "null"
@@ -4794,7 +4794,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -4817,11 +4817,11 @@
             }
           }
         ],
-        "swiftCallName" : "OptionalHolder"
+        "swiftCallName" : "BridgeJSRuntimeTests.OptionalHolder"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_OptionalPropertyHolder_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_OptionalPropertyHolder_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -4890,7 +4890,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -4898,11 +4898,11 @@
             }
           }
         ],
-        "swiftCallName" : "OptionalPropertyHolder"
+        "swiftCallName" : "BridgeJSRuntimeTests.OptionalPropertyHolder"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Container_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_Container_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -4914,7 +4914,7 @@
               "name" : "location",
               "type" : {
                 "swiftStruct" : {
-                  "_0" : "DataPoint"
+                  "_0" : "BridgeJSRuntimeTests.DataPoint"
                 }
               }
             },
@@ -4925,7 +4925,7 @@
                 "nullable" : {
                   "_0" : {
                     "swiftStruct" : {
-                      "_0" : "Config"
+                      "_0" : "BridgeJSRuntimeTests.Config"
                     }
                   },
                   "_1" : "null"
@@ -4945,7 +4945,7 @@
             "name" : "location",
             "type" : {
               "swiftStruct" : {
-                "_0" : "DataPoint"
+                "_0" : "BridgeJSRuntimeTests.DataPoint"
               }
             }
           },
@@ -4957,7 +4957,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Config"
+                    "_0" : "BridgeJSRuntimeTests.Config"
                   }
                 },
                 "_1" : "null"
@@ -4965,11 +4965,11 @@
             }
           }
         ],
-        "swiftCallName" : "Container"
+        "swiftCallName" : "BridgeJSRuntimeTests.Container"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_LeakCheck_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_LeakCheck_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -4987,7 +4987,7 @@
         "properties" : [
 
         ],
-        "swiftCallName" : "LeakCheck"
+        "swiftCallName" : "BridgeJSRuntimeTests.LeakCheck"
       }
     ],
     "enums" : [
@@ -5020,7 +5020,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Severity",
+        "swiftCallName" : "BridgeJSRuntimeTests.Severity",
         "tsFullPath" : "Severity"
       },
       {
@@ -5030,10 +5030,10 @@
               {
                 "type" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "BridgeJSRuntimeTests.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "BridgeJSRuntimeTests.PolygonReference"
                       }
                     }
                   }
@@ -5057,7 +5057,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Shape",
+        "swiftCallName" : "BridgeJSRuntimeTests.Shape",
         "tsFullPath" : "Shape"
       },
       {
@@ -5092,7 +5092,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "InnerTag",
+        "swiftCallName" : "BridgeJSRuntimeTests.InnerTag",
         "tsFullPath" : "InnerTag"
       },
       {
@@ -5103,7 +5103,7 @@
         "name" : "ArraySupportExports",
         "staticMethods" : [
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripIntArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5145,12 +5145,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripStringArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStringArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5186,12 +5186,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripDoubleArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripDoubleArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5227,12 +5227,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripBoolArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripBoolArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5268,12 +5268,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripUnsafeRawPointerArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeRawPointerArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5313,12 +5313,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripUnsafeMutableRawPointerArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeMutableRawPointerArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5358,12 +5358,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOpaquePointerArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOpaquePointerArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5403,12 +5403,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripUnsafePointerArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafePointerArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5450,12 +5450,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripUnsafeMutablePointerArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUnsafeMutablePointerArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5497,12 +5497,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripJSValueArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSValueArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5538,12 +5538,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripJSObjectArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSObjectArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5579,12 +5579,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripCaseEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripCaseEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5602,7 +5602,7 @@
                   "array" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "BridgeJSRuntimeTests.Direction"
                       }
                     }
                   }
@@ -5613,19 +5613,19 @@
               "array" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 }
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripStringRawValueEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStringRawValueEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5643,7 +5643,7 @@
                   "array" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "Theme",
+                        "_0" : "BridgeJSRuntimeTests.Theme",
                         "_1" : "String"
                       }
                     }
@@ -5655,7 +5655,7 @@
               "array" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 }
@@ -5663,12 +5663,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripIntRawValueEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripIntRawValueEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5686,7 +5686,7 @@
                   "array" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "HttpStatus",
+                        "_0" : "BridgeJSRuntimeTests.HttpStatus",
                         "_1" : "Int"
                       }
                     }
@@ -5698,7 +5698,7 @@
               "array" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "HttpStatus",
+                    "_0" : "BridgeJSRuntimeTests.HttpStatus",
                     "_1" : "Int"
                   }
                 }
@@ -5706,12 +5706,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripInt64RawValueEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripInt64RawValueEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5729,7 +5729,7 @@
                   "array" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "FileSize",
+                        "_0" : "BridgeJSRuntimeTests.FileSize",
                         "_1" : "Int64"
                       }
                     }
@@ -5741,7 +5741,7 @@
               "array" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "FileSize",
+                    "_0" : "BridgeJSRuntimeTests.FileSize",
                     "_1" : "Int64"
                   }
                 }
@@ -5749,12 +5749,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripUInt64RawValueEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripUInt64RawValueEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5772,7 +5772,7 @@
                   "array" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "SessionId",
+                        "_0" : "BridgeJSRuntimeTests.SessionId",
                         "_1" : "UInt64"
                       }
                     }
@@ -5784,7 +5784,7 @@
               "array" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "SessionId",
+                    "_0" : "BridgeJSRuntimeTests.SessionId",
                     "_1" : "UInt64"
                   }
                 }
@@ -5792,12 +5792,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripStructArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripStructArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5815,7 +5815,7 @@
                   "array" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "DataPoint"
+                        "_0" : "BridgeJSRuntimeTests.DataPoint"
                       }
                     }
                   }
@@ -5826,19 +5826,19 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "DataPoint"
+                    "_0" : "BridgeJSRuntimeTests.DataPoint"
                   }
                 }
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripSwiftClassArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripSwiftClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5856,7 +5856,7 @@
                   "array" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     }
                   }
@@ -5867,19 +5867,19 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 }
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripNamespacedSwiftClassArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNamespacedSwiftClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5897,7 +5897,7 @@
                   "array" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Utils.Converter"
+                        "_0" : "BridgeJSRuntimeTests.Utils.Converter"
                       }
                     }
                   }
@@ -5908,19 +5908,19 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Utils.Converter"
+                    "_0" : "BridgeJSRuntimeTests.Utils.Converter"
                   }
                 }
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripProtocolArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripProtocolArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5938,7 +5938,7 @@
                   "array" : {
                     "_0" : {
                       "swiftProtocol" : {
-                        "_0" : "ArrayElementProtocol"
+                        "_0" : "BridgeJSRuntimeTests.ArrayElementProtocol"
                       }
                     }
                   }
@@ -5949,19 +5949,19 @@
               "array" : {
                 "_0" : {
                   "swiftProtocol" : {
-                    "_0" : "ArrayElementProtocol"
+                    "_0" : "BridgeJSRuntimeTests.ArrayElementProtocol"
                   }
                 }
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripJSClassArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripJSClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -5997,12 +5997,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalIntArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6054,12 +6054,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalStringArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStringArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6105,12 +6105,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalJSObjectArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalJSObjectArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6156,12 +6156,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalCaseEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalCaseEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6181,7 +6181,7 @@
                       "nullable" : {
                         "_0" : {
                           "caseEnum" : {
-                            "_0" : "Direction"
+                            "_0" : "BridgeJSRuntimeTests.Direction"
                           }
                         },
                         "_1" : "null"
@@ -6197,7 +6197,7 @@
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "BridgeJSRuntimeTests.Direction"
                       }
                     },
                     "_1" : "null"
@@ -6207,12 +6207,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalStringRawValueEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStringRawValueEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6232,7 +6232,7 @@
                       "nullable" : {
                         "_0" : {
                           "rawValueEnum" : {
-                            "_0" : "Theme",
+                            "_0" : "BridgeJSRuntimeTests.Theme",
                             "_1" : "String"
                           }
                         },
@@ -6249,7 +6249,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "Theme",
+                        "_0" : "BridgeJSRuntimeTests.Theme",
                         "_1" : "String"
                       }
                     },
@@ -6260,12 +6260,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalIntRawValueEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalIntRawValueEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6285,7 +6285,7 @@
                       "nullable" : {
                         "_0" : {
                           "rawValueEnum" : {
-                            "_0" : "HttpStatus",
+                            "_0" : "BridgeJSRuntimeTests.HttpStatus",
                             "_1" : "Int"
                           }
                         },
@@ -6302,7 +6302,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "HttpStatus",
+                        "_0" : "BridgeJSRuntimeTests.HttpStatus",
                         "_1" : "Int"
                       }
                     },
@@ -6313,12 +6313,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalInt64RawValueEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalInt64RawValueEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6338,7 +6338,7 @@
                       "nullable" : {
                         "_0" : {
                           "rawValueEnum" : {
-                            "_0" : "FileSize",
+                            "_0" : "BridgeJSRuntimeTests.FileSize",
                             "_1" : "Int64"
                           }
                         },
@@ -6355,7 +6355,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "FileSize",
+                        "_0" : "BridgeJSRuntimeTests.FileSize",
                         "_1" : "Int64"
                       }
                     },
@@ -6366,12 +6366,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalUInt64RawValueEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalUInt64RawValueEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6391,7 +6391,7 @@
                       "nullable" : {
                         "_0" : {
                           "rawValueEnum" : {
-                            "_0" : "SessionId",
+                            "_0" : "BridgeJSRuntimeTests.SessionId",
                             "_1" : "UInt64"
                           }
                         },
@@ -6408,7 +6408,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "SessionId",
+                        "_0" : "BridgeJSRuntimeTests.SessionId",
                         "_1" : "UInt64"
                       }
                     },
@@ -6419,12 +6419,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalStructArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalStructArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6444,7 +6444,7 @@
                       "nullable" : {
                         "_0" : {
                           "swiftStruct" : {
-                            "_0" : "DataPoint"
+                            "_0" : "BridgeJSRuntimeTests.DataPoint"
                           }
                         },
                         "_1" : "null"
@@ -6460,7 +6460,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "DataPoint"
+                        "_0" : "BridgeJSRuntimeTests.DataPoint"
                       }
                     },
                     "_1" : "null"
@@ -6470,12 +6470,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalSwiftClassArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalSwiftClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6495,7 +6495,7 @@
                       "nullable" : {
                         "_0" : {
                           "swiftHeapObject" : {
-                            "_0" : "Greeter"
+                            "_0" : "BridgeJSRuntimeTests.Greeter"
                           }
                         },
                         "_1" : "null"
@@ -6511,7 +6511,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     },
                     "_1" : "null"
@@ -6521,12 +6521,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripOptionalJSClassArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripOptionalJSClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6572,12 +6572,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripNestedIntArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6627,12 +6627,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripNestedStringArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedStringArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6676,12 +6676,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripNestedDoubleArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedDoubleArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6725,12 +6725,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripNestedBoolArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedBoolArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6774,12 +6774,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripNestedStructArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedStructArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6799,7 +6799,7 @@
                       "array" : {
                         "_0" : {
                           "swiftStruct" : {
-                            "_0" : "DataPoint"
+                            "_0" : "BridgeJSRuntimeTests.DataPoint"
                           }
                         }
                       }
@@ -6814,7 +6814,7 @@
                   "array" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "DataPoint"
+                        "_0" : "BridgeJSRuntimeTests.DataPoint"
                       }
                     }
                   }
@@ -6823,12 +6823,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripNestedCaseEnumArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedCaseEnumArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6848,7 +6848,7 @@
                       "array" : {
                         "_0" : {
                           "caseEnum" : {
-                            "_0" : "Direction"
+                            "_0" : "BridgeJSRuntimeTests.Direction"
                           }
                         }
                       }
@@ -6863,7 +6863,7 @@
                   "array" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "BridgeJSRuntimeTests.Direction"
                       }
                     }
                   }
@@ -6872,12 +6872,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_roundTripNestedSwiftClassArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_roundTripNestedSwiftClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6897,7 +6897,7 @@
                       "array" : {
                         "_0" : {
                           "swiftHeapObject" : {
-                            "_0" : "Greeter"
+                            "_0" : "BridgeJSRuntimeTests.Greeter"
                           }
                         }
                       }
@@ -6912,7 +6912,7 @@
                   "array" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     }
                   }
@@ -6921,12 +6921,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_multiArrayFirst",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiArrayFirst",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -6981,12 +6981,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_multiArraySecond",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiArraySecond",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7038,12 +7038,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_multiOptionalArrayFirst",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiOptionalArrayFirst",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7113,12 +7113,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_ArraySupportExports_static_multiOptionalArraySecond",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArraySupportExports_static_multiOptionalArraySecond",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7185,7 +7185,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "ArraySupportExports"
+                "_0" : "BridgeJSRuntimeTests.ArraySupportExports"
               }
             }
           }
@@ -7193,7 +7193,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "ArraySupportExports",
+        "swiftCallName" : "BridgeJSRuntimeTests.ArraySupportExports",
         "tsFullPath" : "ArraySupportExports"
       },
       {
@@ -7240,7 +7240,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "AsyncImportedPayloadResult",
+        "swiftCallName" : "BridgeJSRuntimeTests.AsyncImportedPayloadResult",
         "tsFullPath" : "AsyncImportedPayloadResult"
       },
       {
@@ -7251,7 +7251,7 @@
         "name" : "DefaultArgumentExports",
         "staticMethods" : [
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testStringDefault",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testStringDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7284,12 +7284,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testIntDefault",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testIntDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7328,12 +7328,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testBoolDefault",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testBoolDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7366,12 +7366,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testOptionalDefault",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testOptionalDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7414,12 +7414,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testMultipleDefaults",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testMultipleDefaults",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7483,12 +7483,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testSimpleEnumDefault",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testSimpleEnumDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7502,7 +7502,7 @@
               {
                 "defaultValue" : {
                   "enumCase" : {
-                    "_0" : "Status",
+                    "_0" : "BridgeJSRuntimeTests.Status",
                     "_1" : "success"
                   }
                 },
@@ -7510,24 +7510,24 @@
                 "name" : "status",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Status"
+                    "_0" : "BridgeJSRuntimeTests.Status"
                   }
                 }
               }
             ],
             "returnType" : {
               "caseEnum" : {
-                "_0" : "Status"
+                "_0" : "BridgeJSRuntimeTests.Status"
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testDirectionDefault",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testDirectionDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7541,7 +7541,7 @@
               {
                 "defaultValue" : {
                   "enumCase" : {
-                    "_0" : "Direction",
+                    "_0" : "BridgeJSRuntimeTests.Direction",
                     "_1" : "north"
                   }
                 },
@@ -7549,24 +7549,24 @@
                 "name" : "direction",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 }
               }
             ],
             "returnType" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "BridgeJSRuntimeTests.Direction"
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testRawStringEnumDefault",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testRawStringEnumDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7580,7 +7580,7 @@
               {
                 "defaultValue" : {
                   "enumCase" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "light"
                   }
                 },
@@ -7588,7 +7588,7 @@
                 "name" : "theme",
                 "type" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 }
@@ -7596,18 +7596,18 @@
             ],
             "returnType" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "BridgeJSRuntimeTests.Theme",
                 "_1" : "String"
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testComplexInit",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testComplexInit",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7635,7 +7635,7 @@
                 "name" : "greeter",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 }
               }
@@ -7647,12 +7647,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_testEmptyInit",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_testEmptyInit",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7673,24 +7673,24 @@
                 "name" : "object",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "StaticPropertyHolder"
+                    "_0" : "BridgeJSRuntimeTests.StaticPropertyHolder"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "StaticPropertyHolder"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyHolder"
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_createConstructorDefaults",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_createConstructorDefaults",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7749,7 +7749,7 @@
               {
                 "defaultValue" : {
                   "enumCase" : {
-                    "_0" : "Status",
+                    "_0" : "BridgeJSRuntimeTests.Status",
                     "_1" : "success"
                   }
                 },
@@ -7757,7 +7757,7 @@
                 "name" : "status",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Status"
+                    "_0" : "BridgeJSRuntimeTests.Status"
                   }
                 }
               },
@@ -7783,17 +7783,17 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "DefaultArgumentConstructorDefaults"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults"
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_describeConstructorDefaults",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_describeConstructorDefaults",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7809,7 +7809,7 @@
                 "name" : "value",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "DefaultArgumentConstructorDefaults"
+                    "_0" : "BridgeJSRuntimeTests.DefaultArgumentConstructorDefaults"
                   }
                 }
               }
@@ -7821,12 +7821,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_arrayWithDefault",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayWithDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7885,12 +7885,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_arrayWithOptionalDefault",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayWithOptionalDefault",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -7938,12 +7938,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           },
           {
-            "abiName" : "bjs_DefaultArgumentExports_static_arrayMixedDefaults",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DefaultArgumentExports_static_arrayMixedDefaults",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -8022,7 +8022,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "DefaultArgumentExports"
+                "_0" : "BridgeJSRuntimeTests.DefaultArgumentExports"
               }
             }
           }
@@ -8030,7 +8030,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "DefaultArgumentExports",
+        "swiftCallName" : "BridgeJSRuntimeTests.DefaultArgumentExports",
         "tsFullPath" : "DefaultArgumentExports"
       },
       {
@@ -8069,7 +8069,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Direction",
+        "swiftCallName" : "BridgeJSRuntimeTests.Direction",
         "tsFullPath" : "Direction"
       },
       {
@@ -8101,7 +8101,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Status",
+        "swiftCallName" : "BridgeJSRuntimeTests.Status",
         "tsFullPath" : "Status"
       },
       {
@@ -8137,7 +8137,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Theme",
+        "swiftCallName" : "BridgeJSRuntimeTests.Theme",
         "tsFullPath" : "Theme"
       },
       {
@@ -8180,7 +8180,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "HttpStatus",
+        "swiftCallName" : "BridgeJSRuntimeTests.HttpStatus",
         "tsFullPath" : "HttpStatus"
       },
       {
@@ -8223,7 +8223,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "FileSize",
+        "swiftCallName" : "BridgeJSRuntimeTests.FileSize",
         "tsFullPath" : "FileSize"
       },
       {
@@ -8259,7 +8259,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "SessionId",
+        "swiftCallName" : "BridgeJSRuntimeTests.SessionId",
         "tsFullPath" : "SessionId"
       },
       {
@@ -8295,7 +8295,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Precision",
+        "swiftCallName" : "BridgeJSRuntimeTests.Precision",
         "tsFullPath" : "Precision"
       },
       {
@@ -8331,7 +8331,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Ratio",
+        "swiftCallName" : "BridgeJSRuntimeTests.Ratio",
         "tsFullPath" : "Ratio"
       },
       {
@@ -8369,7 +8369,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "TSDirection",
+        "swiftCallName" : "BridgeJSRuntimeTests.TSDirection",
         "tsFullPath" : "TSDirection"
       },
       {
@@ -8405,7 +8405,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "TSTheme",
+        "swiftCallName" : "BridgeJSRuntimeTests.TSTheme",
         "tsFullPath" : "TSTheme"
       },
       {
@@ -8452,7 +8452,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "AsyncPayloadResult",
+        "swiftCallName" : "BridgeJSRuntimeTests.AsyncPayloadResult",
         "tsFullPath" : "AsyncPayloadResult"
       },
       {
@@ -8467,7 +8467,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utils",
+        "swiftCallName" : "BridgeJSRuntimeTests.Utils",
         "tsFullPath" : "Utils"
       },
       {
@@ -8481,7 +8481,7 @@
         ],
         "staticMethods" : [
           {
-            "abiName" : "bjs_Utils_StringUtils_static_uppercase",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Utils_StringUtils_static_uppercase",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -8510,12 +8510,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "Utils.StringUtils"
+                "_0" : "BridgeJSRuntimeTests.Utils.StringUtils"
               }
             }
           },
           {
-            "abiName" : "bjs_Utils_StringUtils_static_lowercase",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Utils_StringUtils_static_lowercase",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -8544,7 +8544,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "Utils.StringUtils"
+                "_0" : "BridgeJSRuntimeTests.Utils.StringUtils"
               }
             }
           }
@@ -8552,7 +8552,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utils.StringUtils",
+        "swiftCallName" : "BridgeJSRuntimeTests.Utils.StringUtils",
         "tsFullPath" : "Utils.StringUtils"
       },
       {
@@ -8567,7 +8567,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Networking",
+        "swiftCallName" : "BridgeJSRuntimeTests.Networking",
         "tsFullPath" : "Networking"
       },
       {
@@ -8585,7 +8585,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Networking.API",
+        "swiftCallName" : "BridgeJSRuntimeTests.Networking.API",
         "tsFullPath" : "Networking.API"
       },
       {
@@ -8627,7 +8627,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Networking.API.Method",
+        "swiftCallName" : "BridgeJSRuntimeTests.Networking.API.Method",
         "tsFullPath" : "Networking.API.Method"
       },
       {
@@ -8642,7 +8642,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Configuration",
+        "swiftCallName" : "BridgeJSRuntimeTests.Configuration",
         "tsFullPath" : "Configuration"
       },
       {
@@ -8688,7 +8688,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Configuration.LogLevel",
+        "swiftCallName" : "BridgeJSRuntimeTests.Configuration.LogLevel",
         "tsFullPath" : "Configuration.LogLevel"
       },
       {
@@ -8727,7 +8727,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Configuration.Port",
+        "swiftCallName" : "BridgeJSRuntimeTests.Configuration.Port",
         "tsFullPath" : "Configuration.Port"
       },
       {
@@ -8746,7 +8746,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Internal",
+        "swiftCallName" : "BridgeJSRuntimeTests.Internal",
         "tsFullPath" : "Networking.APIV2.Internal"
       },
       {
@@ -8777,7 +8777,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Internal.SupportedMethod",
+        "swiftCallName" : "BridgeJSRuntimeTests.Internal.SupportedMethod",
         "tsFullPath" : "Networking.APIV2.Internal.SupportedMethod"
       },
       {
@@ -8860,7 +8860,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "APIResult",
+        "swiftCallName" : "BridgeJSRuntimeTests.APIResult",
         "tsFullPath" : "APIResult"
       },
       {
@@ -9069,7 +9069,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "ComplexResult",
+        "swiftCallName" : "BridgeJSRuntimeTests.ComplexResult",
         "tsFullPath" : "ComplexResult"
       },
       {
@@ -9084,7 +9084,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utilities",
+        "swiftCallName" : "BridgeJSRuntimeTests.Utilities",
         "tsFullPath" : "Utilities"
       },
       {
@@ -9164,7 +9164,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "Utilities.Result",
+        "swiftCallName" : "BridgeJSRuntimeTests.Utilities.Result",
         "tsFullPath" : "Utilities.Result"
       },
       {
@@ -9179,7 +9179,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "API",
+        "swiftCallName" : "BridgeJSRuntimeTests.API",
         "tsFullPath" : "API"
       },
       {
@@ -9230,7 +9230,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "API.NetworkingResult",
+        "swiftCallName" : "BridgeJSRuntimeTests.API.NetworkingResult",
         "tsFullPath" : "API.NetworkingResult"
       },
       {
@@ -9240,7 +9240,7 @@
               {
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "Address"
+                    "_0" : "BridgeJSRuntimeTests.Address"
                   }
                 }
               }
@@ -9252,7 +9252,7 @@
               {
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 }
               }
@@ -9276,7 +9276,7 @@
               {
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 }
               }
@@ -9329,7 +9329,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "AllTypesResult",
+        "swiftCallName" : "BridgeJSRuntimeTests.AllTypesResult",
         "tsFullPath" : "AllTypesResult"
       },
       {
@@ -9339,7 +9339,7 @@
               {
                 "type" : {
                   "rawValueEnum" : {
-                    "_0" : "Precision",
+                    "_0" : "BridgeJSRuntimeTests.Precision",
                     "_1" : "Float"
                   }
                 }
@@ -9352,7 +9352,7 @@
               {
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 }
               }
@@ -9366,7 +9366,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "Precision",
+                        "_0" : "BridgeJSRuntimeTests.Precision",
                         "_1" : "Float"
                       }
                     },
@@ -9384,7 +9384,7 @@
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Direction"
+                        "_0" : "BridgeJSRuntimeTests.Direction"
                       }
                     },
                     "_1" : "null"
@@ -9409,7 +9409,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "TypedPayloadResult",
+        "swiftCallName" : "BridgeJSRuntimeTests.TypedPayloadResult",
         "tsFullPath" : "TypedPayloadResult"
       },
       {
@@ -9431,7 +9431,7 @@
         "name" : "StaticCalculator",
         "staticMethods" : [
           {
-            "abiName" : "bjs_StaticCalculator_static_roundtrip",
+            "abiName" : "bjs_BridgeJSRuntimeTests_StaticCalculator_static_roundtrip",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -9462,12 +9462,12 @@
             },
             "staticContext" : {
               "enumName" : {
-                "_0" : "StaticCalculator"
+                "_0" : "BridgeJSRuntimeTests.StaticCalculator"
               }
             }
           },
           {
-            "abiName" : "bjs_StaticCalculator_static_doubleValue",
+            "abiName" : "bjs_BridgeJSRuntimeTests_StaticCalculator_static_doubleValue",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -9498,7 +9498,7 @@
             },
             "staticContext" : {
               "enumName" : {
-                "_0" : "StaticCalculator"
+                "_0" : "BridgeJSRuntimeTests.StaticCalculator"
               }
             }
           }
@@ -9510,7 +9510,7 @@
             "name" : "version",
             "staticContext" : {
               "enumName" : {
-                "_0" : "StaticCalculator"
+                "_0" : "BridgeJSRuntimeTests.StaticCalculator"
               }
             },
             "type" : {
@@ -9520,7 +9520,7 @@
             }
           }
         ],
-        "swiftCallName" : "StaticCalculator",
+        "swiftCallName" : "BridgeJSRuntimeTests.StaticCalculator",
         "tsFullPath" : "StaticCalculator"
       },
       {
@@ -9535,7 +9535,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "StaticUtils",
+        "swiftCallName" : "BridgeJSRuntimeTests.StaticUtils",
         "tsFullPath" : "StaticUtils"
       },
       {
@@ -9549,7 +9549,7 @@
         ],
         "staticMethods" : [
           {
-            "abiName" : "bjs_StaticUtils_Nested_static_roundtrip",
+            "abiName" : "bjs_BridgeJSRuntimeTests_StaticUtils_Nested_static_roundtrip",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -9578,7 +9578,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "StaticUtils.Nested"
+                "_0" : "BridgeJSRuntimeTests.StaticUtils.Nested"
               }
             }
           }
@@ -9586,7 +9586,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "StaticUtils.Nested",
+        "swiftCallName" : "BridgeJSRuntimeTests.StaticUtils.Nested",
         "tsFullPath" : "StaticUtils.Nested"
       },
       {
@@ -9601,7 +9601,7 @@
         ],
         "staticMethods" : [
           {
-            "abiName" : "bjs_Services_Graph_GraphOperations_static_createGraph",
+            "abiName" : "bjs_BridgeJSRuntimeTests_GraphOperations_static_createGraph",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -9637,12 +9637,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GraphOperations"
+                "_0" : "BridgeJSRuntimeTests.GraphOperations"
               }
             }
           },
           {
-            "abiName" : "bjs_Services_Graph_GraphOperations_static_nodeCount",
+            "abiName" : "bjs_BridgeJSRuntimeTests_GraphOperations_static_nodeCount",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -9678,7 +9678,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "GraphOperations"
+                "_0" : "BridgeJSRuntimeTests.GraphOperations"
               }
             }
           }
@@ -9686,7 +9686,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "GraphOperations",
+        "swiftCallName" : "BridgeJSRuntimeTests.GraphOperations",
         "tsFullPath" : "Services.Graph.GraphOperations"
       },
       {
@@ -9716,7 +9716,7 @@
             "name" : "enumProperty",
             "staticContext" : {
               "enumName" : {
-                "_0" : "StaticPropertyEnum"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyEnum"
               }
             },
             "type" : {
@@ -9731,7 +9731,7 @@
             "name" : "enumConstant",
             "staticContext" : {
               "enumName" : {
-                "_0" : "StaticPropertyEnum"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyEnum"
               }
             },
             "type" : {
@@ -9749,7 +9749,7 @@
             "name" : "enumBool",
             "staticContext" : {
               "enumName" : {
-                "_0" : "StaticPropertyEnum"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyEnum"
               }
             },
             "type" : {
@@ -9764,7 +9764,7 @@
             "name" : "enumVariable",
             "staticContext" : {
               "enumName" : {
-                "_0" : "StaticPropertyEnum"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyEnum"
               }
             },
             "type" : {
@@ -9782,7 +9782,7 @@
             "name" : "computedReadonly",
             "staticContext" : {
               "enumName" : {
-                "_0" : "StaticPropertyEnum"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyEnum"
               }
             },
             "type" : {
@@ -9800,7 +9800,7 @@
             "name" : "computedReadWrite",
             "staticContext" : {
               "enumName" : {
-                "_0" : "StaticPropertyEnum"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyEnum"
               }
             },
             "type" : {
@@ -9810,7 +9810,7 @@
             }
           }
         ],
-        "swiftCallName" : "StaticPropertyEnum",
+        "swiftCallName" : "BridgeJSRuntimeTests.StaticPropertyEnum",
         "tsFullPath" : "StaticPropertyEnum"
       },
       {
@@ -9832,7 +9832,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "StaticPropertyNamespace"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyNamespace"
               }
             },
             "type" : {
@@ -9850,7 +9850,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "StaticPropertyNamespace"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyNamespace"
               }
             },
             "type" : {
@@ -9860,7 +9860,7 @@
             }
           }
         ],
-        "swiftCallName" : "StaticPropertyNamespace",
+        "swiftCallName" : "BridgeJSRuntimeTests.StaticPropertyNamespace",
         "tsFullPath" : "StaticPropertyNamespace"
       },
       {
@@ -9886,7 +9886,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "StaticPropertyNamespace.NestedProperties"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -9908,7 +9908,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "StaticPropertyNamespace.NestedProperties"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -9927,7 +9927,7 @@
             ],
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "StaticPropertyNamespace.NestedProperties"
+                "_0" : "BridgeJSRuntimeTests.StaticPropertyNamespace.NestedProperties"
               }
             },
             "type" : {
@@ -9937,7 +9937,7 @@
             }
           }
         ],
-        "swiftCallName" : "StaticPropertyNamespace.NestedProperties",
+        "swiftCallName" : "BridgeJSRuntimeTests.StaticPropertyNamespace.NestedProperties",
         "tsFullPath" : "StaticPropertyNamespace.NestedProperties"
       },
       {
@@ -9948,7 +9948,7 @@
         "name" : "NestedStructGroupA",
         "staticMethods" : [
           {
-            "abiName" : "bjs_NestedStructGroupA_static_roundtripMetadata",
+            "abiName" : "bjs_BridgeJSRuntimeTests_NestedStructGroupA_static_roundtripMetadata",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -9964,19 +9964,19 @@
                 "name" : "m",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "NestedStructGroupA.Metadata"
+                    "_0" : "BridgeJSRuntimeTests.NestedStructGroupA.Metadata"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "NestedStructGroupA.Metadata"
+                "_0" : "BridgeJSRuntimeTests.NestedStructGroupA.Metadata"
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "NestedStructGroupA"
+                "_0" : "BridgeJSRuntimeTests.NestedStructGroupA"
               }
             }
           }
@@ -9984,7 +9984,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "NestedStructGroupA",
+        "swiftCallName" : "BridgeJSRuntimeTests.NestedStructGroupA",
         "tsFullPath" : "NestedStructGroupA"
       },
       {
@@ -9995,7 +9995,7 @@
         "name" : "NestedStructGroupB",
         "staticMethods" : [
           {
-            "abiName" : "bjs_NestedStructGroupB_static_roundtripMetadata",
+            "abiName" : "bjs_BridgeJSRuntimeTests_NestedStructGroupB_static_roundtripMetadata",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10011,19 +10011,19 @@
                 "name" : "m",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "NestedStructGroupB.Metadata"
+                    "_0" : "BridgeJSRuntimeTests.NestedStructGroupB.Metadata"
                   }
                 }
               }
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "NestedStructGroupB.Metadata"
+                "_0" : "BridgeJSRuntimeTests.NestedStructGroupB.Metadata"
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "NestedStructGroupB"
+                "_0" : "BridgeJSRuntimeTests.NestedStructGroupB"
               }
             }
           }
@@ -10031,7 +10031,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "NestedStructGroupB",
+        "swiftCallName" : "BridgeJSRuntimeTests.NestedStructGroupB",
         "tsFullPath" : "NestedStructGroupB"
       },
       {
@@ -10061,7 +10061,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "NestedTypeHost.Variant",
+        "swiftCallName" : "BridgeJSRuntimeTests.NestedTypeHost.Variant",
         "tsFullPath" : "NestedTypeHost.Variant"
       },
       {
@@ -10093,7 +10093,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "LightColor",
+        "swiftCallName" : "BridgeJSRuntimeTests.LightColor",
         "tsFullPath" : "LightColor"
       },
       {
@@ -10140,7 +10140,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "ImportedPayloadSignal",
+        "swiftCallName" : "BridgeJSRuntimeTests.ImportedPayloadSignal",
         "tsFullPath" : "ImportedPayloadSignal"
       },
       {
@@ -10151,7 +10151,7 @@
         "name" : "IntegerTypesSupportExports",
         "staticMethods" : [
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripInt",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10185,12 +10185,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripUInt",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10224,12 +10224,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripInt8",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt8",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10263,12 +10263,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripUInt8",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt8",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10302,12 +10302,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripInt16",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt16",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10341,12 +10341,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripUInt16",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt16",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10380,12 +10380,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripInt32",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt32",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10419,12 +10419,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripUInt32",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt32",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10458,12 +10458,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripInt64",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripInt64",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10497,12 +10497,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_IntegerTypesSupportExports_static_roundTripUInt64",
+            "abiName" : "bjs_BridgeJSRuntimeTests_IntegerTypesSupportExports_static_roundTripUInt64",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10536,7 +10536,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "IntegerTypesSupportExports"
+                "_0" : "BridgeJSRuntimeTests.IntegerTypesSupportExports"
               }
             }
           }
@@ -10544,7 +10544,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "IntegerTypesSupportExports",
+        "swiftCallName" : "BridgeJSRuntimeTests.IntegerTypesSupportExports",
         "tsFullPath" : "IntegerTypesSupportExports"
       },
       {
@@ -10555,7 +10555,7 @@
         "name" : "JSTypedArrayExports",
         "staticMethods" : [
           {
-            "abiName" : "bjs_JSTypedArrayExports_static_roundTripUint8Array",
+            "abiName" : "bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripUint8Array",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10583,12 +10583,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "JSTypedArrayExports"
+                "_0" : "BridgeJSRuntimeTests.JSTypedArrayExports"
               }
             }
           },
           {
-            "abiName" : "bjs_JSTypedArrayExports_static_roundTripFloat32Array",
+            "abiName" : "bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripFloat32Array",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10616,12 +10616,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "JSTypedArrayExports"
+                "_0" : "BridgeJSRuntimeTests.JSTypedArrayExports"
               }
             }
           },
           {
-            "abiName" : "bjs_JSTypedArrayExports_static_roundTripFloat64Array",
+            "abiName" : "bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripFloat64Array",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10649,12 +10649,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "JSTypedArrayExports"
+                "_0" : "BridgeJSRuntimeTests.JSTypedArrayExports"
               }
             }
           },
           {
-            "abiName" : "bjs_JSTypedArrayExports_static_roundTripInt32Array",
+            "abiName" : "bjs_BridgeJSRuntimeTests_JSTypedArrayExports_static_roundTripInt32Array",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10682,7 +10682,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "JSTypedArrayExports"
+                "_0" : "BridgeJSRuntimeTests.JSTypedArrayExports"
               }
             }
           }
@@ -10690,7 +10690,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "JSTypedArrayExports",
+        "swiftCallName" : "BridgeJSRuntimeTests.JSTypedArrayExports",
         "tsFullPath" : "JSTypedArrayExports"
       },
       {
@@ -10701,7 +10701,7 @@
         "name" : "OptionalSupportExports",
         "staticMethods" : [
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalString",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10739,12 +10739,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalInt",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalInt",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10788,12 +10788,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalBool",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalBool",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10831,12 +10831,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalFloat",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalFloat",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10874,12 +10874,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalDouble",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalDouble",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10917,12 +10917,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalSyntax",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSyntax",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10960,12 +10960,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalCaseEnum",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalCaseEnum",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -10983,7 +10983,7 @@
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Status"
+                        "_0" : "BridgeJSRuntimeTests.Status"
                       }
                     },
                     "_1" : "null"
@@ -10995,7 +10995,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Status"
+                    "_0" : "BridgeJSRuntimeTests.Status"
                   }
                 },
                 "_1" : "null"
@@ -11003,12 +11003,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalStringRawValueEnum",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalStringRawValueEnum",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11026,7 +11026,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "Theme",
+                        "_0" : "BridgeJSRuntimeTests.Theme",
                         "_1" : "String"
                       }
                     },
@@ -11039,7 +11039,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 },
@@ -11048,12 +11048,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalIntRawValueEnum",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalIntRawValueEnum",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11071,7 +11071,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "HttpStatus",
+                        "_0" : "BridgeJSRuntimeTests.HttpStatus",
                         "_1" : "Int"
                       }
                     },
@@ -11084,7 +11084,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "HttpStatus",
+                    "_0" : "BridgeJSRuntimeTests.HttpStatus",
                     "_1" : "Int"
                   }
                 },
@@ -11093,12 +11093,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalInt64RawValueEnum",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalInt64RawValueEnum",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11116,7 +11116,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "FileSize",
+                        "_0" : "BridgeJSRuntimeTests.FileSize",
                         "_1" : "Int64"
                       }
                     },
@@ -11129,7 +11129,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "FileSize",
+                    "_0" : "BridgeJSRuntimeTests.FileSize",
                     "_1" : "Int64"
                   }
                 },
@@ -11138,12 +11138,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalUInt64RawValueEnum",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalUInt64RawValueEnum",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11161,7 +11161,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "SessionId",
+                        "_0" : "BridgeJSRuntimeTests.SessionId",
                         "_1" : "UInt64"
                       }
                     },
@@ -11174,7 +11174,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "SessionId",
+                    "_0" : "BridgeJSRuntimeTests.SessionId",
                     "_1" : "UInt64"
                   }
                 },
@@ -11183,12 +11183,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalTSEnum",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTSEnum",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11206,7 +11206,7 @@
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "TSDirection"
+                        "_0" : "BridgeJSRuntimeTests.TSDirection"
                       }
                     },
                     "_1" : "null"
@@ -11218,7 +11218,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "TSDirection"
+                    "_0" : "BridgeJSRuntimeTests.TSDirection"
                   }
                 },
                 "_1" : "null"
@@ -11226,12 +11226,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalTSStringEnum",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTSStringEnum",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11249,7 +11249,7 @@
                   "nullable" : {
                     "_0" : {
                       "rawValueEnum" : {
-                        "_0" : "TSTheme",
+                        "_0" : "BridgeJSRuntimeTests.TSTheme",
                         "_1" : "String"
                       }
                     },
@@ -11262,7 +11262,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "TSTheme",
+                    "_0" : "BridgeJSRuntimeTests.TSTheme",
                     "_1" : "String"
                   }
                 },
@@ -11271,12 +11271,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalNamespacedEnum",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalNamespacedEnum",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11294,7 +11294,7 @@
                   "nullable" : {
                     "_0" : {
                       "caseEnum" : {
-                        "_0" : "Networking.API.Method"
+                        "_0" : "BridgeJSRuntimeTests.Networking.API.Method"
                       }
                     },
                     "_1" : "null"
@@ -11306,7 +11306,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Networking.API.Method"
+                    "_0" : "BridgeJSRuntimeTests.Networking.API.Method"
                   }
                 },
                 "_1" : "null"
@@ -11314,12 +11314,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalSwiftClass",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSwiftClass",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11337,7 +11337,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     },
                     "_1" : "null"
@@ -11349,7 +11349,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -11357,12 +11357,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalIntArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalIntArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11414,12 +11414,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalStringArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalStringArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11465,12 +11465,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalSwiftClassArray",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalSwiftClassArray",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11490,7 +11490,7 @@
                       "array" : {
                         "_0" : {
                           "swiftHeapObject" : {
-                            "_0" : "Greeter"
+                            "_0" : "BridgeJSRuntimeTests.Greeter"
                           }
                         }
                       }
@@ -11506,7 +11506,7 @@
                   "array" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     }
                   }
@@ -11516,12 +11516,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalAPIResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAPIResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11539,7 +11539,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "BridgeJSRuntimeTests.APIResult"
                       }
                     },
                     "_1" : "null"
@@ -11551,7 +11551,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -11559,12 +11559,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalTypedPayloadResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalTypedPayloadResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11582,7 +11582,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "TypedPayloadResult"
+                        "_0" : "BridgeJSRuntimeTests.TypedPayloadResult"
                       }
                     },
                     "_1" : "null"
@@ -11594,7 +11594,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "TypedPayloadResult"
+                    "_0" : "BridgeJSRuntimeTests.TypedPayloadResult"
                   }
                 },
                 "_1" : "null"
@@ -11602,12 +11602,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalComplexResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalComplexResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11625,7 +11625,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "ComplexResult"
+                        "_0" : "BridgeJSRuntimeTests.ComplexResult"
                       }
                     },
                     "_1" : "null"
@@ -11637,7 +11637,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "ComplexResult"
+                    "_0" : "BridgeJSRuntimeTests.ComplexResult"
                   }
                 },
                 "_1" : "null"
@@ -11645,12 +11645,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalAllTypesResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAllTypesResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11668,7 +11668,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "AllTypesResult"
+                        "_0" : "BridgeJSRuntimeTests.AllTypesResult"
                       }
                     },
                     "_1" : "null"
@@ -11680,7 +11680,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "AllTypesResult"
+                    "_0" : "BridgeJSRuntimeTests.AllTypesResult"
                   }
                 },
                 "_1" : "null"
@@ -11688,12 +11688,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalPayloadResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalPayloadResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11709,24 +11709,24 @@
                 "name" : "v",
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "OptionalAllTypesResult"
+                    "_0" : "BridgeJSRuntimeTests.OptionalAllTypesResult"
                   }
                 }
               }
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "OptionalAllTypesResult"
+                "_0" : "BridgeJSRuntimeTests.OptionalAllTypesResult"
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalPayloadResultOpt",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalPayloadResultOpt",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11744,7 +11744,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "OptionalAllTypesResult"
+                        "_0" : "BridgeJSRuntimeTests.OptionalAllTypesResult"
                       }
                     },
                     "_1" : "null"
@@ -11756,7 +11756,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "OptionalAllTypesResult"
+                    "_0" : "BridgeJSRuntimeTests.OptionalAllTypesResult"
                   }
                 },
                 "_1" : "null"
@@ -11764,12 +11764,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_roundTripOptionalAPIOptionalResult",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_roundTripOptionalAPIOptionalResult",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11787,7 +11787,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIOptionalResult"
+                        "_0" : "BridgeJSRuntimeTests.APIOptionalResult"
                       }
                     },
                     "_1" : "null"
@@ -11799,7 +11799,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIOptionalResult"
+                    "_0" : "BridgeJSRuntimeTests.APIOptionalResult"
                   }
                 },
                 "_1" : "null"
@@ -11807,12 +11807,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_takeOptionalJSObject",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_takeOptionalJSObject",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11845,12 +11845,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_applyOptionalGreeter",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_applyOptionalGreeter",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11868,7 +11868,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     },
                     "_1" : "null"
@@ -11883,14 +11883,14 @@
                     "_0" : {
                       "isAsync" : false,
                       "isThrows" : false,
-                      "mangleName" : "20BridgeJSRuntimeTestsSq7GreeterC_Sq7GreeterC",
+                      "mangleName" : "20BridgeJSRuntimeTestsSq28BridgeJSRuntimeTests_GreeterC_Sq28BridgeJSRuntimeTests_GreeterC",
                       "moduleName" : "BridgeJSRuntimeTests",
                       "parameters" : [
                         {
                           "nullable" : {
                             "_0" : {
                               "swiftHeapObject" : {
-                                "_0" : "Greeter"
+                                "_0" : "BridgeJSRuntimeTests.Greeter"
                               }
                             },
                             "_1" : "null"
@@ -11901,7 +11901,7 @@
                         "nullable" : {
                           "_0" : {
                             "swiftHeapObject" : {
-                              "_0" : "Greeter"
+                              "_0" : "BridgeJSRuntimeTests.Greeter"
                             }
                           },
                           "_1" : "null"
@@ -11918,7 +11918,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -11926,12 +11926,12 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_makeOptionalHolder",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_makeOptionalHolder",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -11949,7 +11949,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     },
                     "_1" : "null"
@@ -11973,17 +11973,17 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "OptionalHolder"
+                "_0" : "BridgeJSRuntimeTests.OptionalHolder"
               }
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           },
           {
-            "abiName" : "bjs_OptionalSupportExports_static_compareAPIResults",
+            "abiName" : "bjs_BridgeJSRuntimeTests_OptionalSupportExports_static_compareAPIResults",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -12001,7 +12001,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "BridgeJSRuntimeTests.APIResult"
                       }
                     },
                     "_1" : "null"
@@ -12015,7 +12015,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "BridgeJSRuntimeTests.APIResult"
                       }
                     },
                     "_1" : "null"
@@ -12030,7 +12030,7 @@
             },
             "staticContext" : {
               "namespaceEnum" : {
-                "_0" : "OptionalSupportExports"
+                "_0" : "BridgeJSRuntimeTests.OptionalSupportExports"
               }
             }
           }
@@ -12038,7 +12038,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "OptionalSupportExports",
+        "swiftCallName" : "BridgeJSRuntimeTests.OptionalSupportExports",
         "tsFullPath" : "OptionalSupportExports"
       },
       {
@@ -12050,7 +12050,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Address"
+                        "_0" : "BridgeJSRuntimeTests.Address"
                       }
                     },
                     "_1" : "null"
@@ -12067,7 +12067,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     },
                     "_1" : "null"
@@ -12101,7 +12101,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "BridgeJSRuntimeTests.APIResult"
                       }
                     },
                     "_1" : "null"
@@ -12167,7 +12167,7 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "OptionalAllTypesResult",
+        "swiftCallName" : "BridgeJSRuntimeTests.OptionalAllTypesResult",
         "tsFullPath" : "OptionalAllTypesResult"
       },
       {
@@ -12274,14 +12274,14 @@
         "staticProperties" : [
 
         ],
-        "swiftCallName" : "APIOptionalResult",
+        "swiftCallName" : "BridgeJSRuntimeTests.APIOptionalResult",
         "tsFullPath" : "APIOptionalResult"
       }
     ],
     "exposeToGlobal" : false,
     "functions" : [
       {
-        "abiName" : "bjs_makeTag",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeTag",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12301,17 +12301,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Tag",
+            "name" : "BridgeJSRuntimeTests.Tag",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "TagReference"
+                "_0" : "BridgeJSRuntimeTests.TagReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripPolygon",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripPolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12324,10 +12324,10 @@
             "name" : "polygon",
             "type" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
@@ -12336,17 +12336,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Polygon",
+            "name" : "BridgeJSRuntimeTests.Polygon",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "PolygonReference"
+                "_0" : "BridgeJSRuntimeTests.PolygonReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_appendVertex",
+        "abiName" : "bjs_BridgeJSRuntimeTests_appendVertex",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12359,10 +12359,10 @@
             "name" : "polygon",
             "type" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
@@ -12380,17 +12380,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Polygon",
+            "name" : "BridgeJSRuntimeTests.Polygon",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "PolygonReference"
+                "_0" : "BridgeJSRuntimeTests.PolygonReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_optionalRoundTripPolygon",
+        "abiName" : "bjs_BridgeJSRuntimeTests_optionalRoundTripPolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12405,10 +12405,10 @@
               "nullable" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "BridgeJSRuntimeTests.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "BridgeJSRuntimeTests.PolygonReference"
                       }
                     }
                   }
@@ -12422,10 +12422,10 @@
           "nullable" : {
             "_0" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
@@ -12435,7 +12435,7 @@
         }
       },
       {
-        "abiName" : "bjs_polygonVertexCount",
+        "abiName" : "bjs_BridgeJSRuntimeTests_polygonVertexCount",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12448,10 +12448,10 @@
             "name" : "polygon",
             "type" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
@@ -12468,7 +12468,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripPolygonArray",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripPolygonArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12483,10 +12483,10 @@
               "array" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "BridgeJSRuntimeTests.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "BridgeJSRuntimeTests.PolygonReference"
                       }
                     }
                   }
@@ -12499,10 +12499,10 @@
           "array" : {
             "_0" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
@@ -12511,7 +12511,7 @@
         }
       },
       {
-        "abiName" : "bjs_concatPolygons",
+        "abiName" : "bjs_BridgeJSRuntimeTests_concatPolygons",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12526,10 +12526,10 @@
               "array" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "BridgeJSRuntimeTests.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "BridgeJSRuntimeTests.PolygonReference"
                       }
                     }
                   }
@@ -12540,17 +12540,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Polygon",
+            "name" : "BridgeJSRuntimeTests.Polygon",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "PolygonReference"
+                "_0" : "BridgeJSRuntimeTests.PolygonReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_validatePolygon",
+        "abiName" : "bjs_BridgeJSRuntimeTests_validatePolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12563,10 +12563,10 @@
             "name" : "polygon",
             "type" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
@@ -12575,17 +12575,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Polygon",
+            "name" : "BridgeJSRuntimeTests.Polygon",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "PolygonReference"
+                "_0" : "BridgeJSRuntimeTests.PolygonReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_splitPolygon",
+        "abiName" : "bjs_BridgeJSRuntimeTests_splitPolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12598,10 +12598,10 @@
             "name" : "polygon",
             "type" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
@@ -12612,10 +12612,10 @@
           "array" : {
             "_0" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
@@ -12624,7 +12624,7 @@
         }
       },
       {
-        "abiName" : "bjs_makePolygonInspector",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makePolygonInspector",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12639,15 +12639,15 @@
             "_0" : {
               "isAsync" : false,
               "isThrows" : false,
-              "mangleName" : "20BridgeJSRuntimeTestsAl7Polygon_Si",
+              "mangleName" : "20BridgeJSRuntimeTestsAl28BridgeJSRuntimeTests_Polygon_Si",
               "moduleName" : "BridgeJSRuntimeTests",
               "parameters" : [
                 {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "BridgeJSRuntimeTests.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "BridgeJSRuntimeTests.PolygonReference"
                       }
                     }
                   }
@@ -12668,7 +12668,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalPolygonArray",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripOptionalPolygonArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12685,10 +12685,10 @@
                   "nullable" : {
                     "_0" : {
                       "alias" : {
-                        "name" : "Polygon",
+                        "name" : "BridgeJSRuntimeTests.Polygon",
                         "underlying" : {
                           "swiftHeapObject" : {
-                            "_0" : "PolygonReference"
+                            "_0" : "BridgeJSRuntimeTests.PolygonReference"
                           }
                         }
                       }
@@ -12706,10 +12706,10 @@
               "nullable" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "BridgeJSRuntimeTests.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "BridgeJSRuntimeTests.PolygonReference"
                       }
                     }
                   }
@@ -12721,7 +12721,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeTagHolder",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeTagHolder",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12753,17 +12753,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "TagHolder",
+            "name" : "BridgeJSRuntimeTests.TagHolder",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "TagHolderReference"
+                "_0" : "BridgeJSRuntimeTests.TagHolderReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripCoordinate",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripCoordinate",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12776,10 +12776,10 @@
             "name" : "coordinate",
             "type" : {
               "alias" : {
-                "name" : "Coordinate",
+                "name" : "BridgeJSRuntimeTests.Coordinate",
                 "underlying" : {
                   "swiftStruct" : {
-                    "_0" : "JSCoordinate"
+                    "_0" : "BridgeJSRuntimeTests.JSCoordinate"
                   }
                 }
               }
@@ -12788,17 +12788,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Coordinate",
+            "name" : "BridgeJSRuntimeTests.Coordinate",
             "underlying" : {
               "swiftStruct" : {
-                "_0" : "JSCoordinate"
+                "_0" : "BridgeJSRuntimeTests.JSCoordinate"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripPriority",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripPriority",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12811,10 +12811,10 @@
             "name" : "priority",
             "type" : {
               "alias" : {
-                "name" : "Priority",
+                "name" : "BridgeJSRuntimeTests.Priority",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PriorityReference"
+                    "_0" : "BridgeJSRuntimeTests.PriorityReference"
                   }
                 }
               }
@@ -12823,17 +12823,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Priority",
+            "name" : "BridgeJSRuntimeTests.Priority",
             "underlying" : {
               "swiftHeapObject" : {
-                "_0" : "PriorityReference"
+                "_0" : "BridgeJSRuntimeTests.PriorityReference"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripAlert",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripAlert",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12846,10 +12846,10 @@
             "name" : "alert",
             "type" : {
               "alias" : {
-                "name" : "Alert",
+                "name" : "BridgeJSRuntimeTests.Alert",
                 "underlying" : {
                   "caseEnum" : {
-                    "_0" : "Severity"
+                    "_0" : "BridgeJSRuntimeTests.Severity"
                   }
                 }
               }
@@ -12858,17 +12858,17 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Alert",
+            "name" : "BridgeJSRuntimeTests.Alert",
             "underlying" : {
               "caseEnum" : {
-                "_0" : "Severity"
+                "_0" : "BridgeJSRuntimeTests.Severity"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_makeAlert",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAlert",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12881,24 +12881,24 @@
             "name" : "level",
             "type" : {
               "caseEnum" : {
-                "_0" : "Severity"
+                "_0" : "BridgeJSRuntimeTests.Severity"
               }
             }
           }
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Alert",
+            "name" : "BridgeJSRuntimeTests.Alert",
             "underlying" : {
               "caseEnum" : {
-                "_0" : "Severity"
+                "_0" : "BridgeJSRuntimeTests.Severity"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripShape",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripShape",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12911,19 +12911,19 @@
             "name" : "s",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "Shape"
+                "_0" : "BridgeJSRuntimeTests.Shape"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "Shape"
+            "_0" : "BridgeJSRuntimeTests.Shape"
           }
         }
       },
       {
-        "abiName" : "bjs_makeShapePolygon",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeShapePolygon",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12936,10 +12936,10 @@
             "name" : "polygon",
             "type" : {
               "alias" : {
-                "name" : "Polygon",
+                "name" : "BridgeJSRuntimeTests.Polygon",
                 "underlying" : {
                   "swiftHeapObject" : {
-                    "_0" : "PolygonReference"
+                    "_0" : "BridgeJSRuntimeTests.PolygonReference"
                   }
                 }
               }
@@ -12948,12 +12948,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "Shape"
+            "_0" : "BridgeJSRuntimeTests.Shape"
           }
         }
       },
       {
-        "abiName" : "bjs_makeShapeEmpty",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeShapeEmpty",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12965,12 +12965,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "Shape"
+            "_0" : "BridgeJSRuntimeTests.Shape"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripUserId",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripUserId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -12983,7 +12983,7 @@
             "name" : "id",
             "type" : {
               "alias" : {
-                "name" : "UserId",
+                "name" : "BridgeJSRuntimeTests.UserId",
                 "underlying" : {
                   "integer" : {
                     "_0" : {
@@ -12998,7 +12998,7 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "UserId",
+            "name" : "BridgeJSRuntimeTests.UserId",
             "underlying" : {
               "integer" : {
                 "_0" : {
@@ -13011,7 +13011,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalUserId",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripOptionalUserId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13026,7 +13026,7 @@
               "nullable" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "UserId",
+                    "name" : "BridgeJSRuntimeTests.UserId",
                     "underlying" : {
                       "integer" : {
                         "_0" : {
@@ -13046,7 +13046,7 @@
           "nullable" : {
             "_0" : {
               "alias" : {
-                "name" : "UserId",
+                "name" : "BridgeJSRuntimeTests.UserId",
                 "underlying" : {
                   "integer" : {
                     "_0" : {
@@ -13062,7 +13062,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUserIdArray",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripUserIdArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13077,7 +13077,7 @@
               "array" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "UserId",
+                    "name" : "BridgeJSRuntimeTests.UserId",
                     "underlying" : {
                       "integer" : {
                         "_0" : {
@@ -13096,7 +13096,7 @@
           "array" : {
             "_0" : {
               "alias" : {
-                "name" : "UserId",
+                "name" : "BridgeJSRuntimeTests.UserId",
                 "underlying" : {
                   "integer" : {
                     "_0" : {
@@ -13111,7 +13111,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripBoxed",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripBoxed",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13124,7 +13124,7 @@
             "name" : "boxed",
             "type" : {
               "alias" : {
-                "name" : "Boxed",
+                "name" : "BridgeJSRuntimeTests.Boxed",
                 "underlying" : {
                   "jsValue" : {
 
@@ -13136,7 +13136,7 @@
         ],
         "returnType" : {
           "alias" : {
-            "name" : "Boxed",
+            "name" : "BridgeJSRuntimeTests.Boxed",
             "underlying" : {
               "jsValue" : {
 
@@ -13146,7 +13146,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalBoxed",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripOptionalBoxed",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13161,7 +13161,7 @@
               "nullable" : {
                 "_0" : {
                   "alias" : {
-                    "name" : "Boxed",
+                    "name" : "BridgeJSRuntimeTests.Boxed",
                     "underlying" : {
                       "jsValue" : {
 
@@ -13178,7 +13178,7 @@
           "nullable" : {
             "_0" : {
               "alias" : {
-                "name" : "Boxed",
+                "name" : "BridgeJSRuntimeTests.Boxed",
                 "underlying" : {
                   "jsValue" : {
 
@@ -13191,7 +13191,7 @@
         }
       },
       {
-        "abiName" : "bjs_awaitAsyncCallback",
+        "abiName" : "bjs_BridgeJSRuntimeTests_awaitAsyncCallback",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -13235,7 +13235,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeAsyncParser",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAsyncParser",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13271,7 +13271,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeAsyncEcho",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAsyncEcho",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13307,7 +13307,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeAsyncRecorder",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAsyncRecorder",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13343,7 +13343,7 @@
         }
       },
       {
-        "abiName" : "bjs_lastRecordedValue",
+        "abiName" : "bjs_BridgeJSRuntimeTests_lastRecordedValue",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13360,7 +13360,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeAsyncPayloadLoader",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAsyncPayloadLoader",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13375,7 +13375,7 @@
             "_0" : {
               "isAsync" : true,
               "isThrows" : true,
-              "mangleName" : "20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO",
+              "mangleName" : "20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO",
               "moduleName" : "BridgeJSRuntimeTests",
               "parameters" : [
                 {
@@ -13386,7 +13386,7 @@
               ],
               "returnType" : {
                 "associatedValueEnum" : {
-                  "_0" : "AsyncPayloadResult"
+                  "_0" : "BridgeJSRuntimeTests.AsyncPayloadResult"
                 }
               },
               "sendingParameters" : false
@@ -13396,7 +13396,7 @@
         }
       },
       {
-        "abiName" : "bjs_awaitPayloadCallback",
+        "abiName" : "bjs_BridgeJSRuntimeTests_awaitPayloadCallback",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -13412,7 +13412,7 @@
                 "_0" : {
                   "isAsync" : true,
                   "isThrows" : true,
-                  "mangleName" : "20BridgeJSRuntimeTestsYaKSb_18AsyncPayloadResultO",
+                  "mangleName" : "20BridgeJSRuntimeTestsYaKSb_39BridgeJSRuntimeTests_AsyncPayloadResultO",
                   "moduleName" : "BridgeJSRuntimeTests",
                   "parameters" : [
                     {
@@ -13423,7 +13423,7 @@
                   ],
                   "returnType" : {
                     "associatedValueEnum" : {
-                      "_0" : "AsyncPayloadResult"
+                      "_0" : "BridgeJSRuntimeTests.AsyncPayloadResult"
                     }
                   },
                   "sendingParameters" : false
@@ -13440,7 +13440,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeAsyncPointMaker",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAsyncPointMaker",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13455,7 +13455,7 @@
             "_0" : {
               "isAsync" : true,
               "isThrows" : false,
-              "mangleName" : "20BridgeJSRuntimeTestsYaSd_9DataPointV",
+              "mangleName" : "20BridgeJSRuntimeTestsYaSd_30BridgeJSRuntimeTests_DataPointV",
               "moduleName" : "BridgeJSRuntimeTests",
               "parameters" : [
                 {
@@ -13466,7 +13466,7 @@
               ],
               "returnType" : {
                 "swiftStruct" : {
-                  "_0" : "DataPoint"
+                  "_0" : "BridgeJSRuntimeTests.DataPoint"
                 }
               },
               "sendingParameters" : false
@@ -13476,7 +13476,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeThrowingParser",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeThrowingParser",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13515,7 +13515,7 @@
         }
       },
       {
-        "abiName" : "bjs_runValidator",
+        "abiName" : "bjs_BridgeJSRuntimeTests_runValidator",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13559,7 +13559,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripVoid",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripVoid",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13576,7 +13576,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripFloat",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripFloat",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13601,7 +13601,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripDouble",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripDouble",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13626,7 +13626,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripBool",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripBool",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13651,7 +13651,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripString",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripString",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13676,7 +13676,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripSwiftHeapObject",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripSwiftHeapObject",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13689,19 +13689,19 @@
             "name" : "v",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests.Greeter"
               }
             }
           }
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "Greeter"
+            "_0" : "BridgeJSRuntimeTests.Greeter"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripUnsafeRawPointer",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripUnsafeRawPointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13730,7 +13730,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUnsafeMutableRawPointer",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripUnsafeMutableRawPointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13759,7 +13759,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOpaquePointer",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripOpaquePointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13788,7 +13788,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUnsafePointer",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripUnsafePointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13819,7 +13819,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripUnsafeMutablePointer",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripUnsafeMutablePointer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13850,7 +13850,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripJSObject",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripJSObject",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13875,7 +13875,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripDictionaryExport",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripDictionaryExport",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13914,7 +13914,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalDictionaryExport",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripOptionalDictionaryExport",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13957,7 +13957,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripJSValue",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripJSValue",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -13982,7 +13982,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalJSValue",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripOptionalJSValue",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14017,7 +14017,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalJSValueArray",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripOptionalJSValueArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14060,7 +14060,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeImportedFoo",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeImportedFoo",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14085,7 +14085,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripOptionalImportedClass",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripOptionalImportedClass",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14120,7 +14120,7 @@
         }
       },
       {
-        "abiName" : "bjs_throwsSwiftError",
+        "abiName" : "bjs_BridgeJSRuntimeTests_throwsSwiftError",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14145,7 +14145,7 @@
         }
       },
       {
-        "abiName" : "bjs_throwsWithIntResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_throwsWithIntResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14165,7 +14165,7 @@
         }
       },
       {
-        "abiName" : "bjs_throwsWithStringResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_throwsWithStringResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14182,7 +14182,7 @@
         }
       },
       {
-        "abiName" : "bjs_throwsWithBoolResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_throwsWithBoolResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14199,7 +14199,7 @@
         }
       },
       {
-        "abiName" : "bjs_throwsWithFloatResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_throwsWithFloatResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14216,7 +14216,7 @@
         }
       },
       {
-        "abiName" : "bjs_throwsWithDoubleResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_throwsWithDoubleResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14233,7 +14233,7 @@
         }
       },
       {
-        "abiName" : "bjs_throwsWithSwiftHeapObjectResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_throwsWithSwiftHeapObjectResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14245,12 +14245,12 @@
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "Greeter"
+            "_0" : "BridgeJSRuntimeTests.Greeter"
           }
         }
       },
       {
-        "abiName" : "bjs_throwsWithJSObjectResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_throwsWithJSObjectResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14267,7 +14267,7 @@
         }
       },
       {
-        "abiName" : "bjs_zeroArgAsyncThrows",
+        "abiName" : "bjs_BridgeJSRuntimeTests_zeroArgAsyncThrows",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14284,7 +14284,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripVoid",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripVoid",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14301,7 +14301,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripInt",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripInt",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14332,7 +14332,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripFloat",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripFloat",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14357,7 +14357,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripDouble",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripDouble",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14382,7 +14382,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripBool",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripBool",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14407,7 +14407,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripString",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripString",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14432,7 +14432,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripSwiftHeapObject",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripSwiftHeapObject",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14445,19 +14445,19 @@
             "name" : "v",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests.Greeter"
               }
             }
           }
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "Greeter"
+            "_0" : "BridgeJSRuntimeTests.Greeter"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripJSObject",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripJSObject",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14482,7 +14482,7 @@
         }
       },
       {
-        "abiName" : "bjs_takeGreeter",
+        "abiName" : "bjs_BridgeJSRuntimeTests_takeGreeter",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14495,7 +14495,7 @@
             "name" : "g",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests.Greeter"
               }
             }
           },
@@ -14516,7 +14516,7 @@
         }
       },
       {
-        "abiName" : "bjs_createCalculator",
+        "abiName" : "bjs_BridgeJSRuntimeTests_createCalculator",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14528,12 +14528,12 @@
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "Calculator"
+            "_0" : "BridgeJSRuntimeTests.Calculator"
           }
         }
       },
       {
-        "abiName" : "bjs_useCalculator",
+        "abiName" : "bjs_BridgeJSRuntimeTests_useCalculator",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14546,7 +14546,7 @@
             "name" : "calc",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Calculator"
+                "_0" : "BridgeJSRuntimeTests.Calculator"
               }
             }
           },
@@ -14585,7 +14585,7 @@
         }
       },
       {
-        "abiName" : "bjs_testGreeterToJSValue",
+        "abiName" : "bjs_BridgeJSRuntimeTests_testGreeterToJSValue",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14602,7 +14602,7 @@
         }
       },
       {
-        "abiName" : "bjs_testCalculatorToJSValue",
+        "abiName" : "bjs_BridgeJSRuntimeTests_testCalculatorToJSValue",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14619,7 +14619,7 @@
         }
       },
       {
-        "abiName" : "bjs_testSwiftClassAsJSValue",
+        "abiName" : "bjs_BridgeJSRuntimeTests_testSwiftClassAsJSValue",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14632,7 +14632,7 @@
             "name" : "greeter",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests.Greeter"
               }
             }
           }
@@ -14644,7 +14644,7 @@
         }
       },
       {
-        "abiName" : "bjs_setDirection",
+        "abiName" : "bjs_BridgeJSRuntimeTests_setDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14657,19 +14657,19 @@
             "name" : "direction",
             "type" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "BridgeJSRuntimeTests.Direction"
               }
             }
           }
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "Direction"
+            "_0" : "BridgeJSRuntimeTests.Direction"
           }
         }
       },
       {
-        "abiName" : "bjs_getDirection",
+        "abiName" : "bjs_BridgeJSRuntimeTests_getDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14681,12 +14681,12 @@
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "Direction"
+            "_0" : "BridgeJSRuntimeTests.Direction"
           }
         }
       },
       {
-        "abiName" : "bjs_processDirection",
+        "abiName" : "bjs_BridgeJSRuntimeTests_processDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14699,19 +14699,19 @@
             "name" : "input",
             "type" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "BridgeJSRuntimeTests.Direction"
               }
             }
           }
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "Status"
+            "_0" : "BridgeJSRuntimeTests.Status"
           }
         }
       },
       {
-        "abiName" : "bjs_setTheme",
+        "abiName" : "bjs_BridgeJSRuntimeTests_setTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14724,7 +14724,7 @@
             "name" : "theme",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "BridgeJSRuntimeTests.Theme",
                 "_1" : "String"
               }
             }
@@ -14732,13 +14732,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Theme",
+            "_0" : "BridgeJSRuntimeTests.Theme",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_getTheme",
+        "abiName" : "bjs_BridgeJSRuntimeTests_getTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -14750,13 +14750,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Theme",
+            "_0" : "BridgeJSRuntimeTests.Theme",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripTheme",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripTheme",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14769,7 +14769,7 @@
             "name" : "v",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "BridgeJSRuntimeTests.Theme",
                 "_1" : "String"
               }
             }
@@ -14777,13 +14777,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Theme",
+            "_0" : "BridgeJSRuntimeTests.Theme",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripDirection",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripDirection",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14796,19 +14796,19 @@
             "name" : "v",
             "type" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "BridgeJSRuntimeTests.Direction"
               }
             }
           }
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "Direction"
+            "_0" : "BridgeJSRuntimeTests.Direction"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripOptionalTheme",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalTheme",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14823,7 +14823,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 },
@@ -14836,7 +14836,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "BridgeJSRuntimeTests.Theme",
                 "_1" : "String"
               }
             },
@@ -14845,7 +14845,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripOptionalDirection",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalDirection",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14860,7 +14860,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 },
                 "_1" : "null"
@@ -14872,7 +14872,7 @@
           "nullable" : {
             "_0" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "BridgeJSRuntimeTests.Direction"
               }
             },
             "_1" : "null"
@@ -14880,7 +14880,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripDirectionArray",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripDirectionArray",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14895,7 +14895,7 @@
               "array" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 }
               }
@@ -14906,14 +14906,14 @@
           "array" : {
             "_0" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "BridgeJSRuntimeTests.Direction"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripDirectionDict",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripDirectionDict",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14928,7 +14928,7 @@
               "dictionary" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 }
               }
@@ -14939,14 +14939,14 @@
           "dictionary" : {
             "_0" : {
               "caseEnum" : {
-                "_0" : "Direction"
+                "_0" : "BridgeJSRuntimeTests.Direction"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripThemeArray",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripThemeArray",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14961,7 +14961,7 @@
               "array" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 }
@@ -14973,7 +14973,7 @@
           "array" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "BridgeJSRuntimeTests.Theme",
                 "_1" : "String"
               }
             }
@@ -14981,7 +14981,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripThemeDict",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripThemeDict",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -14996,7 +14996,7 @@
               "dictionary" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 }
@@ -15008,7 +15008,7 @@
           "dictionary" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "BridgeJSRuntimeTests.Theme",
                 "_1" : "String"
               }
             }
@@ -15016,7 +15016,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripFileSize",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripFileSize",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -15029,7 +15029,7 @@
             "name" : "v",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "FileSize",
+                "_0" : "BridgeJSRuntimeTests.FileSize",
                 "_1" : "Int64"
               }
             }
@@ -15037,13 +15037,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "FileSize",
+            "_0" : "BridgeJSRuntimeTests.FileSize",
             "_1" : "Int64"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripOptionalFileSize",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalFileSize",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -15058,7 +15058,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "FileSize",
+                    "_0" : "BridgeJSRuntimeTests.FileSize",
                     "_1" : "Int64"
                   }
                 },
@@ -15071,7 +15071,7 @@
           "nullable" : {
             "_0" : {
               "rawValueEnum" : {
-                "_0" : "FileSize",
+                "_0" : "BridgeJSRuntimeTests.FileSize",
                 "_1" : "Int64"
               }
             },
@@ -15080,7 +15080,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripAssociatedValueEnum",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripAssociatedValueEnum",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -15093,19 +15093,19 @@
             "name" : "v",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "AsyncPayloadResult"
+                "_0" : "BridgeJSRuntimeTests.AsyncPayloadResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "AsyncPayloadResult"
+            "_0" : "BridgeJSRuntimeTests.AsyncPayloadResult"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripOptionalAssociatedValueEnum",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalAssociatedValueEnum",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -15120,7 +15120,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "AsyncPayloadResult"
+                    "_0" : "BridgeJSRuntimeTests.AsyncPayloadResult"
                   }
                 },
                 "_1" : "null"
@@ -15132,7 +15132,7 @@
           "nullable" : {
             "_0" : {
               "associatedValueEnum" : {
-                "_0" : "AsyncPayloadResult"
+                "_0" : "BridgeJSRuntimeTests.AsyncPayloadResult"
               }
             },
             "_1" : "null"
@@ -15140,7 +15140,7 @@
         }
       },
       {
-        "abiName" : "bjs_setHttpStatus",
+        "abiName" : "bjs_BridgeJSRuntimeTests_setHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15153,7 +15153,7 @@
             "name" : "status",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "HttpStatus",
+                "_0" : "BridgeJSRuntimeTests.HttpStatus",
                 "_1" : "Int"
               }
             }
@@ -15161,13 +15161,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "HttpStatus",
+            "_0" : "BridgeJSRuntimeTests.HttpStatus",
             "_1" : "Int"
           }
         }
       },
       {
-        "abiName" : "bjs_getHttpStatus",
+        "abiName" : "bjs_BridgeJSRuntimeTests_getHttpStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15179,13 +15179,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "HttpStatus",
+            "_0" : "BridgeJSRuntimeTests.HttpStatus",
             "_1" : "Int"
           }
         }
       },
       {
-        "abiName" : "bjs_setFileSize",
+        "abiName" : "bjs_BridgeJSRuntimeTests_setFileSize",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15198,7 +15198,7 @@
             "name" : "size",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "FileSize",
+                "_0" : "BridgeJSRuntimeTests.FileSize",
                 "_1" : "Int64"
               }
             }
@@ -15206,13 +15206,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "FileSize",
+            "_0" : "BridgeJSRuntimeTests.FileSize",
             "_1" : "Int64"
           }
         }
       },
       {
-        "abiName" : "bjs_getFileSize",
+        "abiName" : "bjs_BridgeJSRuntimeTests_getFileSize",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15224,13 +15224,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "FileSize",
+            "_0" : "BridgeJSRuntimeTests.FileSize",
             "_1" : "Int64"
           }
         }
       },
       {
-        "abiName" : "bjs_setSessionId",
+        "abiName" : "bjs_BridgeJSRuntimeTests_setSessionId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15243,7 +15243,7 @@
             "name" : "session",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "SessionId",
+                "_0" : "BridgeJSRuntimeTests.SessionId",
                 "_1" : "UInt64"
               }
             }
@@ -15251,13 +15251,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "SessionId",
+            "_0" : "BridgeJSRuntimeTests.SessionId",
             "_1" : "UInt64"
           }
         }
       },
       {
-        "abiName" : "bjs_getSessionId",
+        "abiName" : "bjs_BridgeJSRuntimeTests_getSessionId",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15269,13 +15269,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "SessionId",
+            "_0" : "BridgeJSRuntimeTests.SessionId",
             "_1" : "UInt64"
           }
         }
       },
       {
-        "abiName" : "bjs_processTheme",
+        "abiName" : "bjs_BridgeJSRuntimeTests_processTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15288,7 +15288,7 @@
             "name" : "theme",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "BridgeJSRuntimeTests.Theme",
                 "_1" : "String"
               }
             }
@@ -15296,13 +15296,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "HttpStatus",
+            "_0" : "BridgeJSRuntimeTests.HttpStatus",
             "_1" : "Int"
           }
         }
       },
       {
-        "abiName" : "bjs_setTSDirection",
+        "abiName" : "bjs_BridgeJSRuntimeTests_setTSDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15315,19 +15315,19 @@
             "name" : "direction",
             "type" : {
               "caseEnum" : {
-                "_0" : "TSDirection"
+                "_0" : "BridgeJSRuntimeTests.TSDirection"
               }
             }
           }
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "TSDirection"
+            "_0" : "BridgeJSRuntimeTests.TSDirection"
           }
         }
       },
       {
-        "abiName" : "bjs_getTSDirection",
+        "abiName" : "bjs_BridgeJSRuntimeTests_getTSDirection",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15339,12 +15339,12 @@
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "TSDirection"
+            "_0" : "BridgeJSRuntimeTests.TSDirection"
           }
         }
       },
       {
-        "abiName" : "bjs_setTSTheme",
+        "abiName" : "bjs_BridgeJSRuntimeTests_setTSTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15357,7 +15357,7 @@
             "name" : "theme",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "TSTheme",
+                "_0" : "BridgeJSRuntimeTests.TSTheme",
                 "_1" : "String"
               }
             }
@@ -15365,13 +15365,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "TSTheme",
+            "_0" : "BridgeJSRuntimeTests.TSTheme",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_getTSTheme",
+        "abiName" : "bjs_BridgeJSRuntimeTests_getTSTheme",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15383,13 +15383,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "TSTheme",
+            "_0" : "BridgeJSRuntimeTests.TSTheme",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_createConverter",
+        "abiName" : "bjs_BridgeJSRuntimeTests_createConverter",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15401,12 +15401,12 @@
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "Utils.Converter"
+            "_0" : "BridgeJSRuntimeTests.Utils.Converter"
           }
         }
       },
       {
-        "abiName" : "bjs_useConverter",
+        "abiName" : "bjs_BridgeJSRuntimeTests_useConverter",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15419,7 +15419,7 @@
             "name" : "converter",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Utils.Converter"
+                "_0" : "BridgeJSRuntimeTests.Utils.Converter"
               }
             }
           },
@@ -15443,7 +15443,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripConverterArray",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripConverterArray",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15458,7 +15458,7 @@
               "array" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Utils.Converter"
+                    "_0" : "BridgeJSRuntimeTests.Utils.Converter"
                   }
                 }
               }
@@ -15469,14 +15469,14 @@
           "array" : {
             "_0" : {
               "swiftHeapObject" : {
-                "_0" : "Utils.Converter"
+                "_0" : "BridgeJSRuntimeTests.Utils.Converter"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_createHTTPServer",
+        "abiName" : "bjs_BridgeJSRuntimeTests_createHTTPServer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15488,12 +15488,12 @@
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "Networking.API.HTTPServer"
+            "_0" : "BridgeJSRuntimeTests.Networking.API.HTTPServer"
           }
         }
       },
       {
-        "abiName" : "bjs_createUUID",
+        "abiName" : "bjs_BridgeJSRuntimeTests_createUUID",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15513,12 +15513,12 @@
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "UUID"
+            "_0" : "BridgeJSRuntimeTests.UUID"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripUUID",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripUUID",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15531,19 +15531,19 @@
             "name" : "uuid",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "UUID"
+                "_0" : "BridgeJSRuntimeTests.UUID"
               }
             }
           }
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "UUID"
+            "_0" : "BridgeJSRuntimeTests.UUID"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripNetworkingAPIMethod",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundtripNetworkingAPIMethod",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15556,19 +15556,19 @@
             "name" : "method",
             "type" : {
               "caseEnum" : {
-                "_0" : "Networking.API.Method"
+                "_0" : "BridgeJSRuntimeTests.Networking.API.Method"
               }
             }
           }
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "Networking.API.Method"
+            "_0" : "BridgeJSRuntimeTests.Networking.API.Method"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripConfigurationLogLevel",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundtripConfigurationLogLevel",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15581,7 +15581,7 @@
             "name" : "level",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Configuration.LogLevel",
+                "_0" : "BridgeJSRuntimeTests.Configuration.LogLevel",
                 "_1" : "String"
               }
             }
@@ -15589,13 +15589,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Configuration.LogLevel",
+            "_0" : "BridgeJSRuntimeTests.Configuration.LogLevel",
             "_1" : "String"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripConfigurationPort",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundtripConfigurationPort",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15608,7 +15608,7 @@
             "name" : "port",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Configuration.Port",
+                "_0" : "BridgeJSRuntimeTests.Configuration.Port",
                 "_1" : "Int"
               }
             }
@@ -15616,13 +15616,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Configuration.Port",
+            "_0" : "BridgeJSRuntimeTests.Configuration.Port",
             "_1" : "Int"
           }
         }
       },
       {
-        "abiName" : "bjs_processConfigurationLogLevel",
+        "abiName" : "bjs_BridgeJSRuntimeTests_processConfigurationLogLevel",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15635,7 +15635,7 @@
             "name" : "level",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Configuration.LogLevel",
+                "_0" : "BridgeJSRuntimeTests.Configuration.LogLevel",
                 "_1" : "String"
               }
             }
@@ -15643,13 +15643,13 @@
         ],
         "returnType" : {
           "rawValueEnum" : {
-            "_0" : "Configuration.Port",
+            "_0" : "BridgeJSRuntimeTests.Configuration.Port",
             "_1" : "Int"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripInternalSupportedMethod",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundtripInternalSupportedMethod",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15662,19 +15662,19 @@
             "name" : "method",
             "type" : {
               "caseEnum" : {
-                "_0" : "Internal.SupportedMethod"
+                "_0" : "BridgeJSRuntimeTests.Internal.SupportedMethod"
               }
             }
           }
         ],
         "returnType" : {
           "caseEnum" : {
-            "_0" : "Internal.SupportedMethod"
+            "_0" : "BridgeJSRuntimeTests.Internal.SupportedMethod"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripAPIResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundtripAPIResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15687,19 +15687,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "BridgeJSRuntimeTests.APIResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "APIResult"
+            "_0" : "BridgeJSRuntimeTests.APIResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeAPIResultSuccess",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAPIResultSuccess",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15719,12 +15719,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "APIResult"
+            "_0" : "BridgeJSRuntimeTests.APIResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeAPIResultFailure",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAPIResultFailure",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15747,12 +15747,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "APIResult"
+            "_0" : "BridgeJSRuntimeTests.APIResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeAPIResultInfo",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAPIResultInfo",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15764,12 +15764,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "APIResult"
+            "_0" : "BridgeJSRuntimeTests.APIResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeAPIResultFlag",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAPIResultFlag",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15789,12 +15789,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "APIResult"
+            "_0" : "BridgeJSRuntimeTests.APIResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeAPIResultRate",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAPIResultRate",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15814,12 +15814,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "APIResult"
+            "_0" : "BridgeJSRuntimeTests.APIResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeAPIResultPrecise",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAPIResultPrecise",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15839,12 +15839,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "APIResult"
+            "_0" : "BridgeJSRuntimeTests.APIResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripComplexResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundtripComplexResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15857,19 +15857,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "ComplexResult"
+                "_0" : "BridgeJSRuntimeTests.ComplexResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "BridgeJSRuntimeTests.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeComplexResultSuccess",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeComplexResultSuccess",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15889,12 +15889,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "BridgeJSRuntimeTests.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeComplexResultError",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeComplexResultError",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15926,12 +15926,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "BridgeJSRuntimeTests.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeComplexResultLocation",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeComplexResultLocation",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -15969,12 +15969,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "BridgeJSRuntimeTests.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeComplexResultStatus",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeComplexResultStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16015,12 +16015,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "BridgeJSRuntimeTests.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeComplexResultCoordinates",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeComplexResultCoordinates",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16058,12 +16058,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "BridgeJSRuntimeTests.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeComplexResultComprehensive",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeComplexResultComprehensive",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16161,12 +16161,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "BridgeJSRuntimeTests.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeComplexResultInfo",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeComplexResultInfo",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16178,12 +16178,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "ComplexResult"
+            "_0" : "BridgeJSRuntimeTests.ComplexResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeUtilitiesResultSuccess",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeUtilitiesResultSuccess",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16203,12 +16203,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "Utilities.Result"
+            "_0" : "BridgeJSRuntimeTests.Utilities.Result"
           }
         }
       },
       {
-        "abiName" : "bjs_makeUtilitiesResultFailure",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeUtilitiesResultFailure",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16240,12 +16240,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "Utilities.Result"
+            "_0" : "BridgeJSRuntimeTests.Utilities.Result"
           }
         }
       },
       {
-        "abiName" : "bjs_makeUtilitiesResultStatus",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeUtilitiesResultStatus",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16286,12 +16286,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "Utilities.Result"
+            "_0" : "BridgeJSRuntimeTests.Utilities.Result"
           }
         }
       },
       {
-        "abiName" : "bjs_makeAPINetworkingResultSuccess",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAPINetworkingResultSuccess",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16311,12 +16311,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "API.NetworkingResult"
+            "_0" : "BridgeJSRuntimeTests.API.NetworkingResult"
           }
         }
       },
       {
-        "abiName" : "bjs_makeAPINetworkingResultFailure",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAPINetworkingResultFailure",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16348,12 +16348,12 @@
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "API.NetworkingResult"
+            "_0" : "BridgeJSRuntimeTests.API.NetworkingResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripUtilitiesResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundtripUtilitiesResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16366,19 +16366,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "Utilities.Result"
+                "_0" : "BridgeJSRuntimeTests.Utilities.Result"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "Utilities.Result"
+            "_0" : "BridgeJSRuntimeTests.Utilities.Result"
           }
         }
       },
       {
-        "abiName" : "bjs_roundtripAPINetworkingResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundtripAPINetworkingResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16391,19 +16391,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "API.NetworkingResult"
+                "_0" : "BridgeJSRuntimeTests.API.NetworkingResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "API.NetworkingResult"
+            "_0" : "BridgeJSRuntimeTests.API.NetworkingResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripAllTypesResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripAllTypesResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16416,19 +16416,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "AllTypesResult"
+                "_0" : "BridgeJSRuntimeTests.AllTypesResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "AllTypesResult"
+            "_0" : "BridgeJSRuntimeTests.AllTypesResult"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripTypedPayloadResult",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripTypedPayloadResult",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16441,19 +16441,19 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "TypedPayloadResult"
+                "_0" : "BridgeJSRuntimeTests.TypedPayloadResult"
               }
             }
           }
         ],
         "returnType" : {
           "associatedValueEnum" : {
-            "_0" : "TypedPayloadResult"
+            "_0" : "BridgeJSRuntimeTests.TypedPayloadResult"
           }
         }
       },
       {
-        "abiName" : "bjs_createPropertyHolder",
+        "abiName" : "bjs_BridgeJSRuntimeTests_createPropertyHolder",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16521,12 +16521,12 @@
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "PropertyHolder"
+            "_0" : "BridgeJSRuntimeTests.PropertyHolder"
           }
         }
       },
       {
-        "abiName" : "bjs_testPropertyHolder",
+        "abiName" : "bjs_BridgeJSRuntimeTests_testPropertyHolder",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16539,7 +16539,7 @@
             "name" : "holder",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "PropertyHolder"
+                "_0" : "BridgeJSRuntimeTests.PropertyHolder"
               }
             }
           }
@@ -16551,7 +16551,7 @@
         }
       },
       {
-        "abiName" : "bjs_resetObserverCounts",
+        "abiName" : "bjs_BridgeJSRuntimeTests_resetObserverCounts",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16568,7 +16568,7 @@
         }
       },
       {
-        "abiName" : "bjs_getObserverStats",
+        "abiName" : "bjs_BridgeJSRuntimeTests_getObserverStats",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16585,7 +16585,7 @@
         }
       },
       {
-        "abiName" : "bjs_formatName",
+        "abiName" : "bjs_BridgeJSRuntimeTests_formatName",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16638,7 +16638,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeFormatter",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeFormatter",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16682,7 +16682,7 @@
         }
       },
       {
-        "abiName" : "bjs_makeAdder",
+        "abiName" : "bjs_BridgeJSRuntimeTests_makeAdder",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16735,7 +16735,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripPointerFields",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripPointerFields",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16748,19 +16748,19 @@
             "name" : "value",
             "type" : {
               "swiftStruct" : {
-                "_0" : "PointerFields"
+                "_0" : "BridgeJSRuntimeTests.PointerFields"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "PointerFields"
+            "_0" : "BridgeJSRuntimeTests.PointerFields"
           }
         }
       },
       {
-        "abiName" : "bjs_testStructDefault",
+        "abiName" : "bjs_BridgeJSRuntimeTests_testStructDefault",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16820,7 +16820,7 @@
             "name" : "point",
             "type" : {
               "swiftStruct" : {
-                "_0" : "DataPoint"
+                "_0" : "BridgeJSRuntimeTests.DataPoint"
               }
             }
           }
@@ -16832,7 +16832,7 @@
         }
       },
       {
-        "abiName" : "bjs_cartToJSObject",
+        "abiName" : "bjs_BridgeJSRuntimeTests_cartToJSObject",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16845,7 +16845,7 @@
             "name" : "cart",
             "type" : {
               "swiftStruct" : {
-                "_0" : "CopyableCart"
+                "_0" : "BridgeJSRuntimeTests.CopyableCart"
               }
             }
           }
@@ -16857,7 +16857,7 @@
         }
       },
       {
-        "abiName" : "bjs_nestedCartToJSObject",
+        "abiName" : "bjs_BridgeJSRuntimeTests_nestedCartToJSObject",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16870,7 +16870,7 @@
             "name" : "cart",
             "type" : {
               "swiftStruct" : {
-                "_0" : "CopyableNestedCart"
+                "_0" : "BridgeJSRuntimeTests.CopyableNestedCart"
               }
             }
           }
@@ -16882,7 +16882,7 @@
         }
       },
       {
-        "abiName" : "bjs_roundTripDataPoint",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripDataPoint",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16895,19 +16895,19 @@
             "name" : "data",
             "type" : {
               "swiftStruct" : {
-                "_0" : "DataPoint"
+                "_0" : "BridgeJSRuntimeTests.DataPoint"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "DataPoint"
+            "_0" : "BridgeJSRuntimeTests.DataPoint"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripPublicPoint",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripPublicPoint",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -16920,19 +16920,19 @@
             "name" : "point",
             "type" : {
               "swiftStruct" : {
-                "_0" : "PublicPoint"
+                "_0" : "BridgeJSRuntimeTests.PublicPoint"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "PublicPoint"
+            "_0" : "BridgeJSRuntimeTests.PublicPoint"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripPublicPoint",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPoint",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -16945,19 +16945,19 @@
             "name" : "point",
             "type" : {
               "swiftStruct" : {
-                "_0" : "PublicPoint"
+                "_0" : "BridgeJSRuntimeTests.PublicPoint"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "PublicPoint"
+            "_0" : "BridgeJSRuntimeTests.PublicPoint"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripPublicPointThrows",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointThrows",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -16970,19 +16970,19 @@
             "name" : "point",
             "type" : {
               "swiftStruct" : {
-                "_0" : "PublicPoint"
+                "_0" : "BridgeJSRuntimeTests.PublicPoint"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "PublicPoint"
+            "_0" : "BridgeJSRuntimeTests.PublicPoint"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncStructOrThrow",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncStructOrThrow",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -17002,12 +17002,12 @@
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "PublicPoint"
+            "_0" : "BridgeJSRuntimeTests.PublicPoint"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncCombinePublicPoints",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncCombinePublicPoints",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -17020,7 +17020,7 @@
             "name" : "a",
             "type" : {
               "swiftStruct" : {
-                "_0" : "PublicPoint"
+                "_0" : "BridgeJSRuntimeTests.PublicPoint"
               }
             }
           },
@@ -17029,19 +17029,19 @@
             "name" : "b",
             "type" : {
               "swiftStruct" : {
-                "_0" : "PublicPoint"
+                "_0" : "BridgeJSRuntimeTests.PublicPoint"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "PublicPoint"
+            "_0" : "BridgeJSRuntimeTests.PublicPoint"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripContact",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripContact",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -17054,19 +17054,19 @@
             "name" : "contact",
             "type" : {
               "swiftStruct" : {
-                "_0" : "Contact"
+                "_0" : "BridgeJSRuntimeTests.Contact"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "Contact"
+            "_0" : "BridgeJSRuntimeTests.Contact"
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripPublicPointArray",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointArray",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -17081,7 +17081,7 @@
               "array" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "PublicPoint"
+                    "_0" : "BridgeJSRuntimeTests.PublicPoint"
                   }
                 }
               }
@@ -17092,14 +17092,14 @@
           "array" : {
             "_0" : {
               "swiftStruct" : {
-                "_0" : "PublicPoint"
+                "_0" : "BridgeJSRuntimeTests.PublicPoint"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripOptionalPublicPoint",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripOptionalPublicPoint",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -17114,7 +17114,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "PublicPoint"
+                    "_0" : "BridgeJSRuntimeTests.PublicPoint"
                   }
                 },
                 "_1" : "null"
@@ -17126,7 +17126,7 @@
           "nullable" : {
             "_0" : {
               "swiftStruct" : {
-                "_0" : "PublicPoint"
+                "_0" : "BridgeJSRuntimeTests.PublicPoint"
               }
             },
             "_1" : "null"
@@ -17134,7 +17134,7 @@
         }
       },
       {
-        "abiName" : "bjs_asyncRoundTripPublicPointDict",
+        "abiName" : "bjs_BridgeJSRuntimeTests_asyncRoundTripPublicPointDict",
         "effects" : {
           "isAsync" : true,
           "isStatic" : false,
@@ -17149,7 +17149,7 @@
               "dictionary" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "PublicPoint"
+                    "_0" : "BridgeJSRuntimeTests.PublicPoint"
                   }
                 }
               }
@@ -17160,14 +17160,14 @@
           "dictionary" : {
             "_0" : {
               "swiftStruct" : {
-                "_0" : "PublicPoint"
+                "_0" : "BridgeJSRuntimeTests.PublicPoint"
               }
             }
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripContact",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripContact",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17180,19 +17180,19 @@
             "name" : "contact",
             "type" : {
               "swiftStruct" : {
-                "_0" : "Contact"
+                "_0" : "BridgeJSRuntimeTests.Contact"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "Contact"
+            "_0" : "BridgeJSRuntimeTests.Contact"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripConfig",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripConfig",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17205,19 +17205,19 @@
             "name" : "config",
             "type" : {
               "swiftStruct" : {
-                "_0" : "Config"
+                "_0" : "BridgeJSRuntimeTests.Config"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "Config"
+            "_0" : "BridgeJSRuntimeTests.Config"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripSessionData",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripSessionData",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17230,19 +17230,19 @@
             "name" : "session",
             "type" : {
               "swiftStruct" : {
-                "_0" : "SessionData"
+                "_0" : "BridgeJSRuntimeTests.SessionData"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "SessionData"
+            "_0" : "BridgeJSRuntimeTests.SessionData"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripValidationReport",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripValidationReport",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17255,19 +17255,19 @@
             "name" : "report",
             "type" : {
               "swiftStruct" : {
-                "_0" : "ValidationReport"
+                "_0" : "BridgeJSRuntimeTests.ValidationReport"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "ValidationReport"
+            "_0" : "BridgeJSRuntimeTests.ValidationReport"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripAdvancedConfig",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripAdvancedConfig",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17280,19 +17280,19 @@
             "name" : "config",
             "type" : {
               "swiftStruct" : {
-                "_0" : "AdvancedConfig"
+                "_0" : "BridgeJSRuntimeTests.AdvancedConfig"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "AdvancedConfig"
+            "_0" : "BridgeJSRuntimeTests.AdvancedConfig"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripMeasurementConfig",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripMeasurementConfig",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17305,19 +17305,19 @@
             "name" : "config",
             "type" : {
               "swiftStruct" : {
-                "_0" : "MeasurementConfig"
+                "_0" : "BridgeJSRuntimeTests.MeasurementConfig"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "MeasurementConfig"
+            "_0" : "BridgeJSRuntimeTests.MeasurementConfig"
           }
         }
       },
       {
-        "abiName" : "bjs_updateValidationReport",
+        "abiName" : "bjs_BridgeJSRuntimeTests_updateValidationReport",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17332,7 +17332,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -17344,19 +17344,19 @@
             "name" : "report",
             "type" : {
               "swiftStruct" : {
-                "_0" : "ValidationReport"
+                "_0" : "BridgeJSRuntimeTests.ValidationReport"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "ValidationReport"
+            "_0" : "BridgeJSRuntimeTests.ValidationReport"
           }
         }
       },
       {
-        "abiName" : "bjs_testContainerWithStruct",
+        "abiName" : "bjs_BridgeJSRuntimeTests_testContainerWithStruct",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17369,19 +17369,19 @@
             "name" : "point",
             "type" : {
               "swiftStruct" : {
-                "_0" : "DataPoint"
+                "_0" : "BridgeJSRuntimeTests.DataPoint"
               }
             }
           }
         ],
         "returnType" : {
           "swiftHeapObject" : {
-            "_0" : "Container"
+            "_0" : "BridgeJSRuntimeTests.Container"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripJSObjectContainer",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripJSObjectContainer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17394,19 +17394,19 @@
             "name" : "container",
             "type" : {
               "swiftStruct" : {
-                "_0" : "JSObjectContainer"
+                "_0" : "BridgeJSRuntimeTests.JSObjectContainer"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "JSObjectContainer"
+            "_0" : "BridgeJSRuntimeTests.JSObjectContainer"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripFooContainer",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripFooContainer",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17419,19 +17419,19 @@
             "name" : "container",
             "type" : {
               "swiftStruct" : {
-                "_0" : "FooContainer"
+                "_0" : "BridgeJSRuntimeTests.FooContainer"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "FooContainer"
+            "_0" : "BridgeJSRuntimeTests.FooContainer"
           }
         }
       },
       {
-        "abiName" : "bjs_roundTripArrayMembers",
+        "abiName" : "bjs_BridgeJSRuntimeTests_roundTripArrayMembers",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17444,19 +17444,19 @@
             "name" : "value",
             "type" : {
               "swiftStruct" : {
-                "_0" : "ArrayMembers"
+                "_0" : "BridgeJSRuntimeTests.ArrayMembers"
               }
             }
           }
         ],
         "returnType" : {
           "swiftStruct" : {
-            "_0" : "ArrayMembers"
+            "_0" : "BridgeJSRuntimeTests.ArrayMembers"
           }
         }
       },
       {
-        "abiName" : "bjs_arrayMembersSum",
+        "abiName" : "bjs_BridgeJSRuntimeTests_arrayMembersSum",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17469,7 +17469,7 @@
             "name" : "value",
             "type" : {
               "swiftStruct" : {
-                "_0" : "ArrayMembers"
+                "_0" : "BridgeJSRuntimeTests.ArrayMembers"
               }
             }
           },
@@ -17500,7 +17500,7 @@
         }
       },
       {
-        "abiName" : "bjs_arrayMembersFirst",
+        "abiName" : "bjs_BridgeJSRuntimeTests_arrayMembersFirst",
         "effects" : {
           "isAsync" : false,
           "isStatic" : false,
@@ -17513,7 +17513,7 @@
             "name" : "value",
             "type" : {
               "swiftStruct" : {
-                "_0" : "ArrayMembers"
+                "_0" : "BridgeJSRuntimeTests.ArrayMembers"
               }
             }
           },
@@ -17696,7 +17696,7 @@
                 "name" : "greeter",
                 "type" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 }
               }
@@ -17720,7 +17720,7 @@
             ],
             "returnType" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests.Greeter"
               }
             }
           },
@@ -17740,7 +17740,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     },
                     "_1" : "null"
@@ -17769,7 +17769,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -17792,7 +17792,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "APIResult"
+                        "_0" : "BridgeJSRuntimeTests.APIResult"
                       }
                     },
                     "_1" : "null"
@@ -17821,7 +17821,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -17890,7 +17890,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 },
                 "_1" : "null"
@@ -17904,7 +17904,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 },
@@ -17919,7 +17919,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "HttpStatus",
+                    "_0" : "BridgeJSRuntimeTests.HttpStatus",
                     "_1" : "Int"
                   }
                 },
@@ -17934,7 +17934,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -17946,7 +17946,7 @@
             "name" : "helper",
             "type" : {
               "swiftHeapObject" : {
-                "_0" : "Greeter"
+                "_0" : "BridgeJSRuntimeTests.Greeter"
               }
             }
           },
@@ -17957,7 +17957,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -17970,7 +17970,7 @@
     "structs" : [
       {
         "constructor" : {
-          "abiName" : "bjs_JSCoordinate_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_JSCoordinate_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18023,7 +18023,7 @@
             }
           }
         ],
-        "swiftCallName" : "JSCoordinate"
+        "swiftCallName" : "BridgeJSRuntimeTests.JSCoordinate"
       },
       {
         "methods" : [
@@ -18064,7 +18064,7 @@
             }
           }
         ],
-        "swiftCallName" : "NestedStructGroupA.Metadata"
+        "swiftCallName" : "BridgeJSRuntimeTests.NestedStructGroupA.Metadata"
       },
       {
         "methods" : [
@@ -18102,11 +18102,11 @@
             }
           }
         ],
-        "swiftCallName" : "NestedStructGroupB.Metadata"
+        "swiftCallName" : "BridgeJSRuntimeTests.NestedStructGroupB.Metadata"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_NestedTypeHost_Label_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18126,7 +18126,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_NestedTypeHost_Label_static_untitled",
+            "abiName" : "bjs_BridgeJSRuntimeTests_NestedTypeHost_Label_static_untitled",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -18138,12 +18138,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "NestedTypeHost.Label"
+                "_0" : "BridgeJSRuntimeTests.NestedTypeHost.Label"
               }
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "NestedTypeHost_Label"
+                "_0" : "BridgeJSRuntimeTests_NestedTypeHost_Label"
               }
             }
           }
@@ -18172,7 +18172,7 @@
             "name" : "maxLength",
             "staticContext" : {
               "structName" : {
-                "_0" : "NestedTypeHost_Label"
+                "_0" : "BridgeJSRuntimeTests_NestedTypeHost_Label"
               }
             },
             "type" : {
@@ -18185,7 +18185,7 @@
             }
           }
         ],
-        "swiftCallName" : "NestedTypeHost.Label"
+        "swiftCallName" : "BridgeJSRuntimeTests.NestedTypeHost.Label"
       },
       {
         "methods" : [
@@ -18220,11 +18220,11 @@
             }
           }
         ],
-        "swiftCallName" : "Point"
+        "swiftCallName" : "BridgeJSRuntimeTests.Point"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_PointerFields_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_PointerFields_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18358,11 +18358,11 @@
             }
           }
         ],
-        "swiftCallName" : "PointerFields"
+        "swiftCallName" : "BridgeJSRuntimeTests.PointerFields"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_DataPoint_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_DataPoint_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18431,7 +18431,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_DataPoint_static_origin",
+            "abiName" : "bjs_BridgeJSRuntimeTests_DataPoint_static_origin",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -18443,12 +18443,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "DataPoint"
+                "_0" : "BridgeJSRuntimeTests.DataPoint"
               }
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "DataPoint"
+                "_0" : "BridgeJSRuntimeTests_DataPoint"
               }
             }
           }
@@ -18524,7 +18524,7 @@
             "name" : "dimensions",
             "staticContext" : {
               "structName" : {
-                "_0" : "DataPoint"
+                "_0" : "BridgeJSRuntimeTests_DataPoint"
               }
             },
             "type" : {
@@ -18537,11 +18537,11 @@
             }
           }
         ],
-        "swiftCallName" : "DataPoint"
+        "swiftCallName" : "BridgeJSRuntimeTests.DataPoint"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_PublicPoint_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_PublicPoint_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -18607,7 +18607,7 @@
             }
           }
         ],
-        "swiftCallName" : "PublicPoint"
+        "swiftCallName" : "BridgeJSRuntimeTests.PublicPoint"
       },
       {
         "methods" : [
@@ -18654,7 +18654,7 @@
             }
           }
         ],
-        "swiftCallName" : "Address"
+        "swiftCallName" : "BridgeJSRuntimeTests.Address"
       },
       {
         "methods" : [
@@ -18691,7 +18691,7 @@
             "name" : "address",
             "type" : {
               "swiftStruct" : {
-                "_0" : "Address"
+                "_0" : "BridgeJSRuntimeTests.Address"
               }
             }
           },
@@ -18718,7 +18718,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Address"
+                    "_0" : "BridgeJSRuntimeTests.Address"
                   }
                 },
                 "_1" : "null"
@@ -18726,7 +18726,7 @@
             }
           }
         ],
-        "swiftCallName" : "Contact"
+        "swiftCallName" : "BridgeJSRuntimeTests.Contact"
       },
       {
         "methods" : [
@@ -18752,7 +18752,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Theme",
+                    "_0" : "BridgeJSRuntimeTests.Theme",
                     "_1" : "String"
                   }
                 },
@@ -18768,7 +18768,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Direction"
+                    "_0" : "BridgeJSRuntimeTests.Direction"
                   }
                 },
                 "_1" : "null"
@@ -18781,12 +18781,12 @@
             "name" : "status",
             "type" : {
               "caseEnum" : {
-                "_0" : "Status"
+                "_0" : "BridgeJSRuntimeTests.Status"
               }
             }
           }
         ],
-        "swiftCallName" : "Config"
+        "swiftCallName" : "BridgeJSRuntimeTests.Config"
       },
       {
         "methods" : [
@@ -18815,7 +18815,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 },
                 "_1" : "null"
@@ -18823,7 +18823,7 @@
             }
           }
         ],
-        "swiftCallName" : "SessionData"
+        "swiftCallName" : "BridgeJSRuntimeTests.SessionData"
       },
       {
         "methods" : [
@@ -18850,7 +18850,7 @@
             "name" : "result",
             "type" : {
               "associatedValueEnum" : {
-                "_0" : "APIResult"
+                "_0" : "BridgeJSRuntimeTests.APIResult"
               }
             }
           },
@@ -18862,7 +18862,7 @@
               "nullable" : {
                 "_0" : {
                   "caseEnum" : {
-                    "_0" : "Status"
+                    "_0" : "BridgeJSRuntimeTests.Status"
                   }
                 },
                 "_1" : "null"
@@ -18877,7 +18877,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -18885,7 +18885,7 @@
             }
           }
         ],
-        "swiftCallName" : "ValidationReport"
+        "swiftCallName" : "BridgeJSRuntimeTests.ValidationReport"
       },
       {
         "methods" : [
@@ -18932,7 +18932,7 @@
             "name" : "theme",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Theme",
+                "_0" : "BridgeJSRuntimeTests.Theme",
                 "_1" : "String"
               }
             }
@@ -18943,7 +18943,7 @@
             "name" : "status",
             "type" : {
               "caseEnum" : {
-                "_0" : "Status"
+                "_0" : "BridgeJSRuntimeTests.Status"
               }
             }
           },
@@ -18955,7 +18955,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "APIResult"
+                    "_0" : "BridgeJSRuntimeTests.APIResult"
                   }
                 },
                 "_1" : "null"
@@ -18985,7 +18985,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "DataPoint"
+                    "_0" : "BridgeJSRuntimeTests.DataPoint"
                   }
                 },
                 "_1" : "null"
@@ -18998,7 +18998,7 @@
             "name" : "defaults",
             "type" : {
               "swiftStruct" : {
-                "_0" : "ConfigStruct"
+                "_0" : "BridgeJSRuntimeTests.ConfigStruct"
               }
             }
           },
@@ -19010,7 +19010,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "ConfigStruct"
+                    "_0" : "BridgeJSRuntimeTests.ConfigStruct"
                   }
                 },
                 "_1" : "null"
@@ -19018,7 +19018,7 @@
             }
           }
         ],
-        "swiftCallName" : "AdvancedConfig"
+        "swiftCallName" : "BridgeJSRuntimeTests.AdvancedConfig"
       },
       {
         "methods" : [
@@ -19032,7 +19032,7 @@
             "name" : "precision",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Precision",
+                "_0" : "BridgeJSRuntimeTests.Precision",
                 "_1" : "Float"
               }
             }
@@ -19043,7 +19043,7 @@
             "name" : "ratio",
             "type" : {
               "rawValueEnum" : {
-                "_0" : "Ratio",
+                "_0" : "BridgeJSRuntimeTests.Ratio",
                 "_1" : "Double"
               }
             }
@@ -19056,7 +19056,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Precision",
+                    "_0" : "BridgeJSRuntimeTests.Precision",
                     "_1" : "Float"
                   }
                 },
@@ -19072,7 +19072,7 @@
               "nullable" : {
                 "_0" : {
                   "rawValueEnum" : {
-                    "_0" : "Ratio",
+                    "_0" : "BridgeJSRuntimeTests.Ratio",
                     "_1" : "Double"
                   }
                 },
@@ -19081,11 +19081,11 @@
             }
           }
         ],
-        "swiftCallName" : "MeasurementConfig"
+        "swiftCallName" : "BridgeJSRuntimeTests.MeasurementConfig"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_MathOperations_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_MathOperations_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -19110,7 +19110,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_MathOperations_add",
+            "abiName" : "bjs_BridgeJSRuntimeTests_MathOperations_add",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -19149,7 +19149,7 @@
             }
           },
           {
-            "abiName" : "bjs_MathOperations_multiply",
+            "abiName" : "bjs_BridgeJSRuntimeTests_MathOperations_multiply",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -19183,7 +19183,7 @@
             }
           },
           {
-            "abiName" : "bjs_MathOperations_static_subtract",
+            "abiName" : "bjs_BridgeJSRuntimeTests_MathOperations_static_subtract",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -19222,7 +19222,7 @@
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "MathOperations"
+                "_0" : "BridgeJSRuntimeTests_MathOperations"
               }
             }
           }
@@ -19240,12 +19240,12 @@
             }
           }
         ],
-        "swiftCallName" : "MathOperations"
+        "swiftCallName" : "BridgeJSRuntimeTests.MathOperations"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_CopyableCart_static_fromJSObject",
+            "abiName" : "bjs_BridgeJSRuntimeTests_CopyableCart_static_fromJSObject",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -19265,12 +19265,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "CopyableCart"
+                "_0" : "BridgeJSRuntimeTests.CopyableCart"
               }
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "CopyableCart"
+                "_0" : "BridgeJSRuntimeTests_CopyableCart"
               }
             }
           }
@@ -19306,7 +19306,7 @@
             }
           }
         ],
-        "swiftCallName" : "CopyableCart"
+        "swiftCallName" : "BridgeJSRuntimeTests.CopyableCart"
       },
       {
         "methods" : [
@@ -19338,12 +19338,12 @@
             }
           }
         ],
-        "swiftCallName" : "CopyableCartItem"
+        "swiftCallName" : "BridgeJSRuntimeTests.CopyableCartItem"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_CopyableNestedCart_static_fromJSObject",
+            "abiName" : "bjs_BridgeJSRuntimeTests_CopyableNestedCart_static_fromJSObject",
             "effects" : {
               "isAsync" : false,
               "isStatic" : true,
@@ -19363,12 +19363,12 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "CopyableNestedCart"
+                "_0" : "BridgeJSRuntimeTests.CopyableNestedCart"
               }
             },
             "staticContext" : {
               "structName" : {
-                "_0" : "CopyableNestedCart"
+                "_0" : "BridgeJSRuntimeTests_CopyableNestedCart"
               }
             }
           }
@@ -19394,7 +19394,7 @@
             "name" : "item",
             "type" : {
               "swiftStruct" : {
-                "_0" : "CopyableCartItem"
+                "_0" : "BridgeJSRuntimeTests.CopyableCartItem"
               }
             }
           },
@@ -19406,7 +19406,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Address"
+                    "_0" : "BridgeJSRuntimeTests.Address"
                   }
                 },
                 "_1" : "null"
@@ -19414,7 +19414,7 @@
             }
           }
         ],
-        "swiftCallName" : "CopyableNestedCart"
+        "swiftCallName" : "BridgeJSRuntimeTests.CopyableNestedCart"
       },
       {
         "methods" : [
@@ -19451,7 +19451,7 @@
             "name" : "defaultConfig",
             "staticContext" : {
               "structName" : {
-                "_0" : "ConfigStruct"
+                "_0" : "BridgeJSRuntimeTests_ConfigStruct"
               }
             },
             "type" : {
@@ -19466,7 +19466,7 @@
             "name" : "maxRetries",
             "staticContext" : {
               "structName" : {
-                "_0" : "ConfigStruct"
+                "_0" : "BridgeJSRuntimeTests_ConfigStruct"
               }
             },
             "type" : {
@@ -19484,7 +19484,7 @@
             "name" : "timeout",
             "staticContext" : {
               "structName" : {
-                "_0" : "ConfigStruct"
+                "_0" : "BridgeJSRuntimeTests_ConfigStruct"
               }
             },
             "type" : {
@@ -19499,7 +19499,7 @@
             "name" : "computedSetting",
             "staticContext" : {
               "structName" : {
-                "_0" : "ConfigStruct"
+                "_0" : "BridgeJSRuntimeTests_ConfigStruct"
               }
             },
             "type" : {
@@ -19509,11 +19509,11 @@
             }
           }
         ],
-        "swiftCallName" : "ConfigStruct"
+        "swiftCallName" : "BridgeJSRuntimeTests.ConfigStruct"
       },
       {
         "constructor" : {
-          "abiName" : "bjs_Vector2D_init",
+          "abiName" : "bjs_BridgeJSRuntimeTests_Vector2D_init",
           "effects" : {
             "isAsync" : false,
             "isStatic" : false,
@@ -19542,7 +19542,7 @@
         },
         "methods" : [
           {
-            "abiName" : "bjs_Vector2D_magnitude",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Vector2D_magnitude",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -19559,7 +19559,7 @@
             }
           },
           {
-            "abiName" : "bjs_Vector2D_scaled",
+            "abiName" : "bjs_BridgeJSRuntimeTests_Vector2D_scaled",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -19579,7 +19579,7 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Vector2D"
+                "_0" : "BridgeJSRuntimeTests.Vector2D"
               }
             }
           }
@@ -19607,7 +19607,7 @@
             }
           }
         ],
-        "swiftCallName" : "Vector2D"
+        "swiftCallName" : "BridgeJSRuntimeTests.Vector2D"
       },
       {
         "methods" : [
@@ -19641,7 +19641,7 @@
             }
           }
         ],
-        "swiftCallName" : "JSObjectContainer"
+        "swiftCallName" : "BridgeJSRuntimeTests.JSObjectContainer"
       },
       {
         "methods" : [
@@ -19675,12 +19675,12 @@
             }
           }
         ],
-        "swiftCallName" : "FooContainer"
+        "swiftCallName" : "BridgeJSRuntimeTests.FooContainer"
       },
       {
         "methods" : [
           {
-            "abiName" : "bjs_ArrayMembers_sumValues",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArrayMembers_sumValues",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -19715,7 +19715,7 @@
             }
           },
           {
-            "abiName" : "bjs_ArrayMembers_firstString",
+            "abiName" : "bjs_BridgeJSRuntimeTests_ArrayMembers_firstString",
             "effects" : {
               "isAsync" : false,
               "isStatic" : false,
@@ -19788,7 +19788,7 @@
             }
           }
         ],
-        "swiftCallName" : "ArrayMembers"
+        "swiftCallName" : "BridgeJSRuntimeTests.ArrayMembers"
       }
     ]
   },
@@ -19862,7 +19862,7 @@
                     "name" : "value",
                     "type" : {
                       "alias" : {
-                        "name" : "Tagged",
+                        "name" : "BridgeJSRuntimeTests.Tagged",
                         "underlying" : {
                           "string" : {
 
@@ -19874,7 +19874,7 @@
                 ],
                 "returnType" : {
                   "alias" : {
-                    "name" : "Tagged",
+                    "name" : "BridgeJSRuntimeTests.Tagged",
                     "underlying" : {
                       "string" : {
 
@@ -19898,7 +19898,7 @@
                       "nullable" : {
                         "_0" : {
                           "alias" : {
-                            "name" : "Tagged",
+                            "name" : "BridgeJSRuntimeTests.Tagged",
                             "underlying" : {
                               "string" : {
 
@@ -19915,7 +19915,7 @@
                   "nullable" : {
                     "_0" : {
                       "alias" : {
-                        "name" : "Tagged",
+                        "name" : "BridgeJSRuntimeTests.Tagged",
                         "underlying" : {
                           "string" : {
 
@@ -19954,7 +19954,7 @@
                   "nullable" : {
                     "_0" : {
                       "alias" : {
-                        "name" : "Canvas",
+                        "name" : "BridgeJSRuntimeTests.Canvas",
                         "underlying" : {
                           "jsObject" : {
                             "_0" : "Surface"
@@ -19983,10 +19983,10 @@
                           "nullable" : {
                             "_0" : {
                               "alias" : {
-                                "name" : "AliasedTag",
+                                "name" : "BridgeJSRuntimeTests.AliasedTag",
                                 "underlying" : {
                                   "associatedValueEnum" : {
-                                    "_0" : "InnerTag"
+                                    "_0" : "BridgeJSRuntimeTests.InnerTag"
                                   }
                                 }
                               }
@@ -20004,10 +20004,10 @@
                       "nullable" : {
                         "_0" : {
                           "alias" : {
-                            "name" : "AliasedTag",
+                            "name" : "BridgeJSRuntimeTests.AliasedTag",
                             "underlying" : {
                               "associatedValueEnum" : {
-                                "_0" : "InnerTag"
+                                "_0" : "BridgeJSRuntimeTests.InnerTag"
                               }
                             }
                           }
@@ -20031,10 +20031,10 @@
                     "name" : "value",
                     "type" : {
                       "alias" : {
-                        "name" : "Polygon",
+                        "name" : "BridgeJSRuntimeTests.Polygon",
                         "underlying" : {
                           "swiftHeapObject" : {
-                            "_0" : "PolygonReference"
+                            "_0" : "BridgeJSRuntimeTests.PolygonReference"
                           }
                         }
                       }
@@ -20043,10 +20043,10 @@
                 ],
                 "returnType" : {
                   "alias" : {
-                    "name" : "Polygon",
+                    "name" : "BridgeJSRuntimeTests.Polygon",
                     "underlying" : {
                       "swiftHeapObject" : {
-                        "_0" : "PolygonReference"
+                        "_0" : "BridgeJSRuntimeTests.PolygonReference"
                       }
                     }
                   }
@@ -20065,10 +20065,10 @@
                     "name" : "value",
                     "type" : {
                       "alias" : {
-                        "name" : "Coordinate",
+                        "name" : "BridgeJSRuntimeTests.Coordinate",
                         "underlying" : {
                           "swiftStruct" : {
-                            "_0" : "JSCoordinate"
+                            "_0" : "BridgeJSRuntimeTests.JSCoordinate"
                           }
                         }
                       }
@@ -20077,10 +20077,10 @@
                 ],
                 "returnType" : {
                   "alias" : {
-                    "name" : "Coordinate",
+                    "name" : "BridgeJSRuntimeTests.Coordinate",
                     "underlying" : {
                       "swiftStruct" : {
-                        "_0" : "JSCoordinate"
+                        "_0" : "BridgeJSRuntimeTests.JSCoordinate"
                       }
                     }
                   }
@@ -20099,7 +20099,7 @@
                     "name" : "value",
                     "type" : {
                       "alias" : {
-                        "name" : "UserId",
+                        "name" : "BridgeJSRuntimeTests.UserId",
                         "underlying" : {
                           "integer" : {
                             "_0" : {
@@ -20114,7 +20114,7 @@
                 ],
                 "returnType" : {
                   "alias" : {
-                    "name" : "UserId",
+                    "name" : "BridgeJSRuntimeTests.UserId",
                     "underlying" : {
                       "integer" : {
                         "_0" : {
@@ -20141,7 +20141,7 @@
                       "nullable" : {
                         "_0" : {
                           "alias" : {
-                            "name" : "UserId",
+                            "name" : "BridgeJSRuntimeTests.UserId",
                             "underlying" : {
                               "integer" : {
                                 "_0" : {
@@ -20161,7 +20161,7 @@
                   "nullable" : {
                     "_0" : {
                       "alias" : {
-                        "name" : "UserId",
+                        "name" : "BridgeJSRuntimeTests.UserId",
                         "underlying" : {
                           "integer" : {
                             "_0" : {
@@ -21111,7 +21111,7 @@
                     "name" : "v",
                     "type" : {
                       "rawValueEnum" : {
-                        "_0" : "FeatureFlag",
+                        "_0" : "BridgeJSRuntimeTests.FeatureFlag",
                         "_1" : "String"
                       }
                     }
@@ -21119,7 +21119,7 @@
                 ],
                 "returnType" : {
                   "rawValueEnum" : {
-                    "_0" : "FeatureFlag",
+                    "_0" : "BridgeJSRuntimeTests.FeatureFlag",
                     "_1" : "String"
                   }
                 }
@@ -21137,14 +21137,14 @@
                     "name" : "v",
                     "type" : {
                       "associatedValueEnum" : {
-                        "_0" : "AsyncImportedPayloadResult"
+                        "_0" : "BridgeJSRuntimeTests.AsyncImportedPayloadResult"
                       }
                     }
                   }
                 ],
                 "returnType" : {
                   "associatedValueEnum" : {
-                    "_0" : "AsyncImportedPayloadResult"
+                    "_0" : "BridgeJSRuntimeTests.AsyncImportedPayloadResult"
                   }
                 }
               },
@@ -21163,7 +21163,7 @@
                       "nullable" : {
                         "_0" : {
                           "associatedValueEnum" : {
-                            "_0" : "AsyncImportedPayloadResult"
+                            "_0" : "BridgeJSRuntimeTests.AsyncImportedPayloadResult"
                           }
                         },
                         "_1" : "null"
@@ -21175,7 +21175,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "AsyncImportedPayloadResult"
+                        "_0" : "BridgeJSRuntimeTests.AsyncImportedPayloadResult"
                       }
                     },
                     "_1" : "null"
@@ -22617,7 +22617,7 @@
                 "name" : "flag",
                 "type" : {
                   "rawValueEnum" : {
-                    "_0" : "FeatureFlag",
+                    "_0" : "BridgeJSRuntimeTests.FeatureFlag",
                     "_1" : "String"
                   }
                 }
@@ -22625,7 +22625,7 @@
             ],
             "returnType" : {
               "rawValueEnum" : {
-                "_0" : "FeatureFlag",
+                "_0" : "BridgeJSRuntimeTests.FeatureFlag",
                 "_1" : "String"
               }
             }
@@ -23213,14 +23213,14 @@
                 "name" : "value",
                 "type" : {
                   "caseEnum" : {
-                    "_0" : "LightColor"
+                    "_0" : "BridgeJSRuntimeTests.LightColor"
                   }
                 }
               }
             ],
             "returnType" : {
               "caseEnum" : {
-                "_0" : "LightColor"
+                "_0" : "BridgeJSRuntimeTests.LightColor"
               }
             }
           },
@@ -23237,14 +23237,14 @@
                 "name" : "value",
                 "type" : {
                   "associatedValueEnum" : {
-                    "_0" : "ImportedPayloadSignal"
+                    "_0" : "BridgeJSRuntimeTests.ImportedPayloadSignal"
                   }
                 }
               }
             ],
             "returnType" : {
               "associatedValueEnum" : {
-                "_0" : "ImportedPayloadSignal"
+                "_0" : "BridgeJSRuntimeTests.ImportedPayloadSignal"
               }
             }
           },
@@ -23263,7 +23263,7 @@
                   "nullable" : {
                     "_0" : {
                       "associatedValueEnum" : {
-                        "_0" : "ImportedPayloadSignal"
+                        "_0" : "BridgeJSRuntimeTests.ImportedPayloadSignal"
                       }
                     },
                     "_1" : "null"
@@ -23275,7 +23275,7 @@
               "nullable" : {
                 "_0" : {
                   "associatedValueEnum" : {
-                    "_0" : "ImportedPayloadSignal"
+                    "_0" : "BridgeJSRuntimeTests.ImportedPayloadSignal"
                   }
                 },
                 "_1" : "null"
@@ -23302,7 +23302,7 @@
                 "name" : "point",
                 "type" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "BridgeJSRuntimeTests.Point"
                   }
                 }
               },
@@ -23331,7 +23331,7 @@
             ],
             "returnType" : {
               "swiftStruct" : {
-                "_0" : "Point"
+                "_0" : "BridgeJSRuntimeTests.Point"
               }
             }
           },
@@ -23350,7 +23350,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftStruct" : {
-                        "_0" : "Point"
+                        "_0" : "BridgeJSRuntimeTests.Point"
                       }
                     },
                     "_1" : "null"
@@ -23362,7 +23362,7 @@
               "nullable" : {
                 "_0" : {
                   "swiftStruct" : {
-                    "_0" : "Point"
+                    "_0" : "BridgeJSRuntimeTests.Point"
                   }
                 },
                 "_1" : "null"
@@ -24738,14 +24738,14 @@
                     "name" : "greeter",
                     "type" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     }
                   }
                 ],
                 "returnType" : {
                   "swiftHeapObject" : {
-                    "_0" : "Greeter"
+                    "_0" : "BridgeJSRuntimeTests.Greeter"
                   }
                 }
               },
@@ -24762,14 +24762,14 @@
                     "name" : "uuid",
                     "type" : {
                       "swiftHeapObject" : {
-                        "_0" : "UUID"
+                        "_0" : "BridgeJSRuntimeTests.UUID"
                       }
                     }
                   }
                 ],
                 "returnType" : {
                   "swiftHeapObject" : {
-                    "_0" : "UUID"
+                    "_0" : "BridgeJSRuntimeTests.UUID"
                   }
                 }
               },
@@ -24788,7 +24788,7 @@
                       "nullable" : {
                         "_0" : {
                           "swiftHeapObject" : {
-                            "_0" : "Greeter"
+                            "_0" : "BridgeJSRuntimeTests.Greeter"
                           }
                         },
                         "_1" : "null"
@@ -24800,7 +24800,7 @@
                   "nullable" : {
                     "_0" : {
                       "swiftHeapObject" : {
-                        "_0" : "Greeter"
+                        "_0" : "BridgeJSRuntimeTests.Greeter"
                       }
                     },
                     "_1" : "null"
@@ -24820,7 +24820,7 @@
                     "name" : "value",
                     "type" : {
                       "swiftHeapObject" : {
-                        "_0" : "LeakCheck"
+                        "_0" : "BridgeJSRuntimeTests.LeakCheck"
                       }
                     }
                   }
@@ -24846,7 +24846,7 @@
                       "nullable" : {
                         "_0" : {
                           "swiftHeapObject" : {
-                            "_0" : "LeakCheck"
+                            "_0" : "BridgeJSRuntimeTests.LeakCheck"
                           }
                         },
                         "_1" : "null"


### PR DESCRIPTION
Fixes swiftwasm/JavaScriptKit#785.

### Problem

When two Swift modules in a single BridgeJS build both export a `@JS` type with the same name (e.g. `Point`), the generated glue collides silently:

- duplicated `@_expose(wasm, "bjs_Point_init")` thunk names,
- duplicated `swift_js_struct_lower_Point` / `swift_js_struct_lift_Point` extern hooks and their JS-side `bjs[...]` handlers,
- colliding `structHelpers.Point` / `enumHelpers.Point` keys in the shared JS glue.

The JS handlers are plain assignments, so the last-linked module wins and every other module's values are decoded with the wrong field schema — silent data corruption rather than a build error.

### Approach

Type identity in the generated glue is now module-aware, while the public JS surface stays flat:

1. **Module-qualified payloads.** Exported-type `BridgeType` payloads are minted as `Module.[Nesting.]Name` at skeleton-generation time. Cross-module references resolve through `ExternalModuleIndex`, which indexes by module-stripped path (so existing `Point` / `Dep.Point` references keep working) while carrying the defining module's qualified payload.
2. **abiName derived from the qualified name by construction.** `abiName = swiftCallName.replacing(".", "_")`, so the invariant *JS key derived from payload == defining type's helper key* holds structurally instead of by parallel derivations. All `bjs_*` thunks, `swift_js_struct_lower/lift_*` externs, and `structHelpers`/`enumHelpers` keys become `Module_…`-qualified.
3. **Public surface unchanged.** JS class names, `exports` keys, and TypeScript declarations are untouched — the re-record produced **zero `.d.ts` diffs**. Display names strip the module prefix.
4. **Build-time diagnostic.** The linker now rejects two *different modules* exporting the same public name at the same namespace path (classes, structs, non-namespace enums, top-level functions), with an error naming both modules. Namespace enums are exempt (cross-module namespace merging is intentional).

Protocol method hooks (wasm imports, already scoped per module by the import object) and TS-imported types keep their existing naming.

### Testing

- `sameNamedTypesAcrossModulesLinkWithDistinctABINames` — links two skeletons that each define `@JS struct Point` plus same-named top-level functions; asserts distinct module-qualified externs and helper keys in the output (snapshot: `SameNamedTypesAcrossModules.js/.d.ts`).
- `duplicatePublicNamesAcrossModulesProduceDiagnostic` / `duplicatePublicFunctionNamesAcrossModulesProduceDiagnostic` — the new linker error.
- Full snapshot suite re-recorded (~150 fixtures churn from the abiName rename; internal names only).
- `./Utilities/bridge-js-generate.sh` zero drift; `npm run check:bridgejs-dts` passes; WASM E2E (`make unittest`) 32/32 suites pass.

### Notes for reviewers

- ABI names are internal and regenerated atomically on both sides of the bridge, but this *is* a rename of every generated symbol — anyone snapshot-diffing generated output downstream will see churn.
- `@JS(namespace:)` components no longer appear in type abiNames (module + Swift nesting path is used instead, which is unique per module and fixes a latent invariant violation for attribute-namespaced structs).
- Same-named classes/enums across modules in *different* namespaces still collide on public JS declarations (duplicate `class X` / `XValues` emissions). That's a pre-existing public-surface limitation, distinct from the ABI corruption fixed here — happy to file a follow-up issue.
